### PR TITLE
Added a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,8 @@
 * text=auto
 
 /tests export-ignore
-/examples export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit.xml.travisci export-ignore
-/CHANGELOG.md export-ignore
-/CONTRIBUTING.md export-ignore
-/FAQ.md export-ignore
-/README.md export-ignore


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.

Users may run composer with the `--prefer-source` flag and composer will git clone the repos, thus including these excluded files if they so choose.
