### PR TITLE
In accordance with redis, method to flush pipeline should be exec

### DIFF
--- a/lib/Predis/Pipeline/PipelineContext.php
+++ b/lib/Predis/Pipeline/PipelineContext.php
@@ -144,6 +144,16 @@ class PipelineContext
     }
 
     /**
+     * This method is an alias of execute
+     *
+     * @see self::execute()
+     */
+    public function exec($callable = null)
+    {
+        return $this->execute($callable);
+    }
+
+    /**
      * Handles the actual execution of the whole pipeline.
      *
      * @param mixed $callable Callback for execution.


### PR DESCRIPTION
Hi,

Thanks to SNC, the `SncRedisBundle` actually works with `PRedis` or `PHPRedis` ant that's work !

Except one thing, when you create a pipeline with `Predis`:

``` php
$results  = $client->pipeline()
  ->set('foo', 'bar');
  ->set('foo2', 'bar2');
  ->execute();
```

With `phpredis`

``` php
$results  = $client->pipeline()
  ->set('foo', 'bar');
  ->set('foo2', 'bar2');
  ->exec();
```

When i look at [documentation](http://redis.io/commands/exec), i feel that's `exec` method which should be used.

BTW, i create an alias `exec` which call  `execute` method to not BC.
