### PR TITLE
Prevent warning during disconnect if resource is invalid

### DIFF
--- a/lib/Predis/Network/ConnectionBase.php
+++ b/lib/Predis/Network/ConnectionBase.php
@@ -98,7 +98,7 @@ abstract class ConnectionBase implements IConnectionSingle {
     }
 
     public function getResource() {
-        if (isset($this->_resource)) {
+        if (isset($this->_resource) && is_resource($this->_resource)) {
             return $this->_resource;
         }
         $this->connect();


### PR DESCRIPTION
During disconnect the resource is checked if it exists => is connected. If the connection state is lost, the resource is an integer of '0'. This will yield a positiv check with isset($this->_resource). This bugfix prevents an warning triggered by fclose, due an invalid input (expexted resource or integer) during disconnect.
