### PR TITLE
Rework Predis\Command\FactoryInterface and related classes.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -330,7 +330,7 @@ class Client implements ClientInterface, \IteratorAggregate
      */
     public function createCommand($commandID, $arguments = array())
     {
-        return $this->commands->createCommand($commandID, $arguments);
+        return $this->commands->create($commandID, $arguments);
     }
 
     /**

--- a/src/Collection/Iterator/CursorBasedIterator.php
+++ b/src/Collection/Iterator/CursorBasedIterator.php
@@ -65,7 +65,7 @@ abstract class CursorBasedIterator implements \Iterator
      */
     protected function requiredCommand(ClientInterface $client, $commandID)
     {
-        if (!$client->getCommandFactory()->supportsCommand($commandID)) {
+        if (!$client->getCommandFactory()->supports($commandID)) {
             throw new NotSupportedException("'$commandID' is not supported by the current command factory.");
         }
     }

--- a/src/Collection/Iterator/ListKey.php
+++ b/src/Collection/Iterator/ListKey.php
@@ -73,7 +73,7 @@ class ListKey implements \Iterator
      */
     protected function requiredCommand(ClientInterface $client, $commandID)
     {
-        if (!$client->getCommandFactory()->supportsCommand($commandID)) {
+        if (!$client->getCommandFactory()->supports($commandID)) {
             throw new NotSupportedException("'$commandID' is not supported by the current command factory.");
         }
     }

--- a/src/Command/FactoryInterface.php
+++ b/src/Command/FactoryInterface.php
@@ -14,38 +14,30 @@ namespace Predis\Command;
 /**
  * Command factory interface.
  *
- * Each Redis command should have a class counterpart and commands factories are
- * used to create new instances of these classes through the library.
+ * A command factory is used through the library to create instances of commands
+ * classes implementing Predis\Command\CommandInterface mapped to Redis commands
+ * by their command ID string (SET, GET, etc...).
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
 interface FactoryInterface
 {
     /**
-     * Checks if the command factory supports the specified command.
+     * Checks if the command factory supports the specified list of commands.
      *
-     * @param string $commandID Command ID.
+     * @param array $commandIDs List of command IDs
      *
      * @return bool
      */
-    public function supportsCommand($commandID);
-
-    /**
-     * Checks if the command factory supports the specified list of commands.
-     *
-     * @param array $commandIDs List of command IDs.
-     *
-     * @return string
-     */
-    public function supportsCommands(array $commandIDs);
+    public function supports(string ...$commandIDs): bool;
 
     /**
      * Creates a new command instance.
      *
-     * @param string $commandID Command ID.
-     * @param array  $arguments Arguments for the command.
+     * @param string $commandID Command ID
+     * @param array  $arguments Arguments for the command
      *
      * @return CommandInterface
      */
-    public function createCommand($commandID, array $arguments = array());
+    public function create(string $commandID, array $arguments = array()): CommandInterface;
 }

--- a/src/Command/RedisFactory.php
+++ b/src/Command/RedisFactory.php
@@ -12,7 +12,13 @@
 namespace Predis\Command;
 
 /**
- * Command factory for the mainline Redis server.
+ * Command factory for mainline Redis servers.
+ *
+ * This factory is intended to handle standard commands implemented by mainline
+ * Redis servers. By default it maps a command ID to a specific command handler
+ * class in the Predis\Command\Redis namespace but this can be overridden for
+ * any command ID simply by defining a new command handler class implementing
+ * Predis\Command\CommandInterface.
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
@@ -33,7 +39,7 @@ class RedisFactory extends Factory
     /**
      * {@inheritdoc}
      */
-    public function getCommandClass($commandID)
+    public function getCommandClass(string $commandID): ?string
     {
         $commandID = strtoupper($commandID);
 
@@ -42,7 +48,7 @@ class RedisFactory extends Factory
         } elseif (class_exists($commandClass = "Predis\Command\Redis\\$commandID")) {
             $this->commands[$commandID] = $commandClass;
         } else {
-            return;
+            return null;
         }
 
         return $commandClass;
@@ -51,7 +57,7 @@ class RedisFactory extends Factory
     /**
      * {@inheritdoc}
      */
-    public function undefineCommand($commandID)
+    public function undefine(string $commandID): void
     {
         // NOTE: we explicitly associate `NULL` to the command ID in the map
         // instead of the parent's `unset()` because our subclass tries to load

--- a/src/Configuration/Option/Commands.php
+++ b/src/Configuration/Option/Commands.php
@@ -37,9 +37,9 @@ class Commands implements OptionInterface
 
             foreach ($value as $commandID => $commandClass) {
                 if ($commandClass === null) {
-                    $commands->undefineCommand($commandID);
+                    $commands->undefine($commandID);
                 } else {
-                    $commands->defineCommand($commandID, $commandClass);
+                    $commands->define($commandID, $commandClass);
                 }
             }
 

--- a/src/Monitor/Consumer.php
+++ b/src/Monitor/Consumer.php
@@ -62,7 +62,7 @@ class Consumer implements \Iterator
             );
         }
 
-        if ($client->getCommandFactory()->supportsCommand('MONITOR') === false) {
+        if (!$client->getCommandFactory()->supports('MONITOR')) {
             throw new NotSupportedException("'MONITOR' is not supported by the current command factory.");
         }
     }

--- a/src/Pipeline/Atomic.php
+++ b/src/Pipeline/Atomic.php
@@ -31,7 +31,7 @@ class Atomic extends Pipeline
      */
     public function __construct(ClientInterface $client)
     {
-        if (!$client->getCommandFactory()->supportsCommands(array('multi', 'exec', 'discard'))) {
+        if (!$client->getCommandFactory()->supports('multi', 'exec', 'discard')) {
             throw new ClientException(
                 "'MULTI', 'EXEC' and 'DISCARD' are not supported by the current command factory."
             );
@@ -62,7 +62,7 @@ class Atomic extends Pipeline
     protected function executePipeline(ConnectionInterface $connection, \SplQueue $commands)
     {
         $commandFactory = $this->getClient()->getCommandFactory();
-        $connection->executeCommand($commandFactory->createCommand('multi'));
+        $connection->executeCommand($commandFactory->create('multi'));
 
         foreach ($commands as $command) {
             $connection->writeRequest($command);
@@ -72,12 +72,12 @@ class Atomic extends Pipeline
             $response = $connection->readResponse($command);
 
             if ($response instanceof ErrorResponseInterface) {
-                $connection->executeCommand($commandFactory->createCommand('discard'));
+                $connection->executeCommand($commandFactory->create('discard'));
                 throw new ServerException($response->getMessage());
             }
         }
 
-        $executed = $connection->executeCommand($commandFactory->createCommand('exec'));
+        $executed = $connection->executeCommand($commandFactory->create('exec'));
 
         if (!isset($executed)) {
             // TODO: should be throwing a more appropriate exception.

--- a/src/PubSub/Consumer.php
+++ b/src/PubSub/Consumer.php
@@ -70,7 +70,7 @@ class Consumer extends AbstractConsumer
 
         $commands = array('publish', 'subscribe', 'unsubscribe', 'psubscribe', 'punsubscribe');
 
-        if ($client->getCommandFactory()->supportsCommands($commands) === false) {
+        if (!$client->getCommandFactory()->supports(...$commands)) {
             throw new NotSupportedException(
                 'PUB/SUB commands are not supported by the current command factory.'
             );

--- a/src/Transaction/MultiExec.php
+++ b/src/Transaction/MultiExec.php
@@ -72,7 +72,7 @@ class MultiExec implements ClientContextInterface
             );
         }
 
-        if (!$client->getCommandFactory()->supportsCommands(array('MULTI', 'EXEC', 'DISCARD'))) {
+        if (!$client->getCommandFactory()->supports('MULTI', 'EXEC', 'DISCARD')) {
             throw new NotSupportedException(
                 'MULTI, EXEC and DISCARD are not supported by the current command factory.'
             );
@@ -228,7 +228,7 @@ class MultiExec implements ClientContextInterface
      */
     public function watch($keys)
     {
-        if (!$this->client->getCommandFactory()->supportsCommand('WATCH')) {
+        if (!$this->client->getCommandFactory()->supports('WATCH')) {
             throw new NotSupportedException('WATCH is not supported by the current command factory.');
         }
 
@@ -268,7 +268,7 @@ class MultiExec implements ClientContextInterface
      */
     public function unwatch()
     {
-        if (!$this->client->getCommandFactory()->supportsCommand('UNWATCH')) {
+        if (!$this->client->getCommandFactory()->supports('UNWATCH')) {
             throw new NotSupportedException(
                 'UNWATCH is not supported by the current command factory.'
             );

--- a/tests/PHPUnit/PredisCommandTestCase.php
+++ b/tests/PHPUnit/PredisCommandTestCase.php
@@ -57,7 +57,7 @@ abstract class PredisCommandTestCase extends PredisTestCase
     {
         $commands = $this->getCommandFactory();
 
-        if (!$commands->supportsCommand($id = $this->getExpectedId())) {
+        if (!$commands->supports($id = $this->getExpectedId())) {
             $this->markTestSkipped(
                 "The current command factory does not support command $id"
             );

--- a/tests/PHPUnit/PredisConnectionTestCase.php
+++ b/tests/PHPUnit/PredisConnectionTestCase.php
@@ -208,7 +208,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $connection = $this->createConnection();
         $commands = $this->getCommandFactory();
 
-        $cmdPing = $commands->createCommand('ping');
+        $cmdPing = $commands->create('ping');
 
         $this->assertEquals('PONG', $connection->executeCommand($cmdPing));
         $this->assertTrue($connection->isConnected());
@@ -238,7 +238,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     public function testExecutesCommandWithHolesInArguments()
     {
         $commands = $this->getCommandFactory();
-        $cmdDel = $commands->createCommand('mget', array(0 => 'key:0', 2 => 'key:2'));
+        $cmdDel = $commands->create('mget', array(0 => 'key:0', 2 => 'key:2'));
 
         $connection = $this->createConnection();
 
@@ -252,11 +252,11 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     {
         $commands = $this->getCommandFactory();
 
-        $cmdPing = $commands->createCommand('ping');
-        $cmdEcho = $commands->createCommand('echo', array('echoed'));
-        $cmdGet = $commands->createCommand('get', array('foobar'));
-        $cmdRpush = $commands->createCommand('rpush', array('metavars', 'foo', 'hoge', 'lol'));
-        $cmdLrange = $commands->createCommand('lrange', array('metavars', 0, -1));
+        $cmdPing = $commands->create('ping');
+        $cmdEcho = $commands->create('echo', array('echoed'));
+        $cmdGet = $commands->create('get', array('foobar'));
+        $cmdRpush = $commands->create('rpush', array('metavars', 'foo', 'hoge', 'lol'));
+        $cmdLrange = $commands->create('lrange', array('metavars', 0, -1));
 
         $connection = $this->createConnection(true);
 
@@ -378,14 +378,14 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
 
-        $connection->writeRequest($commands->createCommand('set', array('foo', 'bar')));
+        $connection->writeRequest($commands->create('set', array('foo', 'bar')));
         $this->assertInstanceOf('Predis\Response\Status', $connection->read());
 
-        $connection->writeRequest($commands->createCommand('ping'));
+        $connection->writeRequest($commands->create('ping'));
         $this->assertInstanceOf('Predis\Response\Status', $connection->read());
 
-        $connection->writeRequest($commands->createCommand('multi'));
-        $connection->writeRequest($commands->createCommand('ping'));
+        $connection->writeRequest($commands->create('multi'));
+        $connection->writeRequest($commands->create('ping'));
         $this->assertInstanceOf('Predis\Response\Status', $connection->read());
         $this->assertInstanceOf('Predis\Response\Status', $connection->read());
     }
@@ -398,12 +398,12 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
 
-        $connection->executeCommand($commands->createCommand('set', array('foo', 'bar')));
+        $connection->executeCommand($commands->create('set', array('foo', 'bar')));
 
-        $connection->writeRequest($commands->createCommand('get', array('foo')));
+        $connection->writeRequest($commands->create('get', array('foo')));
         $this->assertSame('bar', $connection->read());
 
-        $connection->writeRequest($commands->createCommand('get', array('hoge')));
+        $connection->writeRequest($commands->create('get', array('hoge')));
         $this->assertNull($connection->read());
     }
 
@@ -415,8 +415,8 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
 
-        $connection->executeCommand($commands->createCommand('rpush', array('metavars', 'foo', 'hoge', 'lol')));
-        $connection->writeRequest($commands->createCommand('llen', array('metavars')));
+        $connection->executeCommand($commands->create('rpush', array('metavars', 'foo', 'hoge', 'lol')));
+        $connection->writeRequest($commands->create('llen', array('metavars')));
 
         $this->assertSame(3, $connection->read());
     }
@@ -429,8 +429,8 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
 
-        $connection->executeCommand($commands->createCommand('set', array('foo', 'bar')));
-        $connection->writeRequest($commands->createCommand('rpush', array('foo', 'baz')));
+        $connection->executeCommand($commands->create('set', array('foo', 'bar')));
+        $connection->writeRequest($commands->create('rpush', array('foo', 'baz')));
 
         $this->assertInstanceOf('Predis\Response\Error', $error = $connection->read());
         $this->assertRegExp('/[ERR|WRONGTYPE] Operation against a key holding the wrong kind of value/', $error->getMessage());
@@ -444,8 +444,8 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
 
-        $connection->executeCommand($commands->createCommand('rpush', array('metavars', 'foo', 'hoge', 'lol')));
-        $connection->writeRequest($commands->createCommand('lrange', array('metavars', 0, -1)));
+        $connection->executeCommand($commands->create('rpush', array('metavars', 'foo', 'hoge', 'lol')));
+        $connection->writeRequest($commands->create('lrange', array('metavars', 0, -1)));
 
         $this->assertSame(array('foo', 'hoge', 'lol'), $connection->read());
     }
@@ -531,7 +531,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
             'read_write_timeout' => 0.5,
         ), true);
 
-        $connection->executeCommand($commands->createCommand('brpop', array('foo', 3)));
+        $connection->executeCommand($commands->create('brpop', array('foo', 3)));
     }
 
     /**
@@ -545,7 +545,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $connection = $this->createConnection();
         $stream = $connection->getResource();
 
-        $connection->writeRequest($this->getCommandFactory()->createCommand('ping'));
+        $connection->writeRequest($this->getCommandFactory()->create('ping'));
         fread($stream, 1);
 
         $connection->read();
@@ -638,11 +638,11 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
         if ($initialize) {
             $connection->addConnectCommand(
-                $commands->createCommand('select', array($parameters->database))
+                $commands->create('select', array($parameters->database))
             );
 
             $connection->addConnectCommand(
-                $commands->createCommand('flushdb')
+                $commands->create('flushdb')
             );
         }
 

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -467,12 +467,12 @@ class ClientTest extends PredisTestCase
      */
     public function testCreatesNewCommandUsingSpecifiedCommandFactory()
     {
-        $ping = $this->getCommandFactory()->createCommand('ping', array());
+        $ping = $this->getCommandFactory()->create('ping', array());
 
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->once())
-            ->method('createCommand')
+            ->method('create')
             ->with('ping', array())
             ->will($this->returnValue($ping));
 
@@ -487,8 +487,8 @@ class ClientTest extends PredisTestCase
     {
         $commands = $this->getCommandFactory();
 
-        $ping = $commands->createCommand('ping', array());
-        $hgetall = $commands->createCommand('hgetall', array('metavars', 'foo', 'hoge'));
+        $ping = $commands->create('ping', array());
+        $hgetall = $commands->create('hgetall', array('metavars', 'foo', 'hoge'));
 
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -516,7 +516,7 @@ class ClientTest extends PredisTestCase
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
 
-        $ping = $this->getCommandFactory()->createCommand('ping', array());
+        $ping = $this->getCommandFactory()->create('ping', array());
         $expectedResponse = new Response\Error('ERR Operation against a key holding the wrong kind of value');
 
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
@@ -534,7 +534,7 @@ class ClientTest extends PredisTestCase
      */
     public function testExecuteCommandReturnsErrorResponseOnRedisError()
     {
-        $ping = $this->getCommandFactory()->createCommand('ping', array());
+        $ping = $this->getCommandFactory()->create('ping', array());
         $expectedResponse = new Response\Error('ERR Operation against a key holding the wrong kind of value');
 
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
@@ -554,7 +554,7 @@ class ClientTest extends PredisTestCase
      */
     public function testCallingRedisCommandExecutesInstanceOfCommand()
     {
-        $ping = $this->getCommandFactory()->createCommand('ping', array());
+        $ping = $this->getCommandFactory()->create('ping', array());
 
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -566,7 +566,7 @@ class ClientTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->once())
-            ->method('createCommand')
+            ->method('create')
             ->with('ping', array())
             ->will($this->returnValue($ping));
 

--- a/tests/Predis/Cluster/PredisStrategyTest.php
+++ b/tests/Predis/Cluster/PredisStrategyTest.php
@@ -56,7 +56,7 @@ class PredisStrategyTest extends PredisTestCase
     public function testReturnsNullOnUnsupportedCommand()
     {
         $strategy = $this->getClusterStrategy();
-        $command = $this->getCommandFactory()->createCommand('ping');
+        $command = $this->getCommandFactory()->create('ping');
 
         $this->assertNull($strategy->getSlot($command));
     }
@@ -71,7 +71,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('key');
 
         foreach ($this->getExpectedCommands('keys-first') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -86,7 +86,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('{key}:1', '{key}:2', '{key}:3', '{key}:4');
 
         foreach ($this->getExpectedCommands('keys-all') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -101,7 +101,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('{key}:1', 'value1', '{key}:2', 'value2');
 
         foreach ($this->getExpectedCommands('keys-interleaved') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -117,10 +117,10 @@ class PredisStrategyTest extends PredisTestCase
 
         $commandID = 'SORT';
 
-        $command = $commands->createCommand($commandID, array('{key}:1'));
+        $command = $commands->create($commandID, array('{key}:1'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', array('STORE' => '{key}:2')));
+        $command = $commands->create($commandID, array('{key}:1', array('STORE' => '{key}:2')));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -134,7 +134,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('{key}:1', '{key}:2', 10);
 
         foreach ($this->getExpectedCommands('keys-blockinglist') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -149,7 +149,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('{key}:destination', 2, '{key}:1', '{key}:1', array('aggregate' => 'SUM'));
 
         foreach ($this->getExpectedCommands('keys-zaggregated') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -164,7 +164,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('AND', '{key}:destination', '{key}:src:1', '{key}:src:2');
 
         foreach ($this->getExpectedCommands('keys-bitop') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -178,10 +178,10 @@ class PredisStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $commandID = 'GEORADIUS';
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 10, 10, 1, 'km'));
+        $command = $commands->create($commandID, array('{key}:1', 10, 10, 1, 'km'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 10, 10, 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
+        $command = $commands->create($commandID, array('{key}:1', 10, 10, 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -194,10 +194,10 @@ class PredisStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $commandID = 'GEORADIUSBYMEMBER';
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 'member', 1, 'km'));
+        $command = $commands->create($commandID, array('{key}:1', 'member', 1, 'km'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 'member', 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
+        $command = $commands->create($commandID, array('{key}:1', 'member', 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -211,7 +211,7 @@ class PredisStrategyTest extends PredisTestCase
         $arguments = array('%SCRIPT%', 2, '{key}:1', '{key}:2', 'value1', 'value2');
 
         foreach ($this->getExpectedCommands('keys-script') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -251,10 +251,10 @@ class PredisStrategyTest extends PredisTestCase
         $strategy->setCommandHandler('set');
         $strategy->setCommandHandler('get', null);
 
-        $command = $commands->createCommand('set', array('key', 'value'));
+        $command = $commands->create('set', array('key', 'value'));
         $this->assertNull($strategy->getSlot($command));
 
-        $command = $commands->createCommand('get', array('key'));
+        $command = $commands->create('get', array('key'));
         $this->assertNull($strategy->getSlot($command));
     }
 
@@ -277,7 +277,7 @@ class PredisStrategyTest extends PredisTestCase
 
         $strategy->setCommandHandler('get', $callable);
 
-        $command = $commands->createCommand('get', array('key'));
+        $command = $commands->create('get', array('key'));
         $this->assertNotNull($strategy->getSlot($command));
     }
 

--- a/tests/Predis/Cluster/RedisStrategyTest.php
+++ b/tests/Predis/Cluster/RedisStrategyTest.php
@@ -54,7 +54,7 @@ class RedisStrategyTest extends PredisTestCase
     public function testReturnsNullOnUnsupportedCommand()
     {
         $strategy = $this->getClusterStrategy();
-        $command = $this->getCommandFactory()->createCommand('ping');
+        $command = $this->getCommandFactory()->create('ping');
 
         $this->assertNull($strategy->getSlot($command));
     }
@@ -69,7 +69,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key');
 
         foreach ($this->getExpectedCommands('keys-first') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -84,7 +84,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key');
 
         foreach ($this->getExpectedCommands('keys-all') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -99,7 +99,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key1', 'key2');
 
         foreach ($this->getExpectedCommands('keys-all') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -114,7 +114,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key:1', 'value1');
 
         foreach ($this->getExpectedCommands('keys-interleaved') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -129,7 +129,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key:1', 'value1', 'key:2', 'value2');
 
         foreach ($this->getExpectedCommands('keys-interleaved') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -145,10 +145,10 @@ class RedisStrategyTest extends PredisTestCase
 
         $commandID = 'SORT';
 
-        $command = $commands->createCommand($commandID, array('{key}:1'));
+        $command = $commands->create($commandID, array('{key}:1'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', array('STORE' => '{key}:2')));
+        $command = $commands->create($commandID, array('{key}:1', array('STORE' => '{key}:2')));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -162,7 +162,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key:1', 10);
 
         foreach ($this->getExpectedCommands('keys-blockinglist') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -177,7 +177,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('key:1', 'key:2', 10);
 
         foreach ($this->getExpectedCommands('keys-blockinglist') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -192,10 +192,10 @@ class RedisStrategyTest extends PredisTestCase
 
         $commandID = 'GEORADIUS';
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 10, 10, 1, 'km'));
+        $command = $commands->create($commandID, array('{key}:1', 10, 10, 1, 'km'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 10, 10, 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
+        $command = $commands->create($commandID, array('{key}:1', 10, 10, 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -209,10 +209,10 @@ class RedisStrategyTest extends PredisTestCase
 
         $commandID = 'GEORADIUSBYMEMBER';
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 'member', 1, 'km'));
+        $command = $commands->create($commandID, array('{key}:1', 'member', 1, 'km'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
 
-        $command = $commands->createCommand($commandID, array('{key}:1', 'member', 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
+        $command = $commands->create($commandID, array('{key}:1', 'member', 1, 'km', 'store', '{key}:2', 'storedist', '{key}:3'));
         $this->assertNotNull($strategy->getSlot($command), $commandID);
     }
 
@@ -226,7 +226,7 @@ class RedisStrategyTest extends PredisTestCase
         $arguments = array('%SCRIPT%', 1, 'key:1', 'value1');
 
         foreach ($this->getExpectedCommands('keys-script') as $commandID) {
-            $command = $commands->createCommand($commandID, $arguments);
+            $command = $commands->create($commandID, $arguments);
             $this->assertNotNull($strategy->getSlot($command), $commandID);
         }
     }
@@ -266,10 +266,10 @@ class RedisStrategyTest extends PredisTestCase
         $strategy->setCommandHandler('set');
         $strategy->setCommandHandler('get', null);
 
-        $command = $commands->createCommand('set', array('key', 'value'));
+        $command = $commands->create('set', array('key', 'value'));
         $this->assertNull($strategy->getSlot($command));
 
-        $command = $commands->createCommand('get', array('key'));
+        $command = $commands->create('get', array('key'));
         $this->assertNull($strategy->getSlot($command));
     }
 
@@ -292,7 +292,7 @@ class RedisStrategyTest extends PredisTestCase
 
         $strategy->setCommandHandler('get', $callable);
 
-        $command = $commands->createCommand('get', array('key'));
+        $command = $commands->create('get', array('key'));
         $this->assertNotNull($strategy->getSlot($command));
     }
 

--- a/tests/Predis/Collection/Iterator/HashKeyTest.php
+++ b/tests/Predis/Collection/Iterator/HashKeyTest.php
@@ -29,7 +29,7 @@ class HashKeyTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommand')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();

--- a/tests/Predis/Collection/Iterator/KeyspaceTest.php
+++ b/tests/Predis/Collection/Iterator/KeyspaceTest.php
@@ -29,7 +29,7 @@ class KeyspaceTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommand')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();

--- a/tests/Predis/Collection/Iterator/ListKeyTest.php
+++ b/tests/Predis/Collection/Iterator/ListKeyTest.php
@@ -29,7 +29,7 @@ class ListKeyTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommand')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = $this->getMockBuilder('Predis\Client')

--- a/tests/Predis/Collection/Iterator/SetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SetKeyTest.php
@@ -29,7 +29,7 @@ class SetKeyTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommand')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();

--- a/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
@@ -30,7 +30,7 @@ class SortedSetKeyTest extends PredisTestCase
             ->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommand')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();

--- a/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
@@ -142,7 +142,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     public function testCanSendQuitAfterPsubscribe()
     {
         $redis = $this->getClient();
-        $quit = $this->getCommandFactory()->createCommand('quit');
+        $quit = $this->getCommandFactory()->create('quit');
 
         $this->assertSame(array('subscribe', 'channel1', 1), $redis->subscribe('channel1'));
         $this->assertEquals('OK', $redis->executeCommand($quit));

--- a/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
@@ -142,7 +142,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     public function testCanSendQuitAfterSubscribe()
     {
         $redis = $this->getClient();
-        $quit = $this->getCommandFactory()->createCommand('quit');
+        $quit = $this->getCommandFactory()->create('quit');
 
         $this->assertSame(array('subscribe', 'channel:foo', 1), $redis->subscribe('channel:foo'));
         $this->assertEquals('OK', $redis->executeCommand($quit));

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -27,7 +27,7 @@ class RedisFactoryTest extends PredisTestCase
         $factory = new RedisFactory();
 
         foreach ($this->getExpectedCommands() as $commandID) {
-            $this->assertTrue($factory->supportsCommand($commandID), "Command factory does not support $commandID");
+            $this->assertTrue($factory->supports($commandID), "Command factory does not support $commandID");
         }
     }
 
@@ -38,11 +38,11 @@ class RedisFactoryTest extends PredisTestCase
     {
         $factory = new RedisFactory();
 
-        $this->assertTrue($factory->supportsCommand('info'));
-        $this->assertTrue($factory->supportsCommand('INFO'));
+        $this->assertTrue($factory->supports('info'));
+        $this->assertTrue($factory->supports('INFO'));
 
-        $this->assertFalse($factory->supportsCommand('unknown'));
-        $this->assertFalse($factory->supportsCommand('UNKNOWN'));
+        $this->assertFalse($factory->supports('unknown'));
+        $this->assertFalse($factory->supports('UNKNOWN'));
     }
 
     /**
@@ -52,12 +52,12 @@ class RedisFactoryTest extends PredisTestCase
     {
         $factory = new RedisFactory();
 
-        $this->assertTrue($factory->supportsCommands(array('get', 'set')));
-        $this->assertTrue($factory->supportsCommands(array('GET', 'SET')));
+        $this->assertTrue($factory->supports('get', 'set'));
+        $this->assertTrue($factory->supports('GET', 'SET'));
 
-        $this->assertFalse($factory->supportsCommands(array('get', 'unknown')));
+        $this->assertFalse($factory->supports('get', 'unknown'));
 
-        $this->assertFalse($factory->supportsCommands(array('unknown1', 'unknown2')));
+        $this->assertFalse($factory->supports('unknown1', 'unknown2'));
     }
 
     /**
@@ -84,10 +84,10 @@ class RedisFactoryTest extends PredisTestCase
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')
             ->getMock();
 
-        $factory->defineCommand('mock', get_class($command));
+        $factory->define('mock', get_class($command));
 
-        $this->assertTrue($factory->supportsCommand('mock'));
-        $this->assertTrue($factory->supportsCommand('MOCK'));
+        $this->assertTrue($factory->supports('mock'));
+        $this->assertTrue($factory->supports('MOCK'));
 
         $this->assertSame(get_class($command), $factory->getCommandClass('mock'));
     }
@@ -99,12 +99,12 @@ class RedisFactoryTest extends PredisTestCase
     {
         $factory = new RedisFactory();
 
-        $this->assertTrue($factory->supportsCommand('PING'));
+        $this->assertTrue($factory->supports('PING'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
 
-        $factory->undefineCommand('PING');
+        $factory->undefine('PING');
 
-        $this->assertFalse($factory->supportsCommand('PING'));
+        $this->assertFalse($factory->supports('PING'));
         $this->assertNull($factory->getCommandClass('PING'));
     }
 
@@ -116,14 +116,14 @@ class RedisFactoryTest extends PredisTestCase
         $factory = new RedisFactory();
 
         $commandClass = get_class($this->getMockBuilder('Predis\Command\CommandInterface')->getMock());
-        $factory->defineCommand('MOCK', $commandClass);
+        $factory->define('MOCK', $commandClass);
 
-        $this->assertTrue($factory->supportsCommand('MOCK'));
+        $this->assertTrue($factory->supports('MOCK'));
         $this->assertSame($commandClass, $factory->getCommandClass('MOCK'));
 
-        $factory->undefineCommand('MOCK');
+        $factory->undefine('MOCK');
 
-        $this->assertFalse($factory->supportsCommand('MOCK'));
+        $this->assertFalse($factory->supports('MOCK'));
         $this->assertNull($factory->getCommandClass('MOCK'));
     }
 
@@ -137,7 +137,7 @@ class RedisFactoryTest extends PredisTestCase
 
         $factory = new RedisFactory();
 
-        $factory->defineCommand('mock', 'stdClass');
+        $factory->define('mock', 'stdClass');
     }
 
     /**
@@ -147,7 +147,7 @@ class RedisFactoryTest extends PredisTestCase
     {
         $factory = new RedisFactory();
 
-        $command = $factory->createCommand('info');
+        $command = $factory->create('info');
 
         $this->assertInstanceOf('Predis\Command\CommandInterface', $command);
         $this->assertEquals('INFO', $command->getId());
@@ -162,7 +162,7 @@ class RedisFactoryTest extends PredisTestCase
         $factory = new RedisFactory();
 
         $arguments = array('foo', 'bar');
-        $command = $factory->createCommand('set', $arguments);
+        $command = $factory->create('set', $arguments);
 
         $this->assertInstanceOf('Predis\Command\CommandInterface', $command);
         $this->assertEquals('SET', $command->getId());
@@ -179,7 +179,7 @@ class RedisFactoryTest extends PredisTestCase
 
         $factory = new RedisFactory();
 
-        $factory->createCommand('unknown');
+        $factory->create('unknown');
     }
 
     /**
@@ -246,7 +246,7 @@ class RedisFactoryTest extends PredisTestCase
 
         $factory = new RedisFactory();
         $factory->setProcessor($processor);
-        $factory->createCommand('set', array('foo', 'bar'));
+        $factory->create('set', array('foo', 'bar'));
 
         $this->assertSame(array('FOO', 'BAR'), $argsRef);
     }
@@ -269,7 +269,7 @@ class RedisFactoryTest extends PredisTestCase
         $factory = new RedisFactory();
         $factory->setProcessor($chain);
 
-        $factory->createCommand('info');
+        $factory->create('info');
     }
 
     // ******************************************************************** //

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -254,23 +254,23 @@ class PredisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $set = $commands->createCommand('set', array('node01:5431', 'foobar'));
-        $get = $commands->createCommand('get', array('node01:5431'));
+        $set = $commands->create('set', array('node01:5431', 'foobar'));
+        $get = $commands->create('get', array('node01:5431'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('prefix:{node01:5431}', 'foobar'));
-        $get = $commands->createCommand('get', array('prefix:{node01:5431}'));
+        $set = $commands->create('set', array('prefix:{node01:5431}', 'foobar'));
+        $get = $commands->create('get', array('prefix:{node01:5431}'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('node02:3212', 'foobar'));
-        $get = $commands->createCommand('get', array('node02:3212'));
+        $set = $commands->create('set', array('node02:3212', 'foobar'));
+        $get = $commands->create('get', array('node02:3212'));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('prefix:{node02:3212}', 'foobar'));
-        $get = $commands->createCommand('get', array('prefix:{node02:3212}'));
+        $set = $commands->create('set', array('prefix:{node02:3212}', 'foobar'));
+        $get = $commands->create('get', array('prefix:{node02:3212}'));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($get));
     }
@@ -283,7 +283,7 @@ class PredisClusterTest extends PredisTestCase
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Cannot use 'PING' over clusters of connections.");
 
-        $ping = $this->getCommandFactory()->createCommand('ping');
+        $ping = $this->getCommandFactory()->create('ping');
 
         $cluster = new PredisCluster();
 
@@ -307,13 +307,13 @@ class PredisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $set = $commands->createCommand('set', array('{node:1001}:foo', 'foobar'));
-        $get = $commands->createCommand('get', array('{node:1001}:foo'));
+        $set = $commands->create('set', array('{node:1001}:foo', 'foobar'));
+        $get = $commands->create('get', array('{node:1001}:foo'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('{node:1001}:bar', 'foobar'));
-        $get = $commands->createCommand('get', array('{node:1001}:bar'));
+        $set = $commands->create('set', array('{node:1001}:bar', 'foobar'));
+        $get = $commands->create('get', array('{node:1001}:bar'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
     }
@@ -323,7 +323,7 @@ class PredisClusterTest extends PredisTestCase
      */
     public function testWritesCommandToCorrectConnection()
     {
-        $command = $this->getCommandFactory()->createCommand('get', array('node01:5431'));
+        $command = $this->getCommandFactory()->create('get', array('node01:5431'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -349,7 +349,7 @@ class PredisClusterTest extends PredisTestCase
      */
     public function testReadsCommandFromCorrectConnection()
     {
-        $command = $this->getCommandFactory()->createCommand('get', array('node02:3212'));
+        $command = $this->getCommandFactory()->create('get', array('node02:3212'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -375,7 +375,7 @@ class PredisClusterTest extends PredisTestCase
      */
     public function testExecutesCommandOnCorrectConnection()
     {
-        $command = $this->getCommandFactory()->createCommand('get', array('node01:5431'));
+        $command = $this->getCommandFactory()->create('get', array('node01:5431'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -506,18 +506,18 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection2);
         $cluster->add($connection3);
 
-        $set = $commands->createCommand('set', array('node:1001', 'foobar'));
-        $get = $commands->createCommand('get', array('node:1001'));
+        $set = $commands->create('set', array('node:1001', 'foobar'));
+        $get = $commands->create('get', array('node:1001'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('node:1048', 'foobar'));
-        $get = $commands->createCommand('get', array('node:1048'));
+        $set = $commands->create('set', array('node:1048', 'foobar'));
+        $get = $commands->create('get', array('node:1048'));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection2, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('node:1082', 'foobar'));
-        $get = $commands->createCommand('get', array('node:1082'));
+        $set = $commands->create('set', array('node:1082', 'foobar'));
+        $get = $commands->create('get', array('node:1082'));
         $this->assertSame($connection3, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection3, $cluster->getConnectionByCommand($get));
     }
@@ -527,7 +527,7 @@ class RedisClusterTest extends PredisTestCase
      */
     public function testWritesCommandToCorrectConnection()
     {
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -554,7 +554,7 @@ class RedisClusterTest extends PredisTestCase
      */
     public function testReadsCommandFromCorrectConnection()
     {
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1050'));
+        $command = $this->getCommandFactory()->create('get', array('node:1050'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -910,13 +910,13 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $set = $commands->createCommand('set', array('{node:1001}:foo', 'foobar'));
-        $get = $commands->createCommand('get', array('{node:1001}:foo'));
+        $set = $commands->create('set', array('{node:1001}:foo', 'foobar'));
+        $get = $commands->create('get', array('{node:1001}:foo'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
 
-        $set = $commands->createCommand('set', array('{node:1001}:bar', 'foobar'));
-        $get = $commands->createCommand('get', array('{node:1001}:bar'));
+        $set = $commands->create('set', array('{node:1001}:bar', 'foobar'));
+        $get = $commands->create('get', array('{node:1001}:bar'));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($set));
         $this->assertSame($connection1, $cluster->getConnectionByCommand($get));
     }
@@ -928,7 +928,7 @@ class RedisClusterTest extends PredisTestCase
     {
         $askResponse = new Response\Error('ASK 1970 127.0.0.1:6380');
 
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -971,7 +971,7 @@ class RedisClusterTest extends PredisTestCase
     {
         $askResponse = new Response\Error('ASK 1970 127.0.0.1:6381');
 
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -1026,7 +1026,7 @@ class RedisClusterTest extends PredisTestCase
     {
         $movedResponse = new Response\Error('MOVED 1970 127.0.0.1:6380');
 
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -1063,7 +1063,7 @@ class RedisClusterTest extends PredisTestCase
     {
         $movedResponse = new Response\Error('MOVED 1970 127.0.0.1:6381');
 
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -1112,7 +1112,7 @@ class RedisClusterTest extends PredisTestCase
     {
         $movedResponse = new Response\Error('MOVED 1970 2001:db8:0:f101::2:6379');
 
-        $command = $this->getCommandFactory()->createCommand('get', array('node:1001'));
+        $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
         $connection1 = $this->getMockConnection('tcp://[2001:db8:0:f101::1]:6379');
         $connection1
@@ -1249,7 +1249,7 @@ class RedisClusterTest extends PredisTestCase
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Cannot use 'PING' with redis-cluster");
 
-        $ping = $this->getCommandFactory()->createCommand('ping');
+        $ping = $this->getCommandFactory()->create('ping');
 
         $cluster = new RedisCluster(new Connection\Factory());
 

--- a/tests/Predis/Connection/CompositeStreamConnectionTest.php
+++ b/tests/Predis/Connection/CompositeStreamConnectionTest.php
@@ -63,8 +63,8 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
 
         $connection->getProtocol()->useIterableMultibulk(true);
 
-        $connection->executeCommand($commands->createCommand('rpush', array('metavars', 'foo', 'hoge', 'lol')));
-        $connection->writeRequest($commands->createCommand('lrange', array('metavars', 0, -1)));
+        $connection->executeCommand($commands->create('rpush', array('metavars', 'foo', 'hoge', 'lol')));
+        $connection->writeRequest($commands->create('lrange', array('metavars', 0, -1)));
 
         $this->assertInstanceOf('Predis\Response\Iterator\MultiBulkIterator', $iterator = $connection->read());
         $this->assertSame(array('foo', 'hoge', 'lol'), iterator_to_array($iterator));

--- a/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
@@ -103,7 +103,7 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
         $connection = $this->createConnection();
         $socket = $connection->getResource();
 
-        $connection->writeRequest($this->getCommandFactory()->createCommand('ping'));
+        $connection->writeRequest($this->getCommandFactory()->create('ping'));
         socket_read($socket, 1);
 
         $connection->read();

--- a/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
@@ -94,7 +94,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
         ), true);
 
         $connection->executeCommand(
-            $this->getCommandFactory()->createCommand('brpop', array('foo', 3))
+            $this->getCommandFactory()->create('brpop', array('foo', 3))
         );
     }
 
@@ -109,7 +109,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
         $connection = $this->createConnection();
         $stream = $connection->getResource();
 
-        $connection->writeRequest($this->getCommandFactory()->createCommand('ping'));
+        $connection->writeRequest($this->getCommandFactory()->create('ping'));
         stream_socket_recvfrom($stream, 1);
 
         $connection->read();

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -451,10 +451,10 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $replication->add($master);
         $replication->add($slave1);
 
-        $cmd = $commands->createCommand('exists', array('foo'));
+        $cmd = $commands->create('exists', array('foo'));
         $this->assertSame($slave1, $replication->getConnectionByCommand($cmd));
 
-        $cmd = $commands->createCommand('get', array('foo'));
+        $cmd = $commands->create('get', array('foo'));
         $this->assertSame($slave1, $replication->getConnectionByCommand($cmd));
     }
 
@@ -473,10 +473,10 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $replication->add($master);
         $replication->add($slave1);
 
-        $cmd = $commands->createCommand('set', array('foo', 'bar'));
+        $cmd = $commands->create('set', array('foo', 'bar'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
 
-        $cmd = $commands->createCommand('get', array('foo'));
+        $cmd = $commands->create('get', array('foo'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
     }
 
@@ -493,10 +493,10 @@ class MasterSlaveReplicationTest extends PredisTestCase
 
         $replication->add($master);
 
-        $cmd = $commands->createCommand('exists', array('foo'));
+        $cmd = $commands->create('exists', array('foo'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
 
-        $cmd = $commands->createCommand('set', array('foo', 'bar'));
+        $cmd = $commands->create('set', array('foo', 'bar'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
     }
 
@@ -515,13 +515,13 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $replication->add($master);
         $replication->add($slave1);
 
-        $cmd = $commands->createCommand('exists', array('foo'));
+        $cmd = $commands->create('exists', array('foo'));
         $this->assertSame($slave1, $replication->getConnectionByCommand($cmd));
 
-        $cmd = $commands->createCommand('set', array('foo', 'bar'));
+        $cmd = $commands->create('set', array('foo', 'bar'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
 
-        $cmd = $commands->createCommand('exists', array('foo'));
+        $cmd = $commands->create('exists', array('foo'));
         $this->assertSame($master, $replication->getConnectionByCommand($cmd));
     }
 
@@ -531,8 +531,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testWritesCommandToCorrectConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('foo'));
-        $cmdSet = $commands->createCommand('set', array('foo', 'bar'));
+        $cmdExists = $commands->create('exists', array('foo'));
+        $cmdSet = $commands->create('set', array('foo', 'bar'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -560,8 +560,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testReadsCommandFromCorrectConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('foo'));
-        $cmdSet = $commands->createCommand('set', array('foo', 'bar'));
+        $cmdExists = $commands->create('exists', array('foo'));
+        $cmdSet = $commands->create('set', array('foo', 'bar'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -590,8 +590,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testExecutesCommandOnCorrectConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('foo'));
-        $cmdSet = $commands->createCommand('set', array('foo', 'bar'));
+        $cmdExists = $commands->create('exists', array('foo'));
+        $cmdSet = $commands->create('set', array('foo', 'bar'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -620,7 +620,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testWatchTriggersSwitchToMasterConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdWatch = $commands->createCommand('watch', array('foo'));
+        $cmdWatch = $commands->create('watch', array('foo'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -647,7 +647,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testMultiTriggersSwitchToMasterConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdMulti = $commands->createCommand('multi');
+        $cmdMulti = $commands->create('multi');
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -674,7 +674,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testEvalTriggersSwitchToMasterConnection()
     {
         $commands = $this->getCommandFactory();
-        $cmdEval = $commands->createCommand('eval', array("return redis.call('info')"));
+        $cmdEval = $commands->create('eval', array("return redis.call('info')"));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -701,7 +701,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testDiscardsUnreachableSlaveAndExecutesReadOnlyCommandOnNextSlave()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('key'));
+        $cmdExists = $commands->create('exists', array('key'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -745,7 +745,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testDiscardsUnreachableSlavesAndExecutesReadOnlyCommandOnMaster()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('key'));
+        $cmdExists = $commands->create('exists', array('key'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -791,7 +791,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testSucceedOnReadOnlyCommandAndNoConnectionSetAsMaster()
     {
         $commands = $this->getCommandFactory();
-        $cmdExists = $commands->createCommand('exists', array('key'));
+        $cmdExists = $commands->create('exists', array('key'));
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6379?role=slave');
         $slave1
@@ -818,7 +818,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $this->expectExceptionMessage('No master server available for replication');
 
         $commands = $this->getCommandFactory();
-        $cmdSet = $commands->createCommand('set', array('key', 'value'));
+        $cmdSet = $commands->create('set', array('key', 'value'));
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6379?role=slave');
         $slave1
@@ -886,7 +886,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $this->expectException('Predis\Connection\ConnectionException');
 
         $commands = $this->getCommandFactory();
-        $cmdSet = $commands->createCommand('set', array('key', 'value'));
+        $cmdSet = $commands->create('set', array('key', 'value'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -918,7 +918,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The command 'INFO' is not allowed in replication mode.");
 
-        $cmd = $this->getCommandFactory()->createCommand('info');
+        $cmd = $this->getCommandFactory()->create('info');
 
         $replication = new MasterSlaveReplication();
 
@@ -934,8 +934,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testCanOverrideReadOnlyFlagForCommands()
     {
         $commands = $this->getCommandFactory();
-        $cmdSet = $commands->createCommand('set', array('foo', 'bar'));
-        $cmdGet = $commands->createCommand('get', array('foo'));
+        $cmdSet = $commands->create('set', array('foo', 'bar'));
+        $cmdGet = $commands->create('get', array('foo'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -967,8 +967,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     public function testAcceptsCallableToOverrideReadOnlyFlagForCommands()
     {
         $commands = $this->getCommandFactory();
-        $cmdExistsFoo = $commands->createCommand('exists', array('foo'));
-        $cmdExistsBar = $commands->createCommand('exists', array('bar'));
+        $cmdExistsFoo = $commands->create('exists', array('foo'));
+        $cmdExistsBar = $commands->create('exists', array('bar'));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -1006,8 +1006,8 @@ class MasterSlaveReplicationTest extends PredisTestCase
     {
         $commands = $this->getCommandFactory();
 
-        $cmdEval = $commands->createCommand('eval', array($script = "return redis.call('info');"));
-        $cmdEvalSha = $commands->createCommand('evalsha', array($scriptSHA1 = sha1($script)));
+        $cmdEval = $commands->create('eval', array($script = "return redis.call('info');"));
+        $cmdEvalSha = $commands->create('evalsha', array($scriptSHA1 = sha1($script)));
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master

--- a/tests/Predis/Connection/WebdisConnectionTest.php
+++ b/tests/Predis/Connection/WebdisConnectionTest.php
@@ -63,7 +63,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::writeRequest() is not supported");
 
         $connection = $this->createConnection();
-        $connection->writeRequest($this->getCommandFactory()->createCommand('ping'));
+        $connection->writeRequest($this->getCommandFactory()->create('ping'));
     }
 
     /**
@@ -75,7 +75,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::readResponse() is not supported");
 
         $connection = $this->createConnection();
-        $connection->readResponse($this->getCommandFactory()->createCommand('ping'));
+        $connection->readResponse($this->getCommandFactory()->create('ping'));
     }
 
     /**
@@ -99,7 +99,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::addConnectCommand() is not supported");
 
         $connection = $this->createConnection();
-        $connection->addConnectCommand($this->getCommandFactory()->createCommand('ping'));
+        $connection->addConnectCommand($this->getCommandFactory()->create('ping'));
     }
 
     /**
@@ -111,7 +111,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectExceptionMessage("Command 'SELECT' is not allowed by Webdis");
 
         $connection = $this->createConnection();
-        $connection->executeCommand($this->getCommandFactory()->createCommand('select', array(0)));
+        $connection->executeCommand($this->getCommandFactory()->create('select', array(0)));
     }
 
     /**
@@ -123,7 +123,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectExceptionMessage("Command 'AUTH' is not allowed by Webdis");
 
         $connection = $this->createConnection();
-        $connection->executeCommand($this->getCommandFactory()->createCommand('auth', array('foobar')));
+        $connection->executeCommand($this->getCommandFactory()->create('auth', array('foobar')));
     }
 
     /**
@@ -155,11 +155,11 @@ class WebdisConnectionTest extends PredisTestCase
     {
         $commands = $this->getCommandFactory();
 
-        $cmdPing = $commands->createCommand('ping');
-        $cmdEcho = $commands->createCommand('echo', array('echoed'));
-        $cmdGet = $commands->createCommand('get', array('foobar'));
-        $cmdRpush = $commands->createCommand('rpush', array('metavars', 'foo', 'hoge', 'lol'));
-        $cmdLrange = $commands->createCommand('lrange', array('metavars', 0, -1));
+        $cmdPing = $commands->create('ping');
+        $cmdEcho = $commands->create('echo', array('echoed'));
+        $cmdGet = $commands->create('get', array('foobar'));
+        $cmdRpush = $commands->create('rpush', array('metavars', 'foo', 'hoge', 'lol'));
+        $cmdLrange = $commands->create('lrange', array('metavars', 0, -1));
 
         $connection = $this->createConnection(true);
 
@@ -180,7 +180,7 @@ class WebdisConnectionTest extends PredisTestCase
         $this->expectException('Predis\Connection\ConnectionException');
 
         $connection = $this->createConnectionWithParams(array('host' => '169.254.10.10'));
-        $connection->executeCommand($this->getCommandFactory()->createCommand('ping'));
+        $connection->executeCommand($this->getCommandFactory()->create('ping'));
     }
 
     // ******************************************************************** //
@@ -219,7 +219,7 @@ class WebdisConnectionTest extends PredisTestCase
         }
 
         $connection = new WebdisConnection($parameters);
-        $connection->executeCommand($this->getCommandFactory()->createCommand('flushdb'));
+        $connection->executeCommand($this->getCommandFactory()->create('flushdb'));
 
         return $connection;
     }

--- a/tests/Predis/Monitor/ConsumerTest.php
+++ b/tests/Predis/Monitor/ConsumerTest.php
@@ -31,7 +31,7 @@ class ConsumerTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->once())
-            ->method('supportsCommand')
+            ->method('supports')
             ->with('MONITOR')
             ->will($this->returnValue(false));
 
@@ -59,7 +59,7 @@ class ConsumerTest extends PredisTestCase
      */
     public function testConstructorStartsConsumer()
     {
-        $cmdMonitor = $this->getCommandFactory()->createCommand('monitor');
+        $cmdMonitor = $this->getCommandFactory()->create('monitor');
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $client = $this->getMockBuilder('Predis\Client')

--- a/tests/Predis/Pipeline/PipelineTest.php
+++ b/tests/Predis/Pipeline/PipelineTest.php
@@ -144,7 +144,7 @@ class PipelineTest extends PredisTestCase
     public function testExecuteReturnsPipelineForFluentInterface()
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
-        $command = $this->getCommandFactory()->createCommand('echo', array('one'));
+        $command = $this->getCommandFactory()->create('echo', array('one'));
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -168,9 +168,9 @@ class PipelineTest extends PredisTestCase
 
         $pipeline = new Pipeline(new Client($connection));
 
-        $pipeline->executeCommand($commands->createCommand('echo', array('one')));
-        $pipeline->executeCommand($commands->createCommand('echo', array('two')));
-        $pipeline->executeCommand($commands->createCommand('echo', array('three')));
+        $pipeline->executeCommand($commands->create('echo', array('one')));
+        $pipeline->executeCommand($commands->create('echo', array('two')));
+        $pipeline->executeCommand($commands->create('echo', array('three')));
     }
 
     /**

--- a/tests/Predis/PubSub/ConsumerTest.php
+++ b/tests/Predis/PubSub/ConsumerTest.php
@@ -31,7 +31,7 @@ class ConsumerTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->any())
-            ->method('supportsCommands')
+            ->method('supports')
             ->will($this->returnValue(false));
 
         $client = new Client(null, array('commands' => $commands));
@@ -90,7 +90,7 @@ class ConsumerTest extends PredisTestCase
             ->method('createCommand')
             ->with($this->logicalOr($this->equalTo('subscribe'), $this->equalTo('psubscribe')))
             ->will($this->returnCallback(function ($id, $args) use ($commands) {
-                return $commands->createCommand($id, $args);
+                return $commands->create($id, $args);
             }));
 
         $options = array('subscribe' => 'channel:foo', 'psubscribe' => 'channels:*');

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -27,7 +27,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $strategy = new ReplicationStrategy();
 
         foreach ($this->getExpectedCommands('read') as $commandId) {
-            $command = $commands->createCommand($commandId);
+            $command = $commands->create($commandId);
 
             $this->assertTrue(
                 $strategy->isReadOperation($command),
@@ -45,7 +45,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $strategy = new ReplicationStrategy();
 
         foreach ($this->getExpectedCommands('write') as $commandId) {
-            $command = $commands->createCommand($commandId);
+            $command = $commands->create($commandId);
 
             $this->assertFalse(
                 $strategy->isReadOperation($command),
@@ -63,7 +63,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $strategy = new ReplicationStrategy();
 
         foreach ($this->getExpectedCommands('disallowed') as $commandId) {
-            $command = $commands->createCommand($commandId);
+            $command = $commands->create($commandId);
 
             $this->assertTrue(
                 $strategy->isDisallowedOperation($command),
@@ -80,13 +80,13 @@ class ReplicationStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $cmdReturnSort = $commands->createCommand('SORT', array('key:list'));
+        $cmdReturnSort = $commands->create('SORT', array('key:list'));
         $this->assertFalse(
             $strategy->isReadOperation($cmdReturnSort),
             'SORT is expected to be a write operation.'
         );
 
-        $cmdStoreSort = $commands->createCommand('SORT', array('key:list', array('store' => 'key:stored')));
+        $cmdStoreSort = $commands->create('SORT', array('key:list', array('store' => 'key:stored')));
         $this->assertFalse(
             $strategy->isReadOperation($cmdStoreSort),
             'SORT with STORE is expected to be a write operation.'
@@ -101,37 +101,37 @@ class ReplicationStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $command = $commands->createCommand('BITFIELD', array('key'));
+        $command = $commands->create('BITFIELD', array('key'));
         $this->assertTrue(
             $strategy->isReadOperation($command),
             'BITFIELD with no modifiers is expected to be a read operation.'
         );
 
-        $command = $commands->createCommand('BITFIELD', array('key', 'GET', 'u4', '0'));
+        $command = $commands->create('BITFIELD', array('key', 'GET', 'u4', '0'));
         $this->assertTrue(
             $strategy->isReadOperation($command),
             'BITFIELD with GET only is expected to be a read operation.'
         );
 
-        $command = $commands->createCommand('BITFIELD', array('key', 'SET', 'u4', '0', 1));
+        $command = $commands->create('BITFIELD', array('key', 'SET', 'u4', '0', 1));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'BITFIELD with SET is expected to be a write operation.'
         );
 
-        $command = $commands->createCommand('BITFIELD', array('key', 'INCRBY', 'u4', '0', 1));
+        $command = $commands->create('BITFIELD', array('key', 'INCRBY', 'u4', '0', 1));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'BITFIELD with INCRBY is expected to be a write operation.'
         );
 
-        $command = $commands->createCommand('BITFIELD', array('key', 'GET', 'u4', '0', 'INCRBY', 'u4', '0', 1));
+        $command = $commands->create('BITFIELD', array('key', 'GET', 'u4', '0', 'INCRBY', 'u4', '0', 1));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'BITFIELD with GET and INCRBY is expected to be a write operation.'
         );
 
-        $command = $commands->createCommand('BITFIELD', array('key', 'GET', 'u4', '0', 'SET', 'u4', '0', 1));
+        $command = $commands->create('BITFIELD', array('key', 'GET', 'u4', '0', 'SET', 'u4', '0', 1));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'BITFIELD with GET and SET is expected to be a write operation.'
@@ -146,19 +146,19 @@ class ReplicationStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $command = $commands->createCommand('GEORADIUS', array('key:geo', 15, 37, 200, 'km'));
+        $command = $commands->create('GEORADIUS', array('key:geo', 15, 37, 200, 'km'));
         $this->assertTrue(
             $strategy->isReadOperation($command),
             'GEORADIUS is expected to be a read operation.'
         );
 
-        $command = $commands->createCommand('GEORADIUS', array('key:geo', 15, 37, 200, 'km', 'store', 'key:store'));
+        $command = $commands->create('GEORADIUS', array('key:geo', 15, 37, 200, 'km', 'store', 'key:store'));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'GEORADIUS with STORE is expected to be a write operation.'
         );
 
-        $command = $commands->createCommand('GEORADIUS', array('key:geo', 15, 37, 200, 'km', 'storedist', 'key:storedist'));
+        $command = $commands->create('GEORADIUS', array('key:geo', 15, 37, 200, 'km', 'storedist', 'key:storedist'));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'GEORADIUS with STOREDIST is expected to be a write operation.'
@@ -173,19 +173,19 @@ class ReplicationStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $command = $commands->createCommand('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km'));
+        $command = $commands->create('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km'));
         $this->assertTrue(
             $strategy->isReadOperation($command),
             'GEORADIUSBYMEMBER is expected to be a read operation.'
         );
 
-        $command = $commands->createCommand('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km', 'store', 'key:store'));
+        $command = $commands->create('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km', 'store', 'key:store'));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'GEORADIUSBYMEMBER with STORE is expected to be a write operation.'
         );
 
-        $command = $commands->createCommand('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km', 'storedist', 'key:storedist'));
+        $command = $commands->create('GEORADIUSBYMEMBER', array('key:geo', 15, 37, 200, 'km', 'storedist', 'key:storedist'));
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'GEORADIUSBYMEMBER with STOREDIST is expected to be a write operation.'
@@ -203,7 +203,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $command = $commands->createCommand('INFO');
+        $command = $commands->create('INFO');
         $strategy->isReadOperation($command);
     }
 
@@ -272,10 +272,10 @@ class ReplicationStrategyTest extends PredisTestCase
             return $command->getArgument(1) === true;
         });
 
-        $command = $commands->createCommand('SET', array('trigger', false));
+        $command = $commands->create('SET', array('trigger', false));
         $this->assertFalse($strategy->isReadOperation($command));
 
-        $command = $commands->createCommand('SET', array('trigger', true));
+        $command = $commands->create('SET', array('trigger', true));
         $this->assertTrue($strategy->isReadOperation($command));
     }
 
@@ -292,13 +292,13 @@ class ReplicationStrategyTest extends PredisTestCase
 
         $strategy->setScriptReadOnly($readScript, true);
 
-        $cmdEval = $commands->createCommand('EVAL', array($writeScript));
-        $cmdEvalSHA = $commands->createCommand('EVALSHA', array(sha1($writeScript)));
+        $cmdEval = $commands->create('EVAL', array($writeScript));
+        $cmdEvalSHA = $commands->create('EVALSHA', array(sha1($writeScript)));
         $this->assertFalse($strategy->isReadOperation($cmdEval));
         $this->assertFalse($strategy->isReadOperation($cmdEvalSHA));
 
-        $cmdEval = $commands->createCommand('EVAL', array($readScript));
-        $cmdEvalSHA = $commands->createCommand('EVALSHA', array(sha1($readScript)));
+        $cmdEval = $commands->create('EVAL', array($readScript));
+        $cmdEvalSHA = $commands->create('EVALSHA', array(sha1($readScript)));
         $this->assertTrue($strategy->isReadOperation($cmdEval));
         $this->assertTrue($strategy->isReadOperation($cmdEvalSHA));
     }

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -32,8 +32,8 @@ class MultiExecTest extends PredisTestCase
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->once())
-            ->method('supportsCommands')
-            ->with(array('MULTI', 'EXEC', 'DISCARD'))
+            ->method('supports')
+            ->with('MULTI', 'EXEC', 'DISCARD')
             ->will($this->returnValue(false));
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
@@ -52,15 +52,16 @@ class MultiExecTest extends PredisTestCase
 
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
-            ->expects($this->once())
-            ->method('supportsCommands')
-            ->with(array('MULTI', 'EXEC', 'DISCARD'))
-            ->will($this->returnValue(true));
-        $commands
-            ->expects($this->once())
-            ->method('supportsCommand')
-            ->with('WATCH')
-            ->will($this->returnValue(false));
+            ->expects($this->exactly(2))
+            ->method('supports')
+            ->withConsecutive(
+                array('MULTI', 'EXEC', 'DISCARD'),
+                array('WATCH')
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false
+            );
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $client = new Client($connection, array('commands' => $commands));
@@ -78,16 +79,19 @@ class MultiExecTest extends PredisTestCase
         $this->expectExceptionMessage('UNWATCH is not supported by the current command factory.');
 
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
+
+        $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
-            ->expects($this->once())
-            ->method('supportsCommands')
-            ->with(array('MULTI', 'EXEC', 'DISCARD'))
-            ->will($this->returnValue(true));
-        $commands
-            ->expects($this->once())
-            ->method('supportsCommand')
-            ->with('UNWATCH')
-            ->will($this->returnValue(false));
+            ->expects($this->exactly(2))
+            ->method('supports')
+            ->withConsecutive(
+                array('MULTI', 'EXEC', 'DISCARD'),
+                array('UNWATCH')
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                false
+            );
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $client = new Client($connection, array('commands' => $commands));


### PR DESCRIPTION
More changes to `Predis\Command\FactoryInterface` in continuation to #648. 

Most methods were renamed to drop the _command_ suffix as it is quite redundant. Methods `supportsCommand(string)` and `supportsCommands(array)` were merged into `supports(string...)` so we now have just one method.

Since we do not need to run on anything below PHP 7.2 for v2.0 I took the opportunity to start adding more stringent typehints in functions for parameters and return values, and replace the ancient `array()` notation with `[]`. This will be gradually done for the rest of the library.