### PR TITLE
use a loop instead of recursion in CursorBasedIterator

### DIFF
--- a/lib/Predis/Collection/Iterator/CursorBasedIterator.php
+++ b/lib/Predis/Collection/Iterator/CursorBasedIterator.php
@@ -165,17 +165,21 @@ abstract class CursorBasedIterator implements Iterator
      */
     public function next()
     {
-        if (!$this->elements && $this->fetchmore) {
-            $this->fetch();
-        }
+        do {
+            $more = false;
 
-        if ($this->elements) {
-            $this->extractNext();
-        } elseif ($this->cursor) {
-            $this->next();
-        } else {
-            $this->valid = false;
-        }
+            if (!$this->elements && $this->fetchmore) {
+                $this->fetch();
+            }
+
+            if ($this->elements) {
+                $this->extractNext();
+            } elseif ($this->cursor) {
+                $more = true;
+            } else {
+                $this->valid = false;
+            }
+        } while ($more);
     }
 
     /**


### PR DESCRIPTION
servers with large sets of keys will cause memory and stack exhaustion if recursion is used

intended to fix #181, works for me but welcome a cleaner solution
