### PR TITLE
add uri information on ConectionException

### DIFF
--- a/lib/Predis/Connection/StreamConnection.php
+++ b/lib/Predis/Connection/StreamConnection.php
@@ -91,7 +91,7 @@ class StreamConnection extends AbstractConnection
         $resource = @stream_socket_client($uri, $errno, $errstr, $parameters->timeout, $flags);
 
         if (!$resource) {
-            $this->onConnectionError(trim($errstr), $errno);
+            $this->onConnectionError(trim($errstr.' on '.$uri), $errno);
         }
 
         if (isset($parameters->read_write_timeout)) {
@@ -128,7 +128,7 @@ class StreamConnection extends AbstractConnection
         $resource = @stream_socket_client($uri, $errno, $errstr, $parameters->timeout, $flags);
 
         if (!$resource) {
-            $this->onConnectionError(trim($errstr), $errno);
+            $this->onConnectionError(trim($errstr.' on '.$uri), $errno);
         }
 
         return $resource;

--- a/tests/PHPUnit/ConnectionTestCase.php
+++ b/tests/PHPUnit/ConnectionTestCase.php
@@ -282,7 +282,6 @@ abstract class ConnectionTestCase extends StandardTestCase
      * @group connected
      * @group slow
      * @expectedException Predis\Connection\ConnectionException
-     * @expectedExceptionMessage Connection timed out
      */
     public function testThrowsExceptionOnConnectionTimeout()
     {


### PR DESCRIPTION
 Added Uri info on ConectionException, is very useful to debug network problems on environments with many Redis instances:

Predis\Connection\ConnectionException: Connection refused on tcp://127.0.0.1:6379/

 To pass all testSuite I was not able to find a way to assert ExpectedExceptionMessage, as connection attributes are not fixed, so i'd remove that annotation on ConnectionTestCase.
