### PR TITLE
connection params bug on php5.4--Update ConnectionFactory.php

### DIFF
--- a/lib/Predis/Connection/ConnectionFactory.php
+++ b/lib/Predis/Connection/ConnectionFactory.php
@@ -97,7 +97,7 @@ class ConnectionFactory implements ConnectionFactoryInterface
     public function create($parameters)
     {
         if (!$parameters instanceof ConnectionParametersInterface) {
-            $parameters = new ConnectionParameters($parameters ?: array());
+            $parameters = new ConnectionParameters($parameters ?$parameters: array());
         }
 
         $scheme = $parameters->scheme;


### PR DESCRIPTION
in php5.4: "$parameters?:array()" will always return "array()";
