### PR TITLE
setting medium timeout on slow tests

### DIFF
--- a/tests/Predis/Command/KeyExpireAtTest.php
+++ b/tests/Predis/Command/KeyExpireAtTest.php
@@ -96,6 +96,7 @@ class KeyExpireAtTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */

--- a/tests/Predis/Command/KeyExpireTest.php
+++ b/tests/Predis/Command/KeyExpireTest.php
@@ -96,6 +96,7 @@ class KeyExpireTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */
@@ -114,6 +115,7 @@ class KeyExpireTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */

--- a/tests/Predis/Command/KeyPreciseExpireAtTest.php
+++ b/tests/Predis/Command/KeyPreciseExpireAtTest.php
@@ -86,6 +86,7 @@ class KeyPreciseExpireAtTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */

--- a/tests/Predis/Command/KeyPreciseExpireTest.php
+++ b/tests/Predis/Command/KeyPreciseExpireTest.php
@@ -96,6 +96,7 @@ class KeyPreciseExpireTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */

--- a/tests/Predis/Command/StringSetExpireTest.php
+++ b/tests/Predis/Command/StringSetExpireTest.php
@@ -95,6 +95,7 @@ class StringSetExpireTest extends CommandTestCase
     }
 
     /**
+     * @medium
      * @group connected
      * @group slow
      */


### PR DESCRIPTION
Added @medium anotations in all @slow group to pass testSuite under strict mode.
