### PR TITLE
Fix DispatcherLoop error with client prefix keys

### DIFF
--- a/lib/Predis/PubSub/DispatcherLoop.php
+++ b/lib/Predis/PubSub/DispatcherLoop.php
@@ -96,8 +96,10 @@ class DispatcherLoop
      */
     public function attachCallback($channel, $callback)
     {
+        $callbackName = $this->getPrefixKeys() . $channel;
+
         $this->validateCallback($callback);
-        $this->callbacks[$channel] = $callback;
+        $this->callbacks[$callbackName] = $callback;
         $this->pubSubContext->subscribe($channel);
     }
 
@@ -108,8 +110,10 @@ class DispatcherLoop
      */
     public function detachCallback($channel)
     {
-        if (isset($this->callbacks[$channel])) {
-            unset($this->callbacks[$channel]);
+        $callbackName = $this->getPrefixKeys() . $channel;
+
+        if (isset($this->callbacks[$callbackName])) {
+            unset($this->callbacks[$callbackName]);
             $this->pubSubContext->unsubscribe($channel);
         }
     }
@@ -147,5 +151,17 @@ class DispatcherLoop
     public function stop()
     {
         $this->pubSubContext->closeContext();
+    }
+
+    /**
+     * Return the prefix of the keys
+     *
+     * @return string
+     */
+    protected function getPrefixKeys()
+    {
+        $prefix = $this->client->getOptions()->prefix;
+
+        return $prefix ? $prefix->getPrefix() : '';
     }
 }


### PR DESCRIPTION
DispatcherLoop does not work properly if a client have configured a
prefix for the keys
