### PR TITLE
Pipeline: Perform all I/O in try/catch before processing responses

### DIFF
--- a/tests/Predis/Pipeline/PipelineTest.php
+++ b/tests/Predis/Pipeline/PipelineTest.php
@@ -93,7 +93,7 @@ class PipelineTest extends PredisTestCase
         $error = new Response\Error('ERR Test error');
 
         $connection = $this->getMock('Predis\Connection\NodeConnectionInterface');
-        $connection->expects($this->once())
+        $connection->expects($this->exactly(2))
                    ->method('readResponse')
                    ->will($this->returnValue($error));
 


### PR DESCRIPTION
By restructuring, any failure during I/O will cause a disconnect (since the connection(s) are now out-of-sync with local state, or may be unusable).  Exceptions during response processing may happen without disconnecting as the connection state is ok.

Test is updated to reflect that all responses are read before throwing an exception (to flush the recv channel).

This patch targets issue #547 