### PR TITLE
Handle EINTR errors in PhpiredisSocketConnection

### DIFF
--- a/src/Connection/PhpiredisSocketConnection.php
+++ b/src/Connection/PhpiredisSocketConnection.php
@@ -381,7 +381,13 @@ class PhpiredisSocketConnection extends AbstractConnection
 
         while (PHPIREDIS_READER_STATE_INCOMPLETE === $state = phpiredis_reader_get_state($reader)) {
             if (@socket_recv($socket, $buffer, 4096, 0) === false || $buffer === '' || $buffer === null) {
-                $this->emitSocketError();
+                if (socket_last_error() === SOCKET_EINTR) {
+                    if (@socket_recv($socket, $buffer, 4096, 0) === false || $buffer === '' || $buffer === null) {
+                        $this->emitSocketError();
+                    }
+                } else {
+                    $this->emitSocketError();
+                }
             }
 
             phpiredis_reader_feed($reader, $buffer);


### PR DESCRIPTION
Between PHP 7.0 and 7.1 something changed and sometimes EINTR is
returned.  This is in fact normal for socket operations on
Linux. After EINTR operation should be retried. Retry it once, as that
how it is handled in PHP streams.