### PR TITLE
Add support for Redis4.0+ SLOWLOG client IP & client name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ matrix:
       services: redis-server
       before_install: skip
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
     - v0.6
     - v0.6-PHP_5.2
     - documentation
-services: redis-server
 before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
@@ -16,10 +15,19 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      dist: precise
+      services: redis-server
     - php: 5.4
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 5.5
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 5.6
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.0
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.1
-    - php: hhvm
-      dist: trusty
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
+    - php: 7.2
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
+    - php: 7.3
+      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
 script:
-  - vendor/bin/phpunit -c phpunit.xml.travisci
+  - travis_retry vendor/bin/phpunit -c phpunit.xml.travisci
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
     - v0.6
     - v0.6-PHP_5.2
     - documentation
+before_install:
+  - docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
 before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
@@ -17,17 +19,11 @@ matrix:
     - php: 5.3
       dist: precise
       services: redis-server
+      before_install: skip
     - php: 5.4
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 5.5
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 5.6
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.0
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.1
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.2
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3
     - php: 7.3
-      before_install: docker run -d --rm -p 127.0.0.1:6379:6379 redis:3

--- a/src/Command/ServerSlowlog.php
+++ b/src/Command/ServerSlowlog.php
@@ -40,6 +40,8 @@ class ServerSlowlog extends Command
                     'timestamp' => $entry[1],
                     'duration' => $entry[2],
                     'command' => $entry[3],
+                    'clientIp' => isset($entry[4]) ? $entry[4] : null,
+                    'clientName' => isset($entry[5]) ? $entry[5] : null,
                 );
             }
 

--- a/tests/Predis/Command/ServerSlowlogTest.php
+++ b/tests/Predis/Command/ServerSlowlogTest.php
@@ -61,7 +61,9 @@ class ServerSlowlogTest extends PredisCommandTestCase
                 'id' => 0,
                 'timestamp' => 1323163469,
                 'duration' => 12451,
-                'command' => array('SORT', 'list:unordered'),
+                'command' => array('SORT', 'list:unordered'),#
+                'clientIp' => null,
+                'clientName' => null,
             ),
         );
 


### PR DESCRIPTION
Not sure if this is sensible, or if a `Predis\Profile\RedisVersion400` needs to be created instead.

Either way, this is basically what I'm doing with an extended class of ServerSlowlog and injecting it into the profile.