### PR TITLE
Disconnect when server returns bad response in an atomic pipeline

### DIFF
--- a/tests/Predis/Pipeline/AtomicTest.php
+++ b/tests/Predis/Pipeline/AtomicTest.php
@@ -33,7 +33,7 @@ class AtomicTest extends PredisTestCase
                    ->method('writeRequest');
         $connection->expects($this->exactly(5))
                    ->method('readResponse')
-                   ->will($this->onConsecutiveCalls(true, $queued, $queued, $queued, [ $pong, $pong, $pong ]));
+                   ->will($this->onConsecutiveCalls(true, $queued, $queued, $queued, array($pong, $pong, $pong)));
 
         $pipeline = new Atomic(new Client($connection));
 

--- a/tests/Predis/Pipeline/AtomicTest.php
+++ b/tests/Predis/Pipeline/AtomicTest.php
@@ -46,7 +46,7 @@ class AtomicTest extends PredisTestCase
 
     /**
      * @group disconnected
-     * @expectedException \Predis\Transaction\AbortedMultiExecException
+     * @expectedException \Predis\ClientException
      * @expectedExceptionMessage The underlying transaction has been aborted by the server.
      */
     public function testThrowsExceptionOnAbortedTransaction()


### PR DESCRIPTION
Predis' atomic pipelines are not throwing a ServerException when Redis
returns an error.  Instead, the code considers it to be a ClientException
and maintains the connection.

This patch will convert server errors to ServerExceptions and disconnect.
The Client object will re-connect on the next command attempt.

This patch also disconnects from the server if no response or the partial
response does not include a server error, as the connection state appears
to be in a bad state and should not be reused.