### PR TITLE
Ignore replication when value it's `false|null`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -120,7 +120,7 @@ class Client implements ClientInterface, \IteratorAggregate
             if ($options->defined('aggregate')) {
                 $initializer = $this->getConnectionInitializerWrapper($options->aggregate);
                 $connection = $initializer($parameters, $options);
-            } elseif ($options->defined('replication')) {
+            } elseif ($options->defined('replication') && $options->replication) {
                 $replication = $options->replication;
 
                 if ($replication instanceof AggregateConnectionInterface) {

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -297,19 +297,15 @@ class ClientTest extends PredisTestCase
     {
         $arg1 = array('tcp://host1', 'tcp://host2');
 
-        $arg2 = array(
+        $clientReplicationFalse = new Client($arg1, array(
             'cluster' => 'redis',
             'replication' =>  false,
-        );
+        ));
 
-        $clientReplicationFalse = new Client($arg1, $arg2);
-
-        $arg2 = array(
+        $clientReplicationNull = new Client($arg1, array(
             'cluster' => 'redis',
             'replication' =>  null,
-        );
-
-        $clientReplicationNull = new Client($arg1, $arg2);
+        ));
 
         $this->assertInstanceOf('Predis\Connection\Aggregate\ClusterInterface', $clientReplicationFalse->getConnection());
         $this->assertInstanceOf('Predis\Connection\Aggregate\ClusterInterface', $clientReplicationNull->getConnection());

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -292,6 +292,31 @@ class ClientTest extends PredisTestCase
 
     /**
      * @group disconnected
+     */
+    public function testConstructorWithReplicationFalseOrNull()
+    {
+        $arg1 = array('tcp://host1', 'tcp://host2');
+
+        $arg2 = array(
+            'cluster' => 'redis',
+            'replication' =>  false,
+        );
+
+        $clientReplicationFalse = new Client($arg1, $arg2);
+
+        $arg2 = array(
+            'cluster' => 'redis',
+            'replication' =>  null,
+        );
+
+        $clientReplicationNull = new Client($arg1, $arg2);
+
+        $this->assertInstanceOf('Predis\Connection\Aggregate\ClusterInterface', $clientReplicationFalse->getConnection());
+        $this->assertInstanceOf('Predis\Connection\Aggregate\ClusterInterface', $clientReplicationNull->getConnection());
+    }
+
+    /**
+     * @group disconnected
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage The callable connection initializer returned an invalid type.
      */


### PR DESCRIPTION
`const VERSION = '1.1.1';`

I'm working with [SncRedisBundle](https://github.com/snc/SncRedisBundle) and I saw that `replication` parameter its always passed to the `Predis\Client` even when it's null or false.
You may think it's a bad implementation, and it is because its causing errors like:
`Warning: call_user_func_array() expects parameter 1 to be a valid callback, no array or string given`

However I think its a good idea ignore this parameters when they doesn't make sense or when the value its a non action value like `false|null` considering that a `string|callable` are the only values that require actions.