### PR TITLE
Correcting the return type hint for BRPOPLPUSH method

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -83,7 +83,7 @@ use Predis\Profile\ProfileInterface;
  * @method int    hstrlen($key, $field)
  * @method array  blpop(array|string $keys, $timeout)
  * @method array  brpop(array|string $keys, $timeout)
- * @method array  brpoplpush($source, $destination, $timeout)
+ * @method string brpoplpush($source, $destination, $timeout)
  * @method string lindex($key, $index)
  * @method int    linsert($key, $whence, $pivot, $value)
  * @method int    llen($key)


### PR DESCRIPTION
I could be missing something, but in my tests, `brpoplpush` returns a string. [The Redis docs](https://redis.io/commands/brpoplpush) seem to confirm this. My IDE was complaining about the return type not matching in a method I wrote that returns a string after calling `brpoplpush`, and when I dug into the IDE warning, I found the `ClientInterface` class to be providing an `array` type instead of a `string` return type.