### PR TITLE
Fixed stream read blocking signals

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -312,7 +312,7 @@ class StreamConnection extends AbstractConnection
             try {
                 $this->select([$socket], [], []);
             } catch (\Exception $e) {
-                if ($e == 'Interrupted system call') {
+                if ($e->getMessage() == 'Interrupted system call') {
                     pcntl_signal_dispatch();
                     continue;
                 }
@@ -401,7 +401,7 @@ class StreamConnection extends AbstractConnection
                 return;
             }
             // raise all other issues to exceptions
-            throw new \Exception($errstr, 0, $errno, $errfile, $errline);
+            throw new \Exception($errstr, $errno);
         });
 
         $count = stream_select($r, $w, $e, 10.0);

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(ticks=1);
 /*
  * This file is part of the Predis package.
  *
@@ -308,7 +308,18 @@ class StreamConnection extends AbstractConnection
     public function read()
     {
         $socket = $this->getResource();
-        $chunk = fgets($socket);
+        while (true) {
+            try {
+                $this->select([$socket], [], []);
+            } catch (\Exception $e) {
+                if ($e == 'Interrupted system call') {
+                    pcntl_signal_dispatch();
+                    continue;
+                }
+            }
+            $chunk = fgets($socket);
+            break;
+        }
 
         if ($chunk === false || $chunk === '') {
             $this->onConnectionError('Error while reading line from the server.');
@@ -371,6 +382,30 @@ class StreamConnection extends AbstractConnection
 
                 return;
         }
+    }
+
+    function select($r, $w, $e)
+    {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext = null) {
+            $last_error = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+
+            // fwrite notice that the stream isn't ready
+            if (strstr($errstr, 'Resource temporarily unavailable')) {
+                // it's allowed to retry
+                return;
+            }
+            // stream_select warning that it has been interrupted by a signal
+            if (strstr($errstr, 'Interrupted system call')) {
+                throw new \Exception("Interrupted system call");
+                // it's allowed while processing signals
+                return;
+            }
+            // raise all other issues to exceptions
+            throw new \Exception($errstr, 0, $errno, $errfile, $errline);
+        });
+
+        $count = stream_select($r, $w, $e, 10.0);
+        return $count;
     }
 
     /**


### PR DESCRIPTION
this code demo blpop will block pcntl_signal

```
<?php
declare(ticks=1);
# I want ctrl + c terminal this process
# but that unavailable because int signal is blocking by fgets
include __DIR__ . '/../autoload.php';
pcntl_signal(SIGINT, function($signal) {
    echo("INT signal\n");
    exit(0);
});
$client = new \Predis\Client();
$client->blpop('test', 10);
```

https://github.com/imcj/predis/blob/demo-blocking/examples/stream_connection_blocking_signals.php

I fixed that. Add select in read, select not blocking signals.when signal arrived , select will raise an exception.and then dispatch signals again.

now, i can listen SIGINT, save process state. and quit.

why did that?

because i use predis in the imcj/mqk , that library start multi processes consume redis list message, and mapping to the event.i want use signal SIGINT graceful all processes, but predis hold all signals, i cann't listen SIGINT signal.

thx for all contributors.

```
    public function read()
    {
        $socket = $this->getResource();
        while (true) {
            try {
                $this->select([$socket], [], []);
            } catch (\Exception $e) {
                if ($e == 'Interrupted system call') {
                    pcntl_signal_dispatch();
                    continue;
                }
            }
            $chunk = fgets($socket);
            break;
        }
```