### PR TITLE
modify zadd hint so they indicate infinite number of arguments

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -113,7 +113,7 @@ use Predis\Profile\ProfileInterface;
  * @method array  sscan($key, $cursor, array $options = null)
  * @method array  sunion(array|string $keys)
  * @method int    sunionstore($destination, array|string $keys)
- * @method int    zadd($key, array $membersAndScoresDictionary)
+ * @method int    zadd($key, ...$membersAndScoresDictionary)
  * @method int    zcard($key)
  * @method string zcount($key, $min, $max)
  * @method string zincrby($key, $increment, $member)


### PR DESCRIPTION
following example of:
http://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.param.pkg.html