### PR TITLE
Change method used to undefine commands in command factory.

### DIFF
--- a/src/Command/RedisFactory.php
+++ b/src/Command/RedisFactory.php
@@ -47,4 +47,18 @@ class RedisFactory extends Factory
 
         return $commandClass;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function undefineCommand($commandID)
+    {
+        // NOTE: we explicitly associate `NULL` to the command ID in the map
+        // instead of the parent's `unset()` because our subclass tries to load
+        // a predefined class from the Predis\Command\Redis namespace when no
+        // explicit mapping is defined, see RedisFactory::getCommandClass() for
+        // details of the implementation of this mechanism.
+        $this->commands[strtoupper($commandID)] = null;
+    }
+
 }

--- a/src/Configuration/Option/Commands.php
+++ b/src/Configuration/Option/Commands.php
@@ -35,8 +35,12 @@ class Commands implements OptionInterface
         if (is_array($value)) {
             $commands = $this->getDefault($options);
 
-            foreach ($value as $commandID => $classFQN) {
-                $commands->defineCommand($commandID, $classFQN);
+            foreach ($value as $commandID => $commandClass) {
+                if ($commandClass === null) {
+                    $commands->undefineCommand($commandID);
+                } else {
+                    $commands->defineCommand($commandID, $commandClass);
+                }
             }
 
             return $commands;

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -702,7 +702,7 @@ class ClientTest extends PredisTestCase
     public function testThrowsExceptionOnNonRegisteredRedisCommand()
     {
         $this->expectException('Predis\ClientException');
-        $this->expectExceptionMessage("Command 'INVALIDCOMMAND' is not a registered Redis command");
+        $this->expectExceptionMessage("Command `INVALIDCOMMAND` is not a registered Redis command");
 
         $client = new Client();
         $client->invalidCommand();

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -102,7 +102,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->assertTrue($factory->supportsCommand('PING'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
 
-        $factory->defineCommand('PING', null);
+        $factory->undefineCommand('PING');
 
         $this->assertFalse($factory->supportsCommand('PING'));
         $this->assertNull($factory->getCommandClass('PING'));
@@ -121,7 +121,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->assertTrue($factory->supportsCommand('MOCK'));
         $this->assertSame($commandClass, $factory->getCommandClass('MOCK'));
 
-        $factory->defineCommand('MOCK', null);
+        $factory->undefineCommand('MOCK');
 
         $this->assertFalse($factory->supportsCommand('MOCK'));
         $this->assertNull($factory->getCommandClass('MOCK'));
@@ -133,7 +133,7 @@ class RedisFactoryTest extends PredisTestCase
     public function testDefineInvalidCommand()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage("The class 'stdClass' is not a valid command class.");
+        $this->expectExceptionMessage("Class stdClass must implement Predis\Command\CommandInterface");
 
         $factory = new RedisFactory();
 
@@ -175,7 +175,7 @@ class RedisFactoryTest extends PredisTestCase
     public function testCreateUndefinedCommand()
     {
         $this->expectException('Predis\ClientException');
-        $this->expectExceptionMessage("Command 'UNKNOWN' is not a registered Redis command.");
+        $this->expectExceptionMessage("Command `UNKNOWN` is not a registered Redis command.");
 
         $factory = new RedisFactory();
 

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -104,6 +104,29 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
+    public function testAcceptsDictionaryOfCommandsWithNullsToUndefineCommandsAsValue()
+    {
+        $option = new Commands();
+
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $input = array(
+            'ECHO' => null,
+            'EVAL' => null,
+            'FOO'  => null,
+        );
+
+        $commands = $option->filter($options, $input);
+
+        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands);
+        $this->assertNull($commands->getCommandClass('ECHO'));
+        $this->assertNull($commands->getCommandClass('EVAL'));
+        $this->assertNull($commands->getCommandClass('FOO'));
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testAcceptsCallableReturningCommandFactoryInstance()
     {
         $option = new Commands();


### PR DESCRIPTION
This pull request targets some issues [emerged from feedback](https://github.com/predis/predis/pull/644#discussion_r472865273) in #644.

The previous implementation for undefining commands in command factory was not good because we were exposing in the public API an internal implementation detail of the base factory class, furthermore it made `Predis\Command\Factory::defineCommand()` confusing. Having a separate method to undefine commands in the factory is self-explanatory.

We also changed `Predis\Configuration\Option\Commands` accordingly when a dictionary of `[$commandID => $classCommand]` is passed to the `commands` client option and `$classCommand` is `NULL`.

A few minor changes (mostly cosmetic or documentation) were applied too.

By the way, I was thinking about removing the "command" part from method names, so `defineCommand()` would become `define()` or `createCommand()` would become `create()`. Initially I was about to push this change here, but I decided to leave it for another PR. What do you think?