### PR TITLE
Returning associative array from zrange command family

### DIFF
--- a/lib/Predis/Command/ZSetRange.php
+++ b/lib/Predis/Command/ZSetRange.php
@@ -92,7 +92,7 @@ class ZSetRange extends Command
             $result = array();
 
             for ($i = 0; $i < count($data); $i++) {
-                $result[] = array($data[$i], $data[++$i]);
+                $result[$data[$i]] = $data[++$i];
             }
 
             return $result;

--- a/tests/Predis/Command/ZSetIntersectionStoreTest.php
+++ b/tests/Predis/Command/ZSetIntersectionStoreTest.php
@@ -94,7 +94,7 @@ class ZSetIntersectionStoreTest extends PredisCommandTestCase
         $redis->zadd('letters:2nd', 1, 'b', 2, 'c', 3, 'd');
 
         $this->assertSame(2, $redis->zinterstore('letters:out', 2, 'letters:1st', 'letters:2nd'));
-        $this->assertSame(array(array('b', '3'), array('c', '5')), $redis->zrange('letters:out', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '3', 'c' => '5'), $redis->zrange('letters:out', 0, -1, 'withscores'));
 
         $this->assertSame(0, $redis->zinterstore('letters:out', 2, 'letters:1st', 'letters:void'));
         $this->assertSame(0, $redis->zinterstore('letters:out', 2, 'letters:void', 'letters:2nd'));
@@ -113,15 +113,15 @@ class ZSetIntersectionStoreTest extends PredisCommandTestCase
 
         $options = array('aggregate' => 'min');
         $this->assertSame(2, $redis->zinterstore('letters:min', 2, 'letters:1st', 'letters:2nd', $options));
-        $this->assertSame(array(array('b', '1'), array('c', '2')), $redis->zrange('letters:min', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '1', 'c' => '2'), $redis->zrange('letters:min', 0, -1, 'withscores'));
 
         $options = array('aggregate' => 'max');
         $this->assertSame(2, $redis->zinterstore('letters:max', 2, 'letters:1st', 'letters:2nd', $options));
-        $this->assertSame(array(array('b', '2'), array('c', '3')), $redis->zrange('letters:max', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '2', 'c' => '3'), $redis->zrange('letters:max', 0, -1, 'withscores'));
 
         $options = array('aggregate' => 'sum');
         $this->assertSame(2, $redis->zinterstore('letters:sum', 2, 'letters:1st', 'letters:2nd', $options));
