### PR TITLE
fix array_rand

### DIFF
--- a/src/Connection/Aggregate/MasterSlaveReplication.php
+++ b/src/Connection/Aggregate/MasterSlaveReplication.php
@@ -273,7 +273,9 @@ class MasterSlaveReplication implements ReplicationInterface
     protected function pickSlave()
     {
         if ($this->slaves) {
-            return $this->slaves[array_rand($this->slaves)];
+            $keys = array_keys($this->slaves);
+            $key = $keys[mt_rand(0, count($keys) - 1)];
+            return $this->slaves[$key];
         }
     }
 

--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -436,7 +436,9 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     protected function getRandomConnection()
     {
         if ($this->pool) {
-            return $this->pool[array_rand($this->pool)];
+            $keys = array_keys($this->pool);
+            $key = $keys[mt_rand(0, count($keys) - 1)];
+            return $this->pool[$key];
         }
     }
 


### PR DESCRIPTION
`array_rand` uses the libc generator, which is slower and less-random than Mersenne Twister.

https://github.com/nrk/predis/search?utf8=%E2%9C%93&q=array_rand

You better select random array value using `mt_rand`:
```php
$array = [1, 2, 3];
$random = mt_rand(0, count($array) - 1);
```

It's fixed in php7.1 - consult https://wiki.php.net/rfc/rng_fixes -, but you're targeting outdated one.