### PR TITLE
Added 1.0 Branch Alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
     },
     "autoload": {
         "psr-0": {"Predis": "lib/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }


### PR DESCRIPTION
Let's allow people to install predis using "1.0.x@dev", "~1.0@dev", or any other valid version constraint rather than typing "dev-master" which is really horrible.
