### PR TITLE
Use a random IP when a host has several IPs.

### DIFF
--- a/lib/Predis/Connection/PhpiredisConnection.php
+++ b/lib/Predis/Connection/PhpiredisConnection.php
@@ -236,10 +236,10 @@ class PhpiredisConnection extends AbstractConnection
         $host = $parameters->host;
 
         if (ip2long($host) === false) {
-            if (($address = gethostbyname($host)) === $host) {
+            if (($addresses = gethostbynamel($host)) === false) {
                 $this->onConnectionError("Cannot resolve the address of $host");
             }
-            return $address;
+            return $addresses[array_rand($addresses)];
         }
 
         return $host;


### PR DESCRIPTION
Using gethostbyname, we will reuse the same (first) IP address for
each request. Here, we choose the IP we use randomly.

This is practical in a case where we have multiple redis read-only
slaves that can't invidually support the full application load, but are
accessible through a single hostname.