-        $this->assertSame(array(array('b', '3'), array('c', '5')), $redis->zrange('letters:sum', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '3', 'c' => '5'), $redis->zrange('letters:sum', 0, -1, 'withscores'));
     }
 
     /**
@@ -136,7 +136,7 @@ class ZSetIntersectionStoreTest extends PredisCommandTestCase
 
         $options = array('weights' => array(2, 3));
         $this->assertSame(2, $redis->zinterstore('letters:out', 2, 'letters:1st', 'letters:2nd', $options));
-        $this->assertSame(array(array('b', '7'), array('c', '12')), $redis->zrange('letters:out', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '7', 'c' => '12'), $redis->zrange('letters:out', 0, -1, 'withscores'));
     }
 
     /**
@@ -151,7 +151,7 @@ class ZSetIntersectionStoreTest extends PredisCommandTestCase
 
         $options = array('aggregate' => 'max', 'weights' => array(10, 15));
         $this->assertSame(2, $redis->zinterstore('letters:out', 2, 'letters:1st', 'letters:2nd', $options));
-        $this->assertSame(array(array('b', '20'), array('c', '30')), $redis->zrange('letters:out', 0, -1, 'withscores'));
+        $this->assertSame(array('b' => '20', 'c' => '30'), $redis->zrange('letters:out', 0, -1, 'withscores'));
     }
 
     /**

--- a/tests/Predis/Command/ZSetRangeByScoreTest.php
+++ b/tests/Predis/Command/ZSetRangeByScoreTest.php
@@ -99,7 +99,7 @@ class ZSetRangeByScoreTest extends PredisCommandTestCase
     public function testParseResponseWithScores()
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
-        $expected = array(array('element1', '1'), array('element2', '2'), array('element3', '3'));
+        $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
 
         $command = $this->getCommandWithArgumentsArray(array('zset', 0, 1, 'withscores'));
 
@@ -177,7 +177,7 @@ class ZSetRangeByScoreTest extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
-        $expected = array(array('c', '10'), array('d', '20'), array('e', '20'));
+        $expected = array('c' => '10', 'd' => '20', 'e' => '20');
 
         $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, 'withscores'));
         $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, array('withscores' => true)));
@@ -207,7 +207,7 @@ class ZSetRangeByScoreTest extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
         $options = array('limit' => array(1, 2), 'withscores' => true);
-        $expected = array(array('d', '20'), array('e', '20'));
+        $expected = array('d' => '20', 'e' => '20');
 
         $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, $options));
     }

--- a/tests/Predis/Command/ZSetRangeTest.php
+++ b/tests/Predis/Command/ZSetRangeTest.php
@@ -80,7 +80,7 @@ class ZSetRangeTest extends PredisCommandTestCase
     public function testParseResponseWithScores()
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
-        $expected = array(array('element1', '1'), array('element2', '2'), array('element3', '3'));
+        $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
 
         $command = $this->getCommandWithArgumentsArray(array('zset', 0, 1, 'withscores'));
 
@@ -134,7 +134,7 @@ class ZSetRangeTest extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
-        $expected = array(array('c', '10'), array('d', '20'), array('e', '20'));
+        $expected = array('c' => '10', 'd' => '20', 'e' => '20');
 
         $this->assertSame($expected, $redis->zrange('letters', 2, 4, 'withscores'));
         $this->assertSame($expected, $redis->zrange('letters', 2, 4, array('withscores' => true)));

--- a/tests/Predis/Command/ZSetReverseRangeByScoreTest.php
+++ b/tests/Predis/Command/ZSetReverseRangeByScoreTest.php
@@ -99,7 +99,7 @@ class ZSetReverseRangeByScoreTest extends PredisCommandTestCase
     public function testParseResponseWithScores()
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
-        $expected = array(array('element1', '1'), array('element2', '2'), array('element3', '3'));
+        $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
 
         $command = $this->getCommandWithArgumentsArray(array('zset', 0, 1, 'withscores'));
 
@@ -177,7 +177,7 @@ class ZSetReverseRangeByScoreTest extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
-        $expected = array(array('e', '20'), array('d', '20'), array('c', '10'));
+        $expected = array('e' => '20', 'd' => '20', 'c' => '10');
 
         $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, 'withscores'));
         $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, array('withscores' => true)));
@@ -207,7 +207,7 @@ class ZSetReverseRangeByScoreTest extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
         $options = array('limit' => array(1, 2), 'withscores' => true);
-        $expected = array(array('d', '20'), array('c', '10'));
+        $expected = array('d' => '20', 'c' => '10');
 
         $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, $options));
     }

--- a/tests/Predis/Command/ZSetReverseRangeTest.php
+++ b/tests/Predis/Command/ZSetReverseRangeTest.php
@@ -80,7 +80,7 @@ class ZSetReverseRangeTest extends PredisCommandTestCase
     public function testParseResponseWithScores()
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
-        $expected = array(array('element1', '1'), array('element2', '2'), array('element3', '3'));
+        $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
 
         $command = $this->getCommandWithArgumentsArray(array('zset', 0, 1, 'withscores'));
 
@@ -134,7 +134,7 @@ class ZSetReverseRangeTest extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
-        $expected = array(array('d', '20'), array('c', '10'), array('b', '0'));
+        $expected = array('d' => '20', 'c' => '10', 'b' => '0');
 
         $this->assertSame($expected, $redis->zrevrange('letters', 2, 4, 'withscores'));
         $this->assertSame($expected, $redis->zrevrange('letters', 2, 4, array('withscores' => true)));

--- a/tests/Predis/Command/ZSetUnionStoreTest.php
+++ b/tests/Predis/Command/ZSetUnionStoreTest.php
@@ -95,7 +95,7 @@ class ZSetUnionStoreTest extends PredisCommandTestCase
 
         $this->assertSame(4, $redis->zunionstore('letters:out', 2, 'letters:1st', 'letters:2nd'));
         $this->assertSame(
-            array(array('a', '1'), array('b', '3'), array('d', '3'), array('c', '5')),
+            array('a' => '1', 'b' => '3', 'd' => '3', 'c' => '5'),
             $redis->zrange('letters:out', 0, -1, 'withscores')
         );
 
@@ -117,21 +117,21 @@ class ZSetUnionStoreTest extends PredisCommandTestCase
         $options = array('aggregate' => 'min');
         $this->assertSame(4, $redis->zunionstore('letters:min', 2, 'letters:1st', 'letters:2nd', $options));
         $this->assertSame(
-            array(array('a', '1'), array('b', '1'), array('c', '2'), array('d', '3')),
+            array('a' => '1', 'b' => '1', 'c' => '2', 'd' => '3'),
             $redis->zrange('letters:min', 0, -1, 'withscores')
         );
 
         $options = array('aggregate' => 'max');
         $this->assertSame(4, $redis->zunionstore('letters:max', 2, 'letters:1st', 'letters:2nd', $options));
         $this->assertSame(
-            array(array('a', '1'), array('b', '2'), array('c', '3'), array('d', '3')),
+            array('a' => '1', 'b' => '2', 'c' => '3', 'd' => '3'),
             $redis->zrange('letters:max', 0, -1, 'withscores')
         );
 
         $options = array('aggregate' => 'sum');
         $this->assertSame(4, $redis->zunionstore('letters:sum', 2, 'letters:1st', 'letters:2nd', $options));
         $this->assertSame(
-            array(array('a', '1'), array('b', '3'), array('d', '3'), array('c', '5')),
+            array('a' => '1', 'b' => '3', 'd' => '3', 'c' => '5'),
             $redis->zrange('letters:sum', 0, -1, 'withscores')
         );
     }
@@ -149,7 +149,7 @@ class ZSetUnionStoreTest extends PredisCommandTestCase
         $options = array('weights' => array(2, 3));
         $this->assertSame(4, $redis->zunionstore('letters:out', 2, 'letters:1st', 'letters:2nd', $options));
         $this->assertSame(
-            array(array('a', '2'), array('b', '7'), array('d', '9'), array('c', '12')),
+            array('a' => '2', 'b' => '7', 'd' => '9', 'c' => '12'),
             $redis->zrange('letters:out', 0, -1, 'withscores')
         );
     }
@@ -167,7 +167,7 @@ class ZSetUnionStoreTest extends PredisCommandTestCase
         $options = array('aggregate' => 'max', 'weights' => array(10, 15));
         $this->assertSame(4, $redis->zunionstore('letters:out', 2, 'letters:1st', 'letters:2nd', $options));
         $this->assertSame(
-            array(array('a', '10'), array('b', '20'), array('c', '30'), array('d', '45')),
+            array('a' => '10', 'b' => '20', 'c' => '30', 'd' => '45'),
             $redis->zrange('letters:out', 0, -1, 'withscores')
         );
     }


### PR DESCRIPTION
Fixes #120.

I also thought about accepting associative array in `zadd`, so result of `zrange` could be directly passed to `zadd`.
