### PR TITLE
Making autoloader act nicer to autoloaders running in parallel

### DIFF
--- a/lib/Predis/Autoloader.php
+++ b/lib/Predis/Autoloader.php
@@ -53,8 +53,8 @@ class Autoloader
         if (0 === strpos($className, $this->prefix)) {
             $parts = explode('\\', substr($className, $this->prefixLength));
             $filepath = $this->directory.DIRECTORY_SEPARATOR.implode(DIRECTORY_SEPARATOR, $parts).'.php';
-            if (file_exists($filepath)) {
-                require_once($filepath);
+            if (is_file($filepath)) {
+                require($filepath);
             }
         }
     }


### PR DESCRIPTION
If this library is used in an environment with other auto-loaders (a reasonable expectation), it's important to make sure that Predis auto-loader does not break other auto-loaders.

Consider scenario:

Some code in larger codebase tries to autoload a class using a schema different from that used in Predis. Predis autoloader won't be able to load that class, so if Predis autoloader runs first the whole process will fail since there's no file_exists() check in Predis autoloader. Instead, more neighbor-friendly approach would be Predis to just pass on, if it can not include the file / load the class, assuming some other autoloader may be able to do it.

I added a file_exists() around require and replaced require() with require_once (it's possible function to be called multiple times for the same class, so again: less error-probe if it's require_once rather than require(), imho).

Thank you.
