### PR TITLE
Removed hhvm from allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,3 @@ before_script:
   - composer install --no-interaction --prefer-source --dev
 script:
   - vendor/bin/phpunit -c phpunit.xml.travisci
-matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true


### PR DESCRIPTION
Everything passes, so why not?
