### PR TITLE
Disconnect sentinelConnection on SentinelReplication::disconnect()

### DIFF
--- a/src/Connection/Aggregate/SentinelReplication.php
+++ b/src/Connection/Aggregate/SentinelReplication.php
@@ -640,6 +640,10 @@ class SentinelReplication implements ReplicationInterface
         foreach ($this->slaves as $connection) {
             $connection->disconnect();
         }
+
+        if ($this->sentinelConnection) {
+            $this->sentinelConnection->disconnect();
+        }
     }
 
     /**


### PR DESCRIPTION
Without this the sentinel connection is left open which can cause weird effects if the script is forked, etc.