### PR TITLE
Remove useless argument in Predis\Client::getClientBy()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -194,24 +194,36 @@ class Client implements ClientInterface, \IteratorAggregate
     }
 
     /**
-     * Creates a new client from the specified .
+     * Creates a new client using a specific underlying connection.
      *
-     * The new client instances inherites the same options of the original one.
-     * When no callable object is supplied, this method returns the new client.
-     * When a callable object is supplied, the new client is passed as its sole
-     * argument and its return value is returned by this method to the caller.
+     * This method allows to create a new client instance by picking a specific
+     * connection out of an aggregate one, with the same options of the original
+     * client instance.
      *
-     * NOTE: This method works against any kind of underlying connection object
-     * as it uses a duck-typing approach and looks for a suitable method that
-     * matches the selector type to extract the correct connection.
+     * The specified selector defines which logic to use to look for a suitable
+     * connection by the specified value. Supported selectors are:
      *
-     * @param string        $selector Type of selector (`id`, `key`, `slot`, `command`)
-     * @param string        $value    Values of selector.
-     * @param callable|null $callable Optional callable object.
+     *   - `id`
+     *   - `key`
+     *   - `slot`
+     *   - `command`
+     *   - `alias`
+     *   - `role`
      *
-     * @return ClientInterface|mixed
+     * Internally the client relies on duck-typing and follows this convention:
+     *
+     *   $selector string => getConnectionBy$selector($value) method
+     *
+     * This means that support for specific selectors may vary depending on the
+     * actual logic implemented by connection classes and there is no interface
+     * binding a connection class to implement any of these.
+     *
+     * @param string $selector Type of selector.
+     * @param mixed  $value    Value to be used by the selector.
+     *
+     * @return ClientInterface
      */
-    public function getClientBy($selector, $value, $callable = null)
+    public function getClientBy($selector, $value)
     {
         $selector = strtolower($selector);
 
@@ -230,11 +242,7 @@ class Client implements ClientInterface, \IteratorAggregate
 
         $client = new static($connection, $this->getOptions());
 
-        if ($callable) {
-            return call_user_func($callable, $client);
-        } else {
-            return $client;
-        }
+        return $client;
     }
 
     /**

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -728,33 +728,6 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodInvokesCallableInSecondArgumentAndReturnsItsReturnValue()
-    {
-        $test = $this;
-        $client = new Client(array('tcp://host1?alias=node01', 'tcp://host2?alias=node02'), array('cluster' => 'predis'));
-
-        $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
-            ->getMock();
-        $callable
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->callback(function ($clientNode) use ($test, $client) {
-                $test->isInstanceOf('Predis\ClientInterface', $clientNode);
-                $test->assertNotSame($client, $clientNode);
-                $test->assertInstanceOf('Predis\Connection\NodeConnectionInterface', $connection = $clientNode->getConnection());
-                $test->assertSame('node02', $connection->getParameters()->alias);
-
-                return true;
-            }))
-            ->will($this->returnValue('value'));
-
-        $this->assertSame('value', $client->getClientBy('alias', 'node02', $callable));
-    }
-
-    /**
-     * @group disconnected
-     */
     public function testGetClientByMethodSupportsSelectingConnectionById()
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();


### PR DESCRIPTION
This pull request targets some issues [emerged from feedback](https://github.com/predis/predis/pull/644#discussion_r472960440) in #644.

There was no real meaning in having an optional callback argument for `Predis\Client::getClientBy()`, for the most part it was just a leftover of a previous approach implemented with ee7104d and quickly superseded by the current approach that simply returns the new client instance instead of using callbacks.