### PR TITLE
Support the stream path in the connection params and URI (for persistent connections with database initCmd)

### DIFF
--- a/lib/Predis/Connection/ConnectionParameters.php
+++ b/lib/Predis/Connection/ConnectionParameters.php
@@ -27,6 +27,7 @@ class ConnectionParameters implements ConnectionParametersInterface
         'host' => '127.0.0.1',
         'port' => 6379,
         'timeout' => 5.0,
+        'path' => '/'
     );
 
     /**

--- a/lib/Predis/Connection/StreamConnection.php
+++ b/lib/Predis/Connection/StreamConnection.php
@@ -62,7 +62,7 @@ class StreamConnection extends AbstractConnection
      */
     private function tcpStreamInitializer(ConnectionParametersInterface $parameters)
     {
-        $uri = "tcp://{$parameters->host}:{$parameters->port}/";
+        $uri = "tcp://{$parameters->host}:{$parameters->port}{$parameters->path}";
         $flags = STREAM_CLIENT_CONNECT;
 
         if (isset($parameters->async_connect) && $parameters->async_connect) {


### PR DESCRIPTION
Here's a quick example test for the interaction between the `database` connection parameter, and persistent connections:

``` php
<?php
$cache_client = new Predis\Client('tcp://127.0.0.1:6379?persistent=1&database=0', []);
$durable_client = new Predis\Client('tcp://127.0.0.1:6379?persistent=1&database=1', []);

$cache_client->ping();    # Connection 1, "SELECT" "0", db0 "PING"
$durable_client->ping();  # Connection 1, "SELECT" "1", db1 "PING"
$cache_client->ping();    # Connection 1, db1 "PING" <<< This should have been on db0
$durable_client->ping();  # Connection 1, db1 "PING"
```

As you can see, initCmds are only run once, upon a connection being established. Then, because the two clients are connecting to the same IP address and port combination, with persistent connections turned on, they share a single persistent connection. The result is that the third `ping()` is executed in the wrong database (although this is particularly bad when the command is `flushdb` instead of `ping` :-)

The [PHP manual user notes](http://www.php.net/manual/en/function.stream-socket-client.php#105393) (sigh) for `stream_socket_client` mention that it actually supports specifying a path, and that this will make it open separate persistent connections:

> The remote_socket argument, in its end (well... after the port), can also contain a "/" followed by a unique identifier. This is especially useful if you want to create multiple persistent connections to the same transport://host:port combo.

This seems to work. With this PR applied, and specifying different paths in the above example (say, `tcp://127.0.0.1:6379/first?persistent=1&database=0` and `tcp://127.0.0.1:6379/second?persistent=1&database=1`), separate persistent connections are opened, and we can happily have one for each database. Then the `SELECT` in the initCmds will happily stick around, and won't be overwritten.
