### PR TITLE
Fixes Bulk reads of zero-length values

### DIFF
--- a/lib/Predis.php
+++ b/lib/Predis.php
@@ -1832,7 +1832,7 @@ class ResponseBulkHandler implements IResponseHandler {
             ));
         }
         if ($length >= 0) {
-          return $length > 0 ? substr($connection->readBytes($length + 2), 0, -2) : '';
+            return substr($connection->readBytes($length + 2), 0, -2);
         }
         if ($length == -1) {
             return null;


### PR DESCRIPTION
Atm, a response like that:

```
string(2) "$8"
string(8) "username"
string(2) "$0"
string(0) ""
```

Will just crash because it didn't read anything at `$0`, then it failed to extract a prefix from the empty string, and called handle() on a null value instead of a proper Handler class, which means a fatal error :)

My fix worked for 0.6.4, but the pull request is against 0.7_internals, not sure if that's the best thing to do?
