### PR TITLE
Make client configuration easier for phpiredis based connections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ v2.0.0 (202x-xx-xx)
   based connection backends simply, accepted values are:
 
   - `phpiredis-stream` maps `Phpiredis\Connection\PhpiredisStreamConnection` to
-    `tcp` and `unix` URI schemes.
+    `tcp`, `redis`, `unix` URI schemes.
   - `phpiredis-socket` maps `Phpiredis\Connection\PhpiredisSocketConnection` to
-    `tcp` and `unix` URI schemes.
+    `tcp`, `redis`, `unix` URI schemes.
   - `phpiredis-stream` is simply an alias of `phpiredis-stream`.
 
 - Added the new `Predis\Cluster\Hash\PhpiredisCRC16` class using ext-phpiredis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,25 @@ v2.0.0 (202x-xx-xx)
      aggregate connection.
   - `commands`: command factory, named array mapping command IDs to PHP classes,
     callable returning a command factory or a named array.
-  - `connections`: connection factory, callable returning a connection factory,
-    named array mapping connection schemes to PHP classes.
+  - `connections`: connection factory, callable object returning a connection
+    factory, named array mapping URI schemes to PHP classes, string identifying
+    a supported combination of configurations for the connection factory.
   - `prefix`: string value, command processor, callable.
   - `exceptions`: boolean.
 
   Note that both the `cluster` and `replication` options now return a closure
   acting as initializer instead of an aggregate connection instance.
+
+- The `connections` client option now accepts certain string values identifying
+  certain combinations of configurations for the connection factory. Currenlty
+  this is used to provide a short way to configure Predis to load our phpiredis
+  based connection backends simply, accepted values are:
+
+  - `phpiredis-stream` maps `Phpiredis\Connection\PhpiredisStreamConnection` to
+    `tcp` and `unix` URI schemes.
+  - `phpiredis-socket` maps `Phpiredis\Connection\PhpiredisSocketConnection` to
+    `tcp` and `unix` URI schemes.
+  - `phpiredis-stream` is simply an alias of `phpiredis-stream`.
 
 - Added the new `Predis\Cluster\Hash\PhpiredisCRC16` class using ext-phpiredis
   to speed-up the generation of the CRC16 hash of keys for redis-cluster. Predis

--- a/README.md
+++ b/README.md
@@ -412,6 +412,17 @@ $client = new Predis\Client('tcp://127.0.0.1', [
 ]);
 ```
 
+The client can also be configured to rely on a [phpiredis](https://github.com/nrk/phpiredis)-backend
+by specifying a descriptive string for the `connections` client option. Supported string values are:
+
+- `phpiredis-stream` maps `tcp` and `unix` to `Predis\Connection\PhpiredisStreamConnection`
+- `phpiredis-socket` maps `tcp` and `unix` to `Predis\Connection\PhpiredisSocketConnection`
+- `phpiredis` is simply an alias of `phpiredis-stream`
+
+```php
+$client = new Predis\Client('tcp://127.0.0.1', ['connections' => 'phpiredis']);
+```
+
 Developers can create their own connection classes to support whole new network backends, extend
 existing classes or provide completely different implementations. Connection classes must implement
 `Predis\Connection\NodeConnectionInterface` or extend `Predis\Connection\AbstractConnection`:

--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ $client = new Predis\Client('tcp://127.0.0.1', [
 The client can also be configured to rely on a [phpiredis](https://github.com/nrk/phpiredis)-backend
 by specifying a descriptive string for the `connections` client option. Supported string values are:
 
-- `phpiredis-stream` maps `tcp` and `unix` to `Predis\Connection\PhpiredisStreamConnection`
-- `phpiredis-socket` maps `tcp` and `unix` to `Predis\Connection\PhpiredisSocketConnection`
+- `phpiredis-stream` maps `tcp`, `redis` and `unix` to `Predis\Connection\PhpiredisStreamConnection`
+- `phpiredis-socket` maps `tcp`, `redis` and `unix` to `Predis\Connection\PhpiredisSocketConnection`
 - `phpiredis` is simply an alias of `phpiredis-stream`
 
 ```php

--- a/src/Configuration/Option/Connections.php
+++ b/src/Configuration/Option/Connections.php
@@ -15,6 +15,8 @@ use Predis\Configuration\OptionInterface;
 use Predis\Configuration\OptionsInterface;
 use Predis\Connection\Factory;
 use Predis\Connection\FactoryInterface;
+use Predis\Connection\PhpiredisStreamConnection;
+use Predis\Connection\PhpiredisSocketConnection;
 
 /**
  * Configures a new connection factory instance.
@@ -84,9 +86,9 @@ class Connections implements OptionInterface
      * string that identifies specific configurations of schemes and connection
      * classes. Supported configuration values are:
      *
-     *  - "phpiredis-stream" maps "tcp", "unix" to Predis\Connection\PhpiredisStreamConnection
-     *  - "phpiredis-socket" maps "tcp", "unix" to Predis\Connection\PhpiredisSocketConnection
-     *  - "phpiredis" is an alias of "phpiredis-stream"
+     * - "phpiredis-stream" maps tcp, redis, unix to PhpiredisStreamConnection
+     * - "phpiredis-socket" maps tcp, redis, unix to PhpiredisSocketConnection
+     * - "phpiredis" is an alias of "phpiredis-stream"
      *
      * @param OptionsInterface $options Client options
      * @param string           $value   Descriptive string identifying the desired configuration
@@ -103,13 +105,15 @@ class Connections implements OptionInterface
         switch(strtolower($value)) {
             case 'phpiredis':
             case 'phpiredis-stream':
-                $factory->define('tcp', 'Predis\Connection\PhpiredisStreamConnection');
-                $factory->define('unix', 'Predis\Connection\PhpiredisStreamConnection');
+                $factory->define('tcp', PhpiredisStreamConnection::class);
+                $factory->define('redis', PhpiredisStreamConnection::class);
+                $factory->define('unix', PhpiredisStreamConnection::class);
                 break;
 
             case 'phpiredis-socket':
-                $factory->define('tcp', 'Predis\Connection\PhpiredisSocketConnection');
-                $factory->define('unix', 'Predis\Connection\PhpiredisSocketConnection');
+                $factory->define('tcp', PhpiredisSocketConnection::class);
+                $factory->define('redis', PhpiredisSocketConnection::class);
+                $factory->define('unix', PhpiredisSocketConnection::class);
                 break;
 
             case 'default':

--- a/src/Configuration/Option/Connections.php
+++ b/src/Configuration/Option/Connections.php
@@ -112,6 +112,9 @@ class Connections implements OptionInterface
                 $factory->define('unix', 'Predis\Connection\PhpiredisSocketConnection');
                 break;
 
+            case 'default':
+                return $factory;
+
             default:
                 throw new \InvalidArgumentException(sprintf(
                     '%s does not recognize `%s` as a supported configuration string', static::class, $value

--- a/src/Configuration/Option/Connections.php
+++ b/src/Configuration/Option/Connections.php
@@ -17,8 +17,11 @@ use Predis\Connection\Factory;
 use Predis\Connection\FactoryInterface;
 
 /**
- * Configures a connection factory used by the client to create new connection
- * instances for single Redis nodes.
+ * Configures a new connection factory instance.
+ *
+ * The client uses the connection factory to create the underlying connections
+ * to single redis nodes in a single-server configuration or in replication and
+ * cluster configurations.
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
@@ -36,18 +39,86 @@ class Connections implements OptionInterface
         if ($value instanceof FactoryInterface) {
             return $value;
         } elseif (is_array($value)) {
-            $factory = $this->getDefault($options);
-
-            foreach ($value as $scheme => $initializer) {
-                $factory->define($scheme, $initializer);
-            }
-
-            return $factory;
+            return $this->createFactoryByArray($options, $value);
+        } elseif (is_string($value)) {
+            return $this->createFactoryByString($options, $value);
         } else {
-            $class = get_called_class();
-
-            throw new \InvalidArgumentException("$class expects a valid connection factory");
+            throw new \InvalidArgumentException(sprintf(
+                '%s expects a valid connection factory', static::class
+            ));
         }
+    }
+
+    /**
+     * Creates a new connection factory from a named array.
+     *
+     * The factory instance is configured according to the supplied named array
+     * mapping URI schemes (passed as keys) to the FCQN of classes implementing
+     * Predis\Connection\NodeConnectionInterface, or callable objects acting as
+     * lazy initalizers and returning new instances of classes implementing
+     * Predis\Connection\NodeConnectionInterface.
+     *
+     * @param OptionsInterface $options Client options
+     * @param array            $value   Named array mapping URI schemes to classes or callables
+     *
+     * @return FactoryInterface
+     */
+    protected function createFactoryByArray(OptionsInterface $options, array $value)
+    {
+        /**
+         * @var FactoryInterface
+         */
+        $factory = $this->getDefault($options);
+
+        foreach ($value as $scheme => $initializer) {
+            $factory->define($scheme, $initializer);
+        }
+
+        return $factory;
+    }
+
+    /**
+     * Creates a new connection factory from a descriptive string.
+     *
+     * The factory instance is configured according to the supplied descriptive
+     * string that identifies specific configurations of schemes and connection
+     * classes. Supported configuration values are:
+     *
+     *  - "phpiredis-stream" maps "tcp", "unix" to Predis\Connection\PhpiredisStreamConnection
+     *  - "phpiredis-socket" maps "tcp", "unix" to Predis\Connection\PhpiredisSocketConnection
+     *  - "phpiredis" is an alias of "phpiredis-stream"
+     *
+     * @param OptionsInterface $options Client options
+     * @param string           $value   Descriptive string identifying the desired configuration
+     *
+     * @return FactoryInterface
+     */
+    protected function createFactoryByString(OptionsInterface $options, string $value)
+    {
+        /**
+         * @var FactoryInterface
+         */
+        $factory = $this->getDefault($options);
+
+        switch(strtolower($value)) {
+            case 'phpiredis':
+            case 'phpiredis-stream':
+                $factory->define('tcp', 'Predis\Connection\PhpiredisStreamConnection');
+                $factory->define('unix', 'Predis\Connection\PhpiredisStreamConnection');
+                break;
+
+            case 'phpiredis-socket':
+                $factory->define('tcp', 'Predis\Connection\PhpiredisSocketConnection');
+                $factory->define('unix', 'Predis\Connection\PhpiredisSocketConnection');
+                break;
+
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    '%s does not recognize `%s` as a supported configuration string', static::class, $value
+                ));
+        }
+
+        return $factory;
     }
 
     /**

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -69,9 +69,9 @@ class ConnectionsTest extends PredisTestCase
 
         $default = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $default
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('define')
-            ->with($this->matchesRegularExpression('/^tcp|unix$/'), $classFQCN);
+            ->with($this->matchesRegularExpression('/^tcp|unix|redis$/'), $classFQCN);
 
         $option = $this->getMockBuilder('Predis\Configuration\Option\Connections')
         ->setMethods(array('getDefault'))

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -91,6 +91,33 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
+    public function testAcceptsStringDefaultToReturnConnectionFactoryWithDefaultConfiguration()
+    {
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $default = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
+        $default
+            ->expects($this->never())
+            ->method('define');
+
+        $option = $this->getMockBuilder('Predis\Configuration\Option\Connections')
+        ->setMethods(array('getDefault'))
+        ->getMock();
+        $option
+            ->expects($this->once())
+            ->method('getDefault')
+            ->with($options)
+            ->will($this->returnValue($default));
+
+        $factory = $option->filter($options, 'default');
+
+        $this->assertInstanceOf('Predis\Connection\FactoryInterface', $factory);
+        $this->assertSame($default, $factory);
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testThrowsExceptionOnNotSupportedStringValue()
     {
         $this->expectException('InvalidArgumentException');

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -61,6 +61,49 @@ class ConnectionsTest extends PredisTestCase
 
     /**
      * @group disconnected
+     * @dataProvider provideSupportedStringValuesForOption
+     */
+    public function testAcceptsStringToConfigurePhpiredisStreamBackend($value, $classFQCN)
+    {
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $default = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
+        $default
+            ->expects($this->exactly(2))
+            ->method('define')
+            ->with($this->matchesRegularExpression('/^tcp|unix$/'), $classFQCN);
+
+        $option = $this->getMockBuilder('Predis\Configuration\Option\Connections')
+        ->setMethods(array('getDefault'))
+        ->getMock();
+        $option
+            ->expects($this->once())
+            ->method('getDefault')
+            ->with($options)
+            ->will($this->returnValue($default));
+
+        $factory = $option->filter($options, $value);
+
+        $this->assertInstanceOf('Predis\Connection\FactoryInterface', $factory);
+        $this->assertSame($default, $factory);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testThrowsExceptionOnNotSupportedStringValue()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageMatches('/^.* does not recognize `unsupported` as a supported configuration string$/');
+
+        $option = new Connections();
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $option->filter($options, 'unsupported');
+    }
+
+    /**
+     * @group disconnected
      */
     public function testUsesParametersOptionToSetDefaultParameters()
     {
@@ -139,5 +182,23 @@ class ConnectionsTest extends PredisTestCase
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, new \stdClass());
+    }
+
+    // ******************************************************************** //
+    // ---- HELPER METHODS ------------------------------------------------ //
+    // ******************************************************************** //
+
+    /**
+     * Test provider for string values supported by this client option.
+     *
+     * @return array
+     */
+    public function provideSupportedStringValuesForOption()
+    {
+        return array(
+            array('phpiredis-stream', 'Predis\Connection\PhpiredisStreamConnection'),
+            array('phpiredis-socket', 'Predis\Connection\PhpiredisSocketConnection'),
+            array('phpiredis', 'Predis\Connection\PhpiredisStreamConnection'),
+        );
     }
 }


### PR DESCRIPTION
This is an idea that came up while deciding what to do with the feature request in #397 (which will be rejected in the end).

The `connections` client option can now accept certain string values mapped to specific (and most used) configurations for the connection factory. Basically this is used to make it easier to configure Predis to load our [`phpiredis`](https://github.com/nrk/phpiredis) based connection backends without having to manually pass a map of URI schemes and fully-qualified class names which is a quite cumbersome approach. Valid string values are:

- `phpiredis-stream` maps `tcp`, `redis`, `unix` to [`Predis\Connection\PhpiredisStreamConnection`](https://github.com/predis/predis/blob/accb030eb56ea25ac6635dc70210a4df12da5d6c/src/Connection/PhpiredisStreamConnection.php) (based on PHP streams)
- `phpiredis-socket` maps `tcp`, `redis`, `unix` to [`Predis\Connection\PhpiredisSocketConnection`](https://github.com/predis/predis/blob/accb030eb56ea25ac6635dc70210a4df12da5d6c/src/Connection/PhpiredisSocketConnection.php) (based on [ext-socket](https://www.php.net/manual/en/book.sockets.php))
- `phpiredis` is simply an alias of `phpiredis-stream`

An `InvalidArgumentException` exception is thrown on unsupported string values.

Just a quick example of how it looks like when used in practice:

```php
$client = new Predis\Client('tcp://127.0.0.1', ['connections' => 'phpiredis']);
```

A `Predis\NotSupportedException` is thrown as usual when `ext-phpiredis` is not loaded by PHP. Tthis check is performed by the connection class itself and not by the option handler, so it's triggered at the actual creation of the connection instance (**EDIT** just noticed that we should improve the exception message... which connection backend requires `ext-phpiredis`????)::

```
>>> $client = new Predis\Client('tcp://127.0.0.1', ['connections' => 'phpiredis']);
Predis/NotSupportedException with message 'The "phpiredis" extension is required by this connection backend.'
```

At this point it could be useful to add an additional valid string such as `default` returning a connection factory with the default configuration (implemented in 56d704f):

```php
$client = new Predis\Client('tcp://127.0.0.1', [
    'connections' => extension_loaded('phpiredis') ? 'phpiredis' : 'default'
]);
```

As usual, feedback is appreciated.