### PR TITLE
update sort command to be a write operation

### DIFF
--- a/src/Replication/ReplicationStrategy.php
+++ b/src/Replication/ReplicationStrategy.php
@@ -90,31 +90,6 @@ class ReplicationStrategy
     }
 
     /**
-     * Checks if a SORT command is a readable operation by parsing the arguments
-     * array of the specified commad instance.
-     *
-     * @param CommandInterface $command Command instance.
-     *
-     * @return bool
-     */
-    protected function isSortReadOnly(CommandInterface $command)
-    {
-        $arguments = $command->getArguments();
-        $argc = count($arguments);
-
-        if ($argc > 1) {
-            for ($i = 1; $i < $argc; ++$i) {
-                $argument = strtoupper($arguments[$i]);
-                if ($argument === 'STORE') {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Checks if BITFIELD performs a read-only operation by looking for certain
      * SET and INCRYBY modifiers in the arguments array of the command.
      *
@@ -292,7 +267,6 @@ class ReplicationStrategy
             'BITPOS' => true,
             'TIME' => true,
             'PFCOUNT' => true,
-            'SORT' => array($this, 'isSortReadOnly'),
             'BITFIELD' => array($this, 'isBitfieldReadOnly'),
             'GEOHASH' => true,
             'GEOPOS' => true,

--- a/tests/Predis/Connection/Aggregate/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Aggregate/MasterSlaveReplicationTest.php
@@ -544,29 +544,6 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSortTriggersSwitchToMasterConnectionOnStoreModifier()
-    {
-        $profile = Profile\Factory::get('dev');
-        $cmdSortNormal = $profile->createCommand('sort', array('key'));
-        $cmdSortStore = $profile->createCommand('sort', array('key', array('store' => 'key:store')));
-
-        $master = $this->getMockConnection('tcp://host1?alias=master');
-        $master->expects($this->once())->method('executeCommand')->with($cmdSortStore);
-
-        $slave1 = $this->getMockConnection('tcp://host2?alias=slave1');
-        $slave1->expects($this->once())->method('executeCommand')->with($cmdSortNormal);
-
-        $replication = new MasterSlaveReplication();
-        $replication->add($master);
-        $replication->add($slave1);
-
-        $replication->executeCommand($cmdSortNormal);
-        $replication->executeCommand($cmdSortStore);
-    }
-
-    /**
-     * @group disconnected
-     */
     public function testDiscardsUnreachableSlaveAndExecutesReadOnlyCommandOnNextSlave()
     {
         $profile = Profile\Factory::getDefault();

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -81,15 +81,15 @@ class ReplicationStrategyTest extends PredisTestCase
         $profile = Profile\Factory::getDevelopment();
         $strategy = new ReplicationStrategy();
 
-        $cmdReadSort = $profile->createCommand('SORT', array('key:list'));
-        $this->assertTrue(
-            $strategy->isReadOperation($cmdReadSort),
-            'SORT is expected to be a read operation.'
+        $cmdReturnSort = $profile->createCommand('SORT', array('key:list'));
+        $this->assertFalse(
+            $strategy->isReadOperation($cmdReturnSort),
+            'SORT is expected to be a write operation.'
         );
 
-        $cmdWriteSort = $profile->createCommand('SORT', array('key:list', array('store' => 'key:stored')));
+        $cmdStoreSort = $profile->createCommand('SORT', array('key:list', array('store' => 'key:stored')));
         $this->assertFalse(
-            $strategy->isReadOperation($cmdWriteSort),
+            $strategy->isReadOperation($cmdStoreSort),
             'SORT with STORE is expected to be a write operation.'
         );
     }


### PR DESCRIPTION
Addresses #468 

As noted in the linked issue, Redis treats all SORT commands as 'write' operations
https://github.com/antirez/redis/blob/4.0/src/server.c#L252

This patch removes 'SORT' from the array returned by ReplicationStrategy::getReadOnlyOperations() and removes the isSortReadOnly() helper method. Related tests were also updated.