### PR TITLE
Adds magic methods to the Client phpdoc

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -38,6 +38,12 @@ use Predis\Transaction\MultiExec as MultiExecTransaction;
  *
  * {@inheritdoc}
  *
+ * @method get($key)
+ * @method hget($hash, $key)
+ * @method hgetall($hash)
+ * @method set($key, $value)
+ * @method hset($hash, $key, $value)
+ *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
 class Client implements ClientInterface


### PR DESCRIPTION
Adds the basic methods (get, hget, hgetall, set, hset, expire) to the Client phpdoc. This allows mocking frameworks like [Prophecy](https://github.com/phpspec/prophecy) to mock predis objects.
