### PR TITLE
Enable INCRBYFLOAT in cluster mode

### DIFF
--- a/lib/Predis/Cluster/PredisClusterHashStrategy.php
+++ b/lib/Predis/Cluster/PredisClusterHashStrategy.php
@@ -73,6 +73,7 @@ class PredisClusterHashStrategy implements CommandHashStrategyInterface
             'GETSET'                => $keyIsFirstArgument,
             'INCR'                  => $keyIsFirstArgument,
             'INCRBY'                => $keyIsFirstArgument,
+            'INCRBYFLOAT'           => $keyIsFirstArgument,
             'SETBIT'                => $keyIsFirstArgument,
             'SETEX'                 => $keyIsFirstArgument,
             'MSET'                  => array($this, 'getKeyFromInterleavedArguments'),

--- a/lib/Predis/Cluster/RedisClusterHashStrategy.php
+++ b/lib/Predis/Cluster/RedisClusterHashStrategy.php
@@ -70,6 +70,7 @@ class RedisClusterHashStrategy implements CommandHashStrategyInterface
             'GETSET'                => $keyIsFirstArgument,
             'INCR'                  => $keyIsFirstArgument,
             'INCRBY'                => $keyIsFirstArgument,
+            'INCRBYFLOAT'           => $keyIsFirstArgument,
             'SETBIT'                => $keyIsFirstArgument,
             'SETEX'                 => $keyIsFirstArgument,
             'MSET'                  => array($this, 'getKeyFromInterleavedArguments'),

--- a/tests/Predis/Cluster/PredisClusterHashStrategyTest.php
+++ b/tests/Predis/Cluster/PredisClusterHashStrategyTest.php
@@ -277,6 +277,7 @@ class PredisClusterHashStrategyTest extends PredisTestCase
             'GETSET'                => 'keys-first',
             'INCR'                  => 'keys-first',
             'INCRBY'                => 'keys-first',
+            'INCRBYFLOAT'           => 'keys-first',
             'SETBIT'                => 'keys-first',
             'SETEX'                 => 'keys-first',
             'MSET'                  => 'keys-interleaved',

--- a/tests/Predis/Cluster/RedisClusterHashStrategyTest.php
+++ b/tests/Predis/Cluster/RedisClusterHashStrategyTest.php
@@ -288,6 +288,7 @@ class RedisClusterHashStrategyTest extends PredisTestCase
             'GETSET'                => 'keys-first',
             'INCR'                  => 'keys-first',
             'INCRBY'                => 'keys-first',
+            'INCRBYFLOAT'           => 'keys-first',
             'SETBIT'                => 'keys-first',
             'SETEX'                 => 'keys-first',
             'MSET'                  => 'keys-interleaved',

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -286,6 +286,7 @@ class ReplicationStrategyTest extends PredisTestCase
             'GETSET'                => 'write',
             'INCR'                  => 'write',
             'INCRBY'                => 'write',
+            'INCRBYFLOAT'           => 'write',
             'SETBIT'                => 'write',
             'SETEX'                 => 'write',
             'MSET'                  => 'write',


### PR DESCRIPTION
I've fixed a problem that I met recently:

```
Unknown error: Cannot use INCRBYFLOAT with a cluster of connections
```
