### PR TITLE
Setup Github Actions Workflows

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -1,9 +1,9 @@
-# GitHub Action for Predis with PHP 7.2 & Redis 3
+# GitHub Action for Predis with PHP 7.2, 7.3, 7.4 & 8.0 & Redis 3, 4, 5 & 6
 name: Predis Builds
 on: [push, pull_request]
 jobs:
   predis_redis3:
-    name: Predis (PHP ${{ matrix.php-versions }})
+    name: Redis 3 (PHP ${{ matrix.php-versions }})
     runs-on: ubuntu-latest
     services:
       redis:
@@ -14,7 +14,109 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        # Use composer.json for key, if composer.lock is not committed.
+        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Composer dependencies
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
+    - name: Test with phpunit
+      run: vendor/bin/phpunit
+
+  predis_redis4:
+    name: Redis 4 (PHP ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:4
+        ports:
+        - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        # Use composer.json for key, if composer.lock is not committed.
+        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Composer dependencies
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
+    - name: Test with phpunit
+      run: vendor/bin/phpunit
+
+  predis_redis5:
+    name: Redis 5 (PHP ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:5
+        ports:
+        - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        # Use composer.json for key, if composer.lock is not committed.
+        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Composer dependencies
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
+    - name: Test with phpunit
+      run: vendor/bin/phpunit
+
+  predis_redis6:
+    name: Redis 6 (PHP ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:6
+        ports:
+        - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -2,12 +2,12 @@
 name: Predis Builds
 on: [push, pull_request]
 jobs:
-  predis_redis3:
-    name: Redis 3 (PHP ${{ matrix.php-versions }})
+  predis:
+    name: Redis ${{ matrix.redis-versions }} (PHP ${{ matrix.php-versions }})
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:3
+        image: redis:${{ matrix.redis-versions }}
         ports:
         - 6379/tcp
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0']
+        redis-versions: ['3', '4', '5', '6']
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -27,110 +28,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composercache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-    - name: Install Composer dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader
-    - name: Test with phpunit
-      run: vendor/bin/phpunit
-
-  predis_redis4:
-    name: Redis 4 (PHP ${{ matrix.php-versions }})
-    runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:4
-        ports:
-        - 6379/tcp
-        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup PHP, with composer and extensions
-      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
-    - name: Get composer cache directory
-      id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - name: Cache composer dependencies
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.composercache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-    - name: Install Composer dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader
-    - name: Test with phpunit
-      run: vendor/bin/phpunit
-
-  predis_redis5:
-    name: Redis 5 (PHP ${{ matrix.php-versions }})
-    runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:5
-        ports:
-        - 6379/tcp
-        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup PHP, with composer and extensions
-      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
-    - name: Get composer cache directory
-      id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - name: Cache composer dependencies
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.composercache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-    - name: Install Composer dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader
-    - name: Test with phpunit
-      run: vendor/bin/phpunit
-
-  predis_redis6:
-    name: Redis 6 (PHP ${{ matrix.php-versions }})
-    runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:6
-        ports:
-        - 6379/tcp
-        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup PHP, with composer and extensions
-      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
-    - name: Get composer cache directory
-      id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - name: Cache composer dependencies
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.composercache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-
     - name: Install Composer dependencies

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -1,0 +1,37 @@
+# GitHub Action for Predis with PHP 7.2 & Redis 3
+name: Predis Builds
+on: [push, pull_request]
+jobs:
+  predis_redis3:
+    name: Predis (PHP ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:3
+        ports:
+        - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+    - name: Get composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        # Use composer.json for key, if composer.lock is not committed.
+        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Composer dependencies
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
+    - name: Test with phpunit
+      run: vendor/bin/phpunit

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup PHP, with composer and extensions
+      with:
+        php-version: ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
     - name: Get composer cache directory
       id: composercache
@@ -27,6 +29,7 @@ jobs:
     - name: Cache composer dependencies
       uses: actions/cache@v2
       with:
+        php-version: ${{ matrix.php-versions }}
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest development][ico-version-dev]][link-packagist]
 [![Monthly installs][ico-downloads-monthly]][link-downloads]
 [![Build status][ico-travis]][link-travis]
+![Build](https://github.com/predishq/predis/workflows/Predis%20Builds/badge.svg)
 
 A flexible and feature-complete [Redis](http://redis.io) client for PHP 7.2 and newer.
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "suggest": {
         "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol",


### PR DESCRIPTION
The following adds the Github actions workflow to test builds as mentioned in #621. The PR the Predis build against the following Redis versions:

* Redis 3
* Redis 4
* Redis 5
* Redis 6

with the following PHP versions:

* PHP 7.2
* PHP 7.3
* PHP 7.4
* PHP 8.0

Once the failing tests are fixed, the Github Build will automatically be marked as Green.

@nrk @tillkruss please review, and let me know if any changes are to be done. 