### PR TITLE
[doc] Describe available connection parameters.

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -40,6 +40,78 @@ Or, using an associative array::
        'database' => 3
    ));
 
+By default, Predis supports a lengthy list of connection parameters.
+
+.. note::
+
+   Since the client can use different :doc:`connection backends`, actual support
+   for certain parameters depends on the value of ``scheme`` and the connection
+   backends registered using the ``connections`` client option.
+
+==================  =============================================  =========  =========================================
+parameter           description                                    default    supported by
+==================  =============================================  =========  =========================================
+scheme              Instructs the client how to connect to Redis.  tcp        `Predis\\Connection\\StreamConnection`
+                    Supported values are: ``tcp``, ``unix``,                  `Predis\\Connection\\PhpiredisConnection`
+                    ``http``. Certain values such as ``http``                 `Predis\\Connection\\WebdisConnection`
+                    change the underlying connection backend.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+host                IP address or hostname of the server.          127.0.0.1  `Predis\\Connection\\StreamConnection`
+                    Ignored when using the ``unix`` scheme.                   `Predis\\Connection\\PhpiredisConnection`
+                                                                              `Predis\\Connection\\WebdisConnection`
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+port                TCP port the server listens on.                6379       `Predis\\Connection\\StreamConnection`
+                    Ignored when using the ``unix`` scheme.                   `Predis\\Connection\\PhpiredisConnection`
+                                                                              `Predis\\Connection\\WebdisConnection`
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+path                Path of the UNIX domain socket the server is   not set    `Predis\\Connection\\StreamConnection`
+                    listening on, used only in combination with               `Predis\\Connection\\PhpiredisConnection`
+                    the ``unix`` scheme.
+                    Example: ``/tmp/redis.sock``.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+database            Redis database to select when connecting.      not set    `Predis\\Connection\\StreamConnection`
+                    Its effect is the same of using `SELECT`_.                `Predis\\Connection\\PhpiredisConnection`
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+timeout             Timeout to perform the connection to Redis.    5.0        `Predis\\Connection\\StreamConnection`
+                    Its value is expressed in seconds as a float              `Predis\\Connection\\PhpiredisConnection`
+                    allowing sub-second resolution.                           `Predis\\Connection\\WebdisConnection`
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+read_write_timeout  Timeout for read and write operations.         platform   `Predis\\Connection\\StreamConnection`
+                    Its value is expressed in seconds as a float   dependent  `Predis\\Connection\\PhpiredisConnection`
+                    allowing sub-second resolution.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+async_connect       Tells the client to perform the connection     not set    `Predis\\Connection\\StreamConnection`
+                    asynchronously without waiting for it to be    (false)
+                    fully estabilished.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+persistent          The underlying socket is left intact after a   not set    `Predis\\Connection\\StreamConnection`
+                    GC collection or when the script terminates    (false)
+                    (only when using FastCGI or php-fpm).
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+iterable_multibulk  `Multi-bulk replies`_ are returned as PHP      false      `Predis\\Connection\\StreamConnection`
+                    iterable objects, making them streamable.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+alias               String used to identify a connection by name.  not set    Backend independent.
+                    This is useful with :doc:`clustering` and
+                    :doc:`replication`.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+weight              This is only used with :doc:`clustering` and   not set    Backend independent.
+                    determines the proportion of the load the
+                    corresponding server will bear relative to
+                    other nodes in the cluster.
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+user                Username for HTTP authentication (`Webdis`_).  not set    `Predis\\Connection\\WebdisConnection`
+------------------  ---------------------------------------------  ---------  -----------------------------------------
+pass                Password for HTTP authentication (`Webdis`_).  not set    `Predis\\Connection\\WebdisConnection`
+==================  =============================================  =========  =========================================
+
+.. _SELECT: http://redis.io/commands/select
+.. _Multi-bulk replies: http://redis.io/topics/protocol#multi-bulk-reply
+.. _Webdis: http://webd.is/
+
+Users can also specify their own parameters, they will simply be ignored by the
+client but can be used later to pass additional information for custom purposes.
+
 Client Options
 ''''''''''''''
 


### PR DESCRIPTION
Connection parameters don't need lengthy descriptions so I think that a schematic approach in the client chapter is probably the best, we can always expand on them when needed in a (not yet existing) _connection backend_ chapter where we describe the available connection backends and their differences.

On a related note, we could leverage the same approach for client options.
