### PR TITLE
Slight changes to ZUNIONSTORE/ZINTERSTORE

### DIFF
--- a/lib/Predis.php
+++ b/lib/Predis.php
@@ -2968,10 +2968,17 @@ class ZSetUnionStore extends Command {
     public function filterArguments(Array $arguments) {
         $options = array();
         $argc    = count($arguments);
-        if ($argc > 1 && is_array($arguments[$argc - 1])) {
+        $args    = is_array($arguments[0]) ? $arguments[0] : $arguments;
+        
+        if ($argc > 1 && is_string($arguments[0]) && is_array($arguments[1])) {
+        	$args = array_merge(array($arguments[0], count($arguments[1])), $arguments[1]);
+        }
+        
+        $argsc = count($args);
+        
+        if ($argsc > 1 && is_array($args[$argsc - 1])) {
             $options = $this->prepareOptions(array_pop($arguments));
         }
-        $args = is_array($arguments[0]) ? $arguments[0] : $arguments;
         return  array_merge($args, $options);
     }
     private function prepareOptions($options) {


### PR DESCRIPTION
ZUNIONSTORE and ZINERSTORE can accept an array of keys as the 2nd argument and the key to store the result in as the 1st argument. The 3rd argument can be an array of options to pass in.

The previous implementation was this:

```
$sets = array('sorted_set_one', 'sorted_set_two', 'sorted_set_three');
call_user_func_array(array($redis, 'zinterstore'), array_merge(array(
    'result_key', count($sets),
), $sets));
```

With these changes, zinterstore can be called like this:

```
$sets = array('sorted_set_one', 'sorted_set_two', 'sorted_set_three');
$redis->zinterstore('result_key', $sets);
```

The previous implementation is still intact.
