### PR TITLE
Various improvements to the test suite

### DIFF
--- a/bin/create-command-test
+++ b/bin/create-command-test
@@ -187,7 +187,7 @@ class $class extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return '$fqn';
     }
@@ -195,7 +195,7 @@ class $class extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return '$id';
     }
@@ -203,7 +203,7 @@ class $class extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         \$this->markTestIncomplete('This test has not been implemented yet.');
 
@@ -219,7 +219,7 @@ class $class extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         \$this->markTestIncomplete('This test has not been implemented yet.');
 
@@ -239,7 +239,7 @@ PHP;
     /**
      * @group disconnected
      */
-    public function testPrefixKeys()
+    public function testPrefixKeys(): void
     {
         \$this->markTestIncomplete('This test has not been implemented yet.');
 
@@ -255,7 +255,7 @@ PHP;
     /**
      * @group disconnected
      */
-    public function testPrefixKeysIgnoredOnEmptyArguments()
+    public function testPrefixKeysIgnoredOnEmptyArguments(): void
     {
         \$command = \$this->getCommand();
         \$command->prefixKeys('prefix:');

--- a/tests/PHPUnit/ArrayHasSameValuesConstraint.php
+++ b/tests/PHPUnit/ArrayHasSameValuesConstraint.php
@@ -10,7 +10,7 @@
  */
 
 /**
- * Constraint that accepts arrays with the same elements but different order.
+ * PHPUnit constraint matching arrays with same elemnts even in different order.
  */
 class ArrayHasSameValuesConstraint extends \PHPUnit\Framework\Constraint\Constraint
 {
@@ -19,7 +19,7 @@ class ArrayHasSameValuesConstraint extends \PHPUnit\Framework\Constraint\Constra
     /**
      * @param array $array
      */
-    public function __construct($array)
+    public function __construct(array $array)
     {
         $this->array = $array;
     }

--- a/tests/PHPUnit/PredisCommandTestCase.php
+++ b/tests/PHPUnit/PredisCommandTestCase.php
@@ -11,9 +11,10 @@
 
 namespace Predis\Command\Redis;
 
+use PredisTestCase;
 use Predis\Client;
 use Predis\Command;
-use PredisTestCase;
+use Predis\Command\CommandInterface;
 
 /**
  *
@@ -21,25 +22,25 @@ use PredisTestCase;
 abstract class PredisCommandTestCase extends PredisTestCase
 {
     /**
-     * Returns the expected command.
+     * Returns the expected command for tests.
      *
-     * @return Command\CommandInterface|string Instance or FQN of the expected command.
+     * @return Command\CommandInterface|string Instance or FQCN of the expected command
      */
-    abstract protected function getExpectedCommand();
+    abstract protected function getExpectedCommand(): string;
 
     /**
-     * Returns the expected command ID.
+     * Returns the expected command ID for tests.
      *
      * @return string
      */
-    abstract protected function getExpectedId();
+    abstract protected function getExpectedId(): string;
 
     /**
      * Returns a new command instance.
      *
      * @return Command\CommandInterface
      */
-    public function getCommand()
+    public function getCommand(): Command\CommandInterface
     {
         $command = $this->getExpectedCommand();
 
@@ -49,11 +50,11 @@ abstract class PredisCommandTestCase extends PredisTestCase
     /**
      * Returns a new client instance.
      *
-     * @param bool $flushdb Flush selected database before returning the client.
+     * @param bool $flushdb Flush selected database before returning the client
      *
      * @return Client
      */
-    public function getClient($flushdb = true)
+    public function getClient(bool $flushdb = true): Client
     {
         $commands = $this->getCommandFactory();
 
@@ -69,11 +70,11 @@ abstract class PredisCommandTestCase extends PredisTestCase
     }
 
     /**
-     * Returns wether the command is prefixable or not.
+     * Verifies if the command implements the prefixable interface.
      *
      * @return bool
      */
-    protected function isPrefixable()
+    protected function isPrefixable(): bool
     {
         return $this->getCommand() instanceof Command\PrefixableCommandInterface;
     }
@@ -81,23 +82,23 @@ abstract class PredisCommandTestCase extends PredisTestCase
     /**
      * Returns a new command instance with the specified arguments.
      *
-     * @param ... List of arguments for the command.
+     * @param ... List of arguments for the command
      *
      * @return CommandInterface
      */
-    protected function getCommandWithArguments(/* arguments */)
+    protected function getCommandWithArguments(...$arguments): CommandInterface
     {
-        return $this->getCommandWithArgumentsArray(func_get_args());
+        return $this->getCommandWithArgumentsArray($arguments);
     }
 
     /**
      * Returns a new command instance with the specified arguments.
      *
-     * @param array $arguments Arguments for the command.
+     * @param array $arguments Arguments for the command
      *
      * @return CommandInterface
      */
-    protected function getCommandWithArgumentsArray(array $arguments)
+    protected function getCommandWithArgumentsArray(array $arguments): CommandInterface
     {
         $command = $this->getCommand();
         $command->setArguments($arguments);
@@ -108,7 +109,7 @@ abstract class PredisCommandTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCommandId()
+    public function testCommandId(): void
     {
         $command = $this->getCommand();
 
@@ -119,7 +120,7 @@ abstract class PredisCommandTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRawArguments()
+    public function testRawArguments(): void
     {
         $expected = array('1st', '2nd', '3rd', '4th');
 

--- a/tests/PHPUnit/PredisConnectionTestCase.php
+++ b/tests/PHPUnit/PredisConnectionTestCase.php
@@ -360,7 +360,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $cmdPing
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         /** @var CommandInterface|MockObject */
         $cmdEcho = $this->getMockBuilder($commands->getCommandClass('echo'))
@@ -370,7 +370,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $cmdEcho
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array('ECHOED')));
+            ->willReturn(array('ECHOED'));
 
         $connection = $this->createConnection();
         $connection->addConnectCommand($cmdPing);

--- a/tests/PHPUnit/PredisConnectionTestCase.php
+++ b/tests/PHPUnit/PredisConnectionTestCase.php
@@ -12,6 +12,8 @@
 namespace Predis\Connection;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\CommandInterface;
 
 /**
  * @group realm-connection
@@ -21,7 +23,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorDoesNotOpenConnection()
+    public function testConstructorDoesNotOpenConnection(): void
     {
         $connection = $this->createConnection();
 
@@ -31,7 +33,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeTCP()
+    public function testSupportsSchemeTCP(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'tcp'));
 
@@ -41,7 +43,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeRedis()
+    public function testSupportsSchemeRedis(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'redis'));
 
@@ -51,7 +53,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeTls()
+    public function testSupportsSchemeTls(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'tls'));
 
@@ -61,7 +63,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeRediss()
+    public function testSupportsSchemeRediss(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'rediss'));
 
@@ -71,7 +73,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeUnix()
+    public function testSupportsSchemeUnix(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'unix'));
 
@@ -81,7 +83,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidScheme()
+    public function testThrowsExceptionOnInvalidScheme(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Invalid scheme: 'udp'");
@@ -92,7 +94,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExposesParameters()
+    public function testExposesParameters(): void
     {
         $parameters = $this->getParameters();
         $connection = $this->createConnectionWithParams($parameters);
@@ -103,7 +105,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanBeSerialized()
+    public function testCanBeSerialized(): void
     {
         $parameters = $this->getParameters(array(
             'alias' => 'redis',
@@ -113,7 +115,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
         $connection = $this->createConnectionWithParams($parameters);
         $unserialized = unserialize(serialize($connection));
 
-        $this->assertInstanceOf(static::CONNECTION_CLASS, $unserialized);
+        $this->assertInstanceOf($this->getConnectionClass(), $unserialized);
         $this->assertEquals($parameters, $unserialized->getParameters());
     }
 
@@ -125,7 +127,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testAcceptsTcpNodelayParameter()
+    public function testAcceptsTcpNodelayParameter(): void
     {
         $connection = $this->createConnectionWithParams(array('tcp_nodelay' => false));
         $connection->connect();
@@ -139,7 +141,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testConnectForcesConnection()
+    public function testConnectForcesConnection(): void
     {
         $connection = $this->createConnection();
 
@@ -151,7 +153,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testDoesNotThrowExceptionOnConnectWhenAlreadyConnected()
+    public function testDoesNotThrowExceptionOnConnectWhenAlreadyConnected(): void
     {
         $connection = $this->createConnection();
 
@@ -165,7 +167,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testDisconnectForcesDisconnection()
+    public function testDisconnectForcesDisconnection(): void
     {
         $connection = $this->createConnection();
 
@@ -179,7 +181,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDoesNotThrowExceptionOnDisconnectWhenAlreadyDisconnected()
+    public function testDoesNotThrowExceptionOnDisconnectWhenAlreadyDisconnected(): void
     {
         $connection = $this->createConnection();
 
@@ -191,7 +193,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testGetResourceForcesConnection()
+    public function testGetResourceForcesConnection(): void
     {
         $connection = $this->createConnection();
 
@@ -203,7 +205,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testSendingCommandForcesConnection()
+    public function testSendingCommandForcesConnection(): void
     {
         $connection = $this->createConnection();
         $commands = $this->getCommandFactory();
@@ -217,12 +219,13 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testExecutesCommandOnServer()
+    public function testExecutesCommandOnServer(): void
     {
         $commands = $this->getCommandFactory();
 
+        /** @var CommandInterface|MockObject */
         $cmdPing = $this->getMockBuilder($commands->getCommandClass('ping'))
-            ->setMethods(array('parseResponse'))
+            ->onlyMethods(array('parseResponse'))
             ->getMock();
         $cmdPing->expects($this->never())
             ->method('parseResponse');
@@ -235,7 +238,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testExecutesCommandWithHolesInArguments()
+    public function testExecutesCommandWithHolesInArguments(): void
     {
         $commands = $this->getCommandFactory();
         $cmdDel = $commands->create('mget', array(0 => 'key:0', 2 => 'key:2'));
@@ -248,7 +251,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testExecutesMultipleCommandsOnServer()
+    public function testExecutesMultipleCommandsOnServer(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -270,12 +273,13 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testWritesCommandToServer()
+    public function testWritesCommandToServer(): void
     {
         $commands = $this->getCommandFactory();
 
+        /** @var CommandInterface|MockObject */
         $cmdEcho = $this->getMockBuilder($commands->getCommandClass('echo'))
-            ->setMethods(array('parseResponse'))
+            ->onlyMethods(array('parseResponse'))
             ->getMock();
         $cmdEcho->setArguments(array('ECHOED'));
         $cmdEcho
@@ -290,12 +294,13 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsCommandFromServer()
+    public function testReadsCommandFromServer(): void
     {
         $commands = $this->getCommandFactory();
 
+        /** @var CommandInterface|MockObject */
         $cmdEcho = $this->getMockBuilder($commands->getCommandClass('echo'))
-            ->setMethods(array('parseResponse'))
+            ->onlyMethods(array('parseResponse'))
             ->getMock();
         $cmdEcho->setArguments(array('ECHOED'));
         $cmdEcho
@@ -311,19 +316,21 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIsAbleToWriteMultipleCommandsAndReadThemBackForPipelining()
+    public function testIsAbleToWriteMultipleCommandsAndReadThemBackForPipelining(): void
     {
         $commands = $this->getCommandFactory();
 
+        /** @var CommandInterface|MockObject */
         $cmdPing = $this->getMockBuilder($commands->getCommandClass('ping'))
-            ->setMethods(array('parseResponse'))
+            ->onlyMethods(array('parseResponse'))
             ->getMock();
         $cmdPing
             ->expects($this->never())
             ->method('parseResponse');
 
+        /** @var CommandInterface|MockObject */
         $cmdEcho = $this->getMockBuilder($commands->getCommandClass('echo'))
-            ->setMethods(array('parseResponse'))
+            ->onlyMethods(array('parseResponse'))
             ->getMock();
         $cmdEcho->setArguments(array('ECHOED'));
         $cmdEcho
@@ -342,20 +349,22 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testSendsInitializationCommandsOnConnection()
+    public function testSendsInitializationCommandsOnConnection(): void
     {
         $commands = $this->getCommandFactory();
 
+        /** @var CommandInterface|MockObject */
         $cmdPing = $this->getMockBuilder($commands->getCommandClass('ping'))
-            ->setMethods(array('getArguments'))
+            ->onlyMethods(array('getArguments'))
             ->getMock();
         $cmdPing
             ->expects($this->once())
             ->method('getArguments')
             ->will($this->returnValue(array()));
 
+        /** @var CommandInterface|MockObject */
         $cmdEcho = $this->getMockBuilder($commands->getCommandClass('echo'))
-            ->setMethods(array('getArguments'))
+            ->onlyMethods(array('getArguments'))
             ->getMock();
         $cmdEcho->setArguments(array('ECHOED'));
         $cmdEcho
@@ -373,7 +382,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsStatusResponses()
+    public function testReadsStatusResponses(): void
     {
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
@@ -393,7 +402,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsBulkResponses()
+    public function testReadsBulkResponses(): void
     {
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
@@ -410,7 +419,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsIntegerResponses()
+    public function testReadsIntegerResponses(): void
     {
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
@@ -424,7 +433,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsErrorResponsesAsResponseErrorObjects()
+    public function testReadsErrorResponsesAsResponseErrorObjects(): void
     {
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
@@ -439,7 +448,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
-    public function testReadsMultibulkResponsesAsArrays()
+    public function testReadsMultibulkResponsesAsArrays(): void
     {
         $commands = $this->getCommandFactory();
         $connection = $this->createConnection(true);
@@ -454,22 +463,14 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @group connected
      * @group slow
      */
-    public function testThrowsExceptionOnConnectionTimeout()
+    public function testThrowsExceptionOnConnectionTimeout(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessageMatches('/.* \[tcp:\/\/169.254.10.10:6379\]/');
 
-        // TODO: float timeouts for connect() under HHVM 3.6.6 are broken and,
-        // unfortunately, this is the version still being used by Travis CI.
-        if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.6.6', '<=')) {
-            $timeout = 1;
-        } else {
-            $timeout = 0.1;
-        }
-
         $connection = $this->createConnectionWithParams(array(
             'host' => '169.254.10.10',
-            'timeout' => $timeout,
+            'timeout' => 0.1,
         ), false);
 
         $connection->connect();
@@ -479,22 +480,14 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @group connected
      * @group slow
      */
-    public function testThrowsExceptionOnConnectionTimeoutIPv6()
+    public function testThrowsExceptionOnConnectionTimeoutIPv6(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessageMatches('/.* \[tcp:\/\/\[0:0:0:0:0:ffff:a9fe:a0a\]:6379\]/');
 
-        // TODO: float timeouts for connect() under HHVM 3.6.6 are broken and,
-        // unfortunately, this is the version still being used by Travis CI.
-        if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.6.6', '<=')) {
-            $timeout = 1;
-        } else {
-            $timeout = 0.1;
-        }
-
         $connection = $this->createConnectionWithParams(array(
             'host' => '0:0:0:0:0:ffff:a9fe:a0a',
-            'timeout' => $timeout,
+            'timeout' => 0.1,
         ), false);
 
         $connection->connect();
@@ -504,7 +497,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @group connected
      * @group slow
      */
-    public function testThrowsExceptionOnUnixDomainSocketNotFound()
+    public function testThrowsExceptionOnUnixDomainSocketNotFound(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessageMatches('/.* \[unix:\/tmp\/nonexistent\/redis\.sock]/');
@@ -521,7 +514,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @group connected
      * @group slow
      */
-    public function testThrowsExceptionOnReadWriteTimeout()
+    public function testThrowsExceptionOnReadWriteTimeout(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
 
@@ -538,7 +531,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
      * @medium
      * @group connected
      */
-    public function testThrowsExceptionOnProtocolDesynchronizationErrors()
+    public function testThrowsExceptionOnProtocolDesynchronizationErrors(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
 
@@ -556,63 +549,62 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     // ******************************************************************** //
 
     /**
+     * Returns the fully-qualified class name of the connection used for tests.
+     *
+     * @return string
+     */
+    protected abstract function getConnectionClass(): string;
+
+    /**
      * Returns a named array with the default connection parameters and their values.
      *
      * @return array Default connection parameters.
      */
-    protected function getDefaultParametersArray()
+    protected function getDefaultParametersArray(): array
     {
         return array(
             'scheme' => 'tcp',
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             'read_write_timeout' => 2,
         );
     }
 
     /**
-     * Asserts that the connection is using a persistent resource stream.
+     * Asserts the connection is using a persistent resource stream.
      *
      * This assertion will trigger a connect() operation if the connection has
      * not been open yet.
      *
-     * @param NodeConnectionInterface $connection Connection instance.
+     * @param NodeConnectionInterface $connection Connection instance
      */
-    protected function assertPersistentConnection(NodeConnectionInterface $connection)
+    protected function assertPersistentConnection(NodeConnectionInterface $connection): void
     {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0 || $this->isHHVM()) {
-            $this->markTestSkipped('This test does not currently work on HHVM.');
-        }
-
         $this->assertSame('persistent stream', get_resource_type($connection->getResource()));
     }
 
     /**
-     * Asserts that the connection is not using a persistent resource stream.
+     * Asserts the connection is not using a persistent resource stream.
      *
      * This assertion will trigger a connect() operation if the connection has
      * not been open yet.
      *
-     * @param NodeConnectionInterface $connection Connection instance.
+     * @param NodeConnectionInterface $connection Connection instance
      */
-    protected function assertNonPersistentConnection(NodeConnectionInterface $connection)
+    protected function assertNonPersistentConnection(NodeConnectionInterface $connection): void
     {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0 || $this->isHHVM()) {
-            $this->markTestSkipped('This test does not currently work on HHVM.');
-        }
-
         $this->assertSame('stream', get_resource_type($connection->getResource()));
     }
 
     /**
      * Creates a new connection instance.
      *
-     * @param bool $initialize Push default initialization commands (SELECT and FLUSHDB).
+     * @param bool $initialize Push default initialization commands (SELECT and FLUSHDB)
      *
      * @return NodeConnectionInterface
      */
-    protected function createConnection($initialize = false)
+    protected function createConnection(bool $initialize = false): NodeConnectionInterface
     {
         return $this->createConnectionWithParams(array(), $initialize);
     }
@@ -620,14 +612,14 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * Creates a new connection instance using additional connection parameters.
      *
-     * @param mixed $parameters Additional connection parameters.
-     * @param bool  $initialize Push default initialization commands (SELECT and FLUSHDB).
+     * @param string|array|ParametersInterface $parameters Additional connection parameters
+     * @param bool                             $initialize Push default initialization commands (SELECT and FLUSHDB)
      *
      * @return NodeConnectionInterface
      */
-    protected function createConnectionWithParams($parameters, $initialize = false)
+    protected function createConnectionWithParams($parameters, $initialize = false): NodeConnectionInterface
     {
-        $class = static::CONNECTION_CLASS;
+        $class = $this->getConnectionClass();
         $commands = $this->getCommandFactory();
 
         if (!$parameters instanceof ParametersInterface) {

--- a/tests/PHPUnit/PredisDistributorTestCase.php
+++ b/tests/PHPUnit/PredisDistributorTestCase.php
@@ -21,9 +21,9 @@ abstract class PredisDistributorTestCase extends PredisTestCase
     /**
      * Returns a new instance of the tested distributor.
      *
-     * @return \Predis\Cluster\Distributor\DistributorInterface
+     * @return DistributorInterface
      */
-    abstract protected function getDistributorInstance();
+    abstract protected function getDistributorInstance(): DistributorInterface;
 
     /**
      * Returns a list of nodes from the hashring.
@@ -33,7 +33,7 @@ abstract class PredisDistributorTestCase extends PredisTestCase
      *
      * @return array Nodes from the hashring.
      */
-    protected function getNodes(DistributorInterface $distributor, $iterations = 10)
+    protected function getNodes(DistributorInterface $distributor, int $iterations = 10): array
     {
         $nodes = array();
 
@@ -52,7 +52,7 @@ abstract class PredisDistributorTestCase extends PredisTestCase
      *
      * @return DistributorInterface
      */
-    protected function getSampleDistribution(array $nodes)
+    protected function getSampleDistribution(array $nodes): DistributorInterface
     {
         $distributor = $this->getDistributorInstance();
 
@@ -66,7 +66,7 @@ abstract class PredisDistributorTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testEmptyRingThrowsException()
+    public function testEmptyRingThrowsException(): void
     {
         $this->expectException('Predis\Cluster\Distributor\EmptyRingException');
 
@@ -77,7 +77,7 @@ abstract class PredisDistributorTestCase extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemoveOnEmptyRingDoesNotThrowException()
+    public function testRemoveOnEmptyRingDoesNotThrowException(): void
     {
         $distributor = $this->getDistributorInstance();
 

--- a/tests/PHPUnit/RedisCommandConstraint.php
+++ b/tests/PHPUnit/RedisCommandConstraint.php
@@ -13,7 +13,7 @@ use Predis\Command\CommandInterface;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
- * Constraint that verifies a redis command.
+ * PHPUnit constraint to verify that a Redis command matches certain conditions.
  */
 class RedisCommandConstraint extends \PHPUnit\Framework\Constraint\Constraint
 {
@@ -21,10 +21,10 @@ class RedisCommandConstraint extends \PHPUnit\Framework\Constraint\Constraint
     protected $arguments;
 
     /**
-     * @param string|CommandInterface $command   Expected command ID or instance.
-     * @param array                   $arguments Expected command arguments.
+     * @param string|CommandInterface $command   Expected command instance or command ID
+     * @param ?array                  $arguments Expected command arguments
      */
-    public function __construct($command = null, array $arguments = null)
+    public function __construct($command, ?array $arguments = null)
     {
         if ($command instanceof CommandInterface) {
             $this->commandID = strtoupper($command->getId());
@@ -68,8 +68,7 @@ class RedisCommandConstraint extends \PHPUnit\Framework\Constraint\Constraint
     /**
      * {@inheritdoc}
      *
-     * @todo Improve output using diff when expected and actual arguments of a
-     *       command do not match.
+     * @todo Improve output using diff when expected and actual do not match.
      */
     public function toString(): string
     {

--- a/tests/Predis/ClientExceptionTest.php
+++ b/tests/Predis/ClientExceptionTest.php
@@ -21,7 +21,7 @@ class ClientExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionMessage()
+    public function testExceptionMessage(): void
     {
         $message = 'This is a client exception.';
 
@@ -34,7 +34,7 @@ class ClientExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionClass()
+    public function testExceptionClass(): void
     {
         $exception = new ClientException();
 

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -248,7 +248,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($callable);
 
@@ -272,7 +272,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($wrongType));
+            ->willReturn($wrongType);
 
         new Client($callable);
     }
@@ -330,7 +330,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'), $arg1)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $fnreplication = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -373,7 +373,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'), $arg1)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $fnaggregate = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -406,7 +406,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'), $arg1)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $connections = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connections
@@ -500,7 +500,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('create')
             ->with('ping', array())
-            ->will($this->returnValue($ping));
+            ->willReturn($ping);
 
         $client = new Client(null, array('commands' => $commands));
         $this->assertSame($ping, $client->createCommand('ping', array()));
@@ -521,12 +521,12 @@ class ClientTest extends PredisTestCase
             ->expects($this->at(0))
             ->method('executeCommand')
             ->with($ping)
-            ->will($this->returnValue(new Response\Status('PONG')));
+            ->willReturn(new Response\Status('PONG'));
         $connection
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($hgetall)
-            ->will($this->returnValue(array('foo', 'bar', 'hoge', 'piyo')));
+            ->willReturn(array('foo', 'bar', 'hoge', 'piyo'));
 
         $client = new Client($connection);
 
@@ -549,7 +549,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('executeCommand')
-            ->will($this->returnValue($expectedResponse));
+            ->willReturn($expectedResponse);
 
         $client = new Client($connection);
         $client->executeCommand($ping);
@@ -567,7 +567,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('executeCommand')
-            ->will($this->returnValue($expectedResponse));
+            ->willReturn($expectedResponse);
 
         $client = new Client($connection, array('exceptions' => false));
         $response = $client->executeCommand($ping);
@@ -587,14 +587,14 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($this->isInstanceOf('Predis\Command\Redis\PING'))
-            ->will($this->returnValue('PONG'));
+            ->willReturn('PONG');
 
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
         $commands
             ->expects($this->once())
             ->method('create')
             ->with('ping', array())
-            ->will($this->returnValue($ping));
+            ->willReturn($ping);
 
         $options = array('commands' => $commands);
 
@@ -622,7 +622,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($this->isRedisCommand('PING'))
-            ->will($this->returnValue($expectedResponse));
+            ->willReturn($expectedResponse);
 
         $client = new Client($connection);
         $client->ping();
@@ -640,7 +640,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($this->isRedisCommand('PING'))
-            ->will($this->returnValue($expectedResponse));
+            ->willReturn($expectedResponse);
 
         $client = new Client($connection, array('exceptions' => false));
         $response = $client->ping();
@@ -658,17 +658,17 @@ class ClientTest extends PredisTestCase
             ->expects($this->at(0))
             ->method('executeCommand')
             ->with($this->isRedisCommand('SET', array('foo', 'bar')))
-            ->will($this->returnValue(new Response\Status('OK')));
+            ->willReturn(new Response\Status('OK'));
         $connection
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($this->isRedisCommand('GET', array('foo')))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
         $connection
             ->expects($this->at(2))
             ->method('executeCommand')
             ->with($this->isRedisCommand('PING'))
-            ->will($this->returnValue('PONG'));
+            ->willReturn('PONG');
 
         $client = new Client($connection);
 
@@ -690,12 +690,12 @@ class ClientTest extends PredisTestCase
             ->expects($this->at(0))
             ->method('executeCommand')
             ->with($this->isRedisCommand('SET', array('foo', 'bar')))
-            ->will($this->returnValue(new Response\Status('OK')));
+            ->willReturn(new Response\Status('OK'));
         $connection
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($this->isRedisCommand('GET', array('foo')))
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar');
 
         $client = new Client($connection, array('prefix' => 'predis:'));
 
@@ -716,7 +716,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($this->isRedisCommand('PING'))
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $client = new Client($connection, array('exceptions' => true));
 
@@ -768,7 +768,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionById')
             ->with('127.0.0.1:6379')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('id', '127.0.0.1:6379');
@@ -790,7 +790,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionById')
             ->with('127.0.0.1:7000')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $client = new Client($aggregate);
         $client->getClientBy('id', '127.0.0.1:7000');
@@ -810,7 +810,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionByAlias')
             ->with('myalias')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('alias', 'myalias');
@@ -833,7 +833,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionByKey')
             ->with('key:1')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('key', 'key:1');
@@ -856,7 +856,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionBySlot')
             ->with(5460)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('slot', 5460);
@@ -879,7 +879,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionByRole')
             ->with('master')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('role', 'master');
@@ -903,7 +903,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('getConnectionByCommand')
             ->with($command)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $client = new Client($aggregate);
         $nodeClient = $client->getClientBy('command', $command);
@@ -1017,7 +1017,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(array('subscribe', 'channel', 0)));
+            ->willReturn(array('subscribe', 'channel', 0));
 
         $callable = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -1039,7 +1039,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->at(1))
             ->method('read')
-            ->will($this->returnValue(array('subscribe', 'channel', 1)));
+            ->willReturn(array('subscribe', 'channel', 1));
         $connection
             ->expects($this->at(2))
             ->method('writeRequest')
@@ -1047,7 +1047,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->at(3))
             ->method('read')
-            ->will($this->returnValue(array('unsubscribe', 'channel', 0)));
+            ->willReturn(array('unsubscribe', 'channel', 0));
 
         $callable = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -1055,7 +1055,7 @@ class ClientTest extends PredisTestCase
         $callable
             ->expects($this->at(0))
             ->method('__invoke')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $client = new Client($connection);
 
@@ -1105,7 +1105,7 @@ class ClientTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('executeCommand')
-            ->will($this->returnValue(new Response\Status('QUEUED')));
+            ->willReturn(new Response\Status('QUEUED'));
 
         $callable = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -1113,7 +1113,7 @@ class ClientTest extends PredisTestCase
         $callable
             ->expects($this->once())
             ->method('__invoke')
-            ->will($this->returnCallback(function ($tx) { $tx->ping(); }));
+            ->willReturnCallback(function ($tx) { $tx->ping(); });
 
         $client = new Client($connection);
         $client->transaction($options, $callable);
@@ -1139,24 +1139,24 @@ class ClientTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue('return redis.call(\'exists\', KEYS[1])'));
+            ->willReturn('return redis.call(\'exists\', KEYS[1])');
         $command
             ->expects($this->once())
             ->method('parseResponse')
             ->with('OK')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
             ->expects($this->at(0))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue(new Response\Error('NOSCRIPT')));
+            ->willReturn(new Response\Error('NOSCRIPT'));
         $connection
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($this->isRedisCommand('EVAL'))
-            ->will($this->returnValue('OK'));
+            ->willReturn('OK');
 
         $client = new Client($connection);
 
@@ -1263,7 +1263,7 @@ class ClientTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'), $parameters)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         return $callable;
     }

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -12,6 +12,12 @@
 namespace Predis;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Connection\ParametersInterface;
+use Predis\Command\Factory as CommandFactory;
+use Predis\Connection\NodeConnectionInterface;
+use Predis\Command\Processor\KeyPrefixProcessor;
+use Predis\Connection\Replication\MasterSlaveReplication;
 
 /**
  *
@@ -21,10 +27,11 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithoutArguments()
+    public function testConstructorWithoutArguments(): void
     {
         $client = new Client();
 
+        /** @var NodeConnectionInterface */
         $connection = $client->getConnection();
         $this->assertInstanceOf('Predis\Connection\NodeConnectionInterface', $connection);
 
@@ -41,10 +48,11 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithNullArgument()
+    public function testConstructorWithNullArgument(): void
     {
         $client = new Client(null);
 
+        /** @var NodeConnectionInterface */
         $connection = $client->getConnection();
         $this->assertInstanceOf('Predis\Connection\NodeConnectionInterface', $connection);
 
@@ -61,10 +69,11 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithNullAndNullArguments()
+    public function testConstructorWithNullAndNullArguments(): void
     {
         $client = new Client(null, null);
 
+        /** @var NodeConnectionInterface */
         $connection = $client->getConnection();
         $this->assertInstanceOf('Predis\Connection\NodeConnectionInterface', $connection);
 
@@ -81,11 +90,14 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayArgument()
+    public function testConstructorWithArrayArgument(): void
     {
         $client = new Client($arg1 = array('host' => 'localhost', 'port' => 7000));
 
-        $parameters = $client->getConnection()->getParameters();
+        /** @var NodeConnectionInterface */
+        $connection = $client->getConnection();
+        $parameters = $connection->getParameters();
+
         $this->assertSame($parameters->host, $arg1['host']);
         $this->assertSame($parameters->port, $arg1['port']);
     }
@@ -93,7 +105,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorThrowsExceptionWithArrayOfParametersArgumentAndMissingOption()
+    public function testConstructorThrowsExceptionWithArrayOfParametersArgumentAndMissingOption(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Array of connection parameters requires `cluster`, `replication` or `aggregate` client option');
@@ -109,7 +121,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayOfArrayArgumentAndClusterOption()
+    public function testConstructorWithArrayOfArrayArgumentAndClusterOption(): void
     {
         $arg1 = array(
             array('host' => 'localhost', 'port' => 7000),
@@ -126,11 +138,14 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithStringArgument()
+    public function testConstructorWithStringArgument(): void
     {
         $client = new Client('tcp://localhost:7000');
 
-        $parameters = $client->getConnection()->getParameters();
+        /** @var NodeConnectionInterface */
+        $connection = $client->getConnection();
+        $parameters = $connection->getParameters();
+
         $this->assertSame($parameters->host, 'localhost');
         $this->assertSame($parameters->port, 7000);
     }
@@ -138,7 +153,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayOfStringArgument()
+    public function testConstructorWithArrayOfStringArgument(): void
     {
         $arg1 = array('tcp://localhost:7000', 'tcp://localhost:7001');
 
@@ -152,7 +167,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayOfConnectionsArgument()
+    public function testConstructorWithArrayOfConnectionsArgument(): void
     {
         $arg1 = array(
             $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock(),
@@ -169,7 +184,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithConnectionArgument()
+    public function testConstructorWithConnectionArgument(): void
     {
         $factory = new Connection\Factory();
         $connection = $factory->create('tcp://localhost:7000');
@@ -179,7 +194,10 @@ class ClientTest extends PredisTestCase
         $this->assertInstanceOf('Predis\Connection\NodeConnectionInterface', $client->getConnection());
         $this->assertSame($connection, $client->getConnection());
 
-        $parameters = $client->getConnection()->getParameters();
+        /** @var NodeConnectionInterface */
+        $connection = $client->getConnection();
+        $parameters = $connection->getParameters();
+
         $this->assertSame($parameters->host, 'localhost');
         $this->assertSame($parameters->port, 7000);
     }
@@ -187,7 +205,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithClusterArgument()
+    public function testConstructorWithClusterArgument(): void
     {
         $cluster = new Connection\Cluster\PredisCluster();
 
@@ -203,7 +221,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithReplicationArgument()
+    public function testConstructorWithReplicationArgument(): void
     {
         $replication = new Connection\Replication\MasterSlaveReplication();
 
@@ -219,12 +237,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithCallableArgument()
+    public function testConstructorWithCallableArgument(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -240,7 +258,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithCallableConnectionInitializerThrowsExceptionOnInvalidReturnType()
+    public function testConstructorWithCallableConnectionInitializerThrowsExceptionOnInvalidReturnType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Callable parameters must return a valid connection');
@@ -248,7 +266,7 @@ class ClientTest extends PredisTestCase
         $wrongType = $this->getMockBuilder('stdClass')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -262,28 +280,36 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithNullAndArrayArgument()
+    public function testConstructorWithNullAndArrayArgument(): void
     {
         $connections = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
 
         $arg2 = array('prefix' => 'prefix:', 'connections' => $connections);
         $client = new Client(null, $arg2);
 
-        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands = $client->getCommandFactory());
-        $this->assertInstanceOf('Predis\Command\Processor\KeyPrefixProcessor', $commands->getProcessor());
-        $this->assertSame('prefix:', $commands->getProcessor()->getPrefix());
+        /** @var CommandFactory */
+        $commands = $client->getCommandFactory();
+        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands);
+
+        /** @var KeyPrefixProcessor */
+        $processor = $commands->getProcessor();
+        $this->assertInstanceOf('Predis\Command\Processor\KeyPrefixProcessor', $processor);
+        $this->assertSame('prefix:', $processor->getPrefix());
     }
 
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayAndOptionReplication()
+    public function testConstructorWithArrayAndOptionReplication(): void
     {
         $arg1 = array('tcp://127.0.0.1:6379?role=master', 'tcp://127.0.0.1:6380?role=slave');
         $arg2 = array('replication' => 'predis');
         $client = new Client($arg1, $arg2);
 
-        $this->assertInstanceOf('Predis\Connection\Replication\ReplicationInterface', $connection = $client->getConnection());
+        /** @var MasterSlaveReplication */
+        $connection = $client->getConnection();
+
+        $this->assertInstanceOf('Predis\Connection\Replication\ReplicationInterface', $connection);
         $this->assertSame('127.0.0.1:6379', (string) $connection->getConnectionByRole('master'));
         $this->assertSame('127.0.0.1:6380', (string) $connection->getConnectionByRole('slave'));
     }
@@ -291,14 +317,14 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testClusterOptionHasPrecedenceOverReplicationOptionAndAggregateOption()
+    public function testClusterOptionHasPrecedenceOverReplicationOptionAndAggregateOption(): void
     {
         $arg1 = array('tcp://host1', 'tcp://host2');
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $fncluster = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fncluster
             ->expects($this->once())
@@ -307,14 +333,14 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue($connection));
 
         $fnreplication = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fnreplication
             ->expects($this->never())
             ->method('__invoke');
 
         $fnaggregate = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fnaggregate
             ->expects($this->never())
@@ -334,14 +360,14 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReplicationOptionHasPrecedenceOverAggregateOption()
+    public function testReplicationOptionHasPrecedenceOverAggregateOption(): void
     {
         $arg1 = array('tcp://host1', 'tcp://host2');
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $fnreplication = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fnreplication
             ->expects($this->once())
@@ -350,7 +376,7 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue($connection));
 
         $fnaggregate = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fnaggregate
             ->expects($this->never())
@@ -367,14 +393,14 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAggregateOptionDoesNotTriggerAggregationInClient()
+    public function testAggregateOptionDoesNotTriggerAggregationInClient(): void
     {
         $arg1 = array('tcp://host1', 'tcp://host2');
 
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $fnaggregate = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $fnaggregate
             ->expects($this->once())
@@ -397,7 +423,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithInvalidArgumentType()
+    public function testConstructorWithInvalidArgumentType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid type for connection parameters');
@@ -408,7 +434,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithInvalidOptionType()
+    public function testConstructorWithInvalidOptionType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid type for client options');
@@ -419,7 +445,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectAndDisconnect()
+    public function testConnectAndDisconnect(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -437,7 +463,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedChecksConnectionState()
+    public function testIsConnectedChecksConnectionState(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -451,7 +477,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testQuitIsAliasForDisconnect()
+    public function testQuitIsAliasForDisconnect(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -465,7 +491,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreatesNewCommandUsingSpecifiedCommandFactory()
+    public function testCreatesNewCommandUsingSpecifiedCommandFactory(): void
     {
         $ping = $this->getCommandFactory()->create('ping', array());
 
@@ -483,7 +509,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteCommandReturnsParsedResponses()
+    public function testExecuteCommandReturnsParsedResponses(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -511,7 +537,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteCommandThrowsExceptionOnRedisError()
+    public function testExecuteCommandThrowsExceptionOnRedisError(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -532,7 +558,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteCommandReturnsErrorResponseOnRedisError()
+    public function testExecuteCommandReturnsErrorResponseOnRedisError(): void
     {
         $ping = $this->getCommandFactory()->create('ping', array());
         $expectedResponse = new Response\Error('ERR Operation against a key holding the wrong kind of value');
@@ -552,7 +578,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCallingRedisCommandExecutesInstanceOfCommand()
+    public function testCallingRedisCommandExecutesInstanceOfCommand(): void
     {
         $ping = $this->getCommandFactory()->create('ping', array());
 
@@ -571,8 +597,10 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue($ping));
 
         $options = array('commands' => $commands);
+
+        /** @var ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(null)
+            ->onlyMethods(array())
             ->setConstructorArgs(array($connection, $options))
             ->getMock();
 
@@ -582,7 +610,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCallingRedisCommandThrowsExceptionOnServerError()
+    public function testCallingRedisCommandThrowsExceptionOnServerError(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -603,7 +631,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCallingRedisCommandReturnsErrorResponseOnRedisError()
+    public function testCallingRedisCommandReturnsErrorResponseOnRedisError(): void
     {
         $expectedResponse = new Response\Error('ERR Operation against a key holding the wrong kind of value');
 
@@ -623,7 +651,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRawCommand()
+    public function testRawCommand(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -655,7 +683,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRawCommandNeverAppliesPrefix()
+    public function testRawCommandNeverAppliesPrefix(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
         $connection
@@ -678,7 +706,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRawCommandNeverThrowsExceptions()
+    public function testRawCommandNeverThrowsExceptions(): void
     {
         $message = 'ERR Mock error response';
         $response = new Response\Error($message);
@@ -699,7 +727,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnNonRegisteredRedisCommand()
+    public function testThrowsExceptionOnNonRegisteredRedisCommand(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage("Command `INVALIDCOMMAND` is not a registered Redis command");
@@ -711,10 +739,11 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodReturnsInstanceOfSubclass()
+    public function testGetClientByMethodReturnsInstanceOfSubclass(): void
     {
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(null)
+            ->onlyMethods(array())
             ->setConstructorArgs(array(
                 array('tcp://host1?alias=node01', 'tcp://host2?alias=node02'),
                 array('cluster' => 'predis'),
@@ -728,12 +757,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionById()
+    public function testGetClientByMethodSupportsSelectingConnectionById(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionById'))
+            ->onlyMethods(array('getConnectionById'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -751,7 +780,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodThrowsExceptionSelectingConnectionByUnknownId()
+    public function testGetClientByMethodThrowsExceptionSelectingConnectionByUnknownId(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Cannot find a connection by id matching `127.0.0.1:7000`');
@@ -770,12 +799,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionByAlias()
+    public function testGetClientByMethodSupportsSelectingConnectionByAlias(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionByAlias'))
+            ->addMethods(array('getConnectionByAlias'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -793,12 +822,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionByKey()
+    public function testGetClientByMethodSupportsSelectingConnectionByKey(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionByKey'))
+            ->addMethods(array('getConnectionByKey'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -816,12 +845,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionBySlot()
+    public function testGetClientByMethodSupportsSelectingConnectionBySlot(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionBySlot'))
+            ->addMethods(array('getConnectionBySlot'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -839,12 +868,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionByRole()
+    public function testGetClientByMethodSupportsSelectingConnectionByRole(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionByRole'))
+            ->addMethods(array('getConnectionByRole'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -862,13 +891,13 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodSupportsSelectingConnectionByCommand()
+    public function testGetClientByMethodSupportsSelectingConnectionByCommand(): void
     {
         $command = \Predis\Command\RawCommand::create('GET', 'key');
         $connection = $this->getMockBuilder('Predis\Connection\ConnectionInterface')->getMock();
 
         $aggregate = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')
-            ->setMethods(array('getConnectionByCommand'))
+            ->onlyMethods(array('getConnectionByCommand'))
             ->getMockForAbstractClass();
         $aggregate
             ->expects($this->once())
@@ -886,7 +915,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodThrowsExceptionWhenSelectingConnectionByUnknownType()
+    public function testGetClientByMethodThrowsExceptionWhenSelectingConnectionByUnknownType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid selector type: `unknown`');
@@ -899,7 +928,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetClientByMethodThrowsExceptionWhenConnectionDoesNotSupportSelectorType()
+    public function testGetClientByMethodThrowsExceptionWhenConnectionDoesNotSupportSelectorType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Selecting connection by id is not supported by Predis\Connection\StreamConnection');
@@ -912,7 +941,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithoutArgumentsReturnsPipeline()
+    public function testPipelineWithoutArgumentsReturnsPipeline(): void
     {
         $client = new Client();
 
@@ -922,7 +951,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithArrayReturnsPipeline()
+    public function testPipelineWithArrayReturnsPipeline(): void
     {
         $client = new Client();
 
@@ -934,10 +963,10 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithCallableExecutesPipeline()
+    public function testPipelineWithCallableExecutesPipeline(): void
     {
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -951,7 +980,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubLoopWithoutArgumentsReturnsPubSubConsumer()
+    public function testPubSubLoopWithoutArgumentsReturnsPubSubConsumer(): void
     {
         $client = new Client();
 
@@ -961,7 +990,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubLoopWithArrayReturnsPubSubConsumerWithOptions()
+    public function testPubSubLoopWithArrayReturnsPubSubConsumerWithOptions(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $options = array('subscribe' => 'channel');
@@ -979,7 +1008,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubLoopWithArrayAndCallableExecutesPubSub()
+    public function testPubSubLoopWithArrayAndCallableExecutesPubSub(): void
     {
         // NOTE: we use a subscribe count of 0 in the message payload to trick
         //       the context and forcing it to be closed since there are no more
@@ -991,7 +1020,7 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue(array('subscribe', 'channel', 0)));
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -1004,7 +1033,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubLoopWithCallableReturningFalseStopsPubSubConsumer()
+    public function testPubSubLoopWithCallableReturningFalseStopsPubSubConsumer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -1021,7 +1050,7 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue(array('unsubscribe', 'channel', 0)));
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->at(0))
@@ -1036,7 +1065,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testTransactionWithoutArgumentsReturnsMultiExec()
+    public function testTransactionWithoutArgumentsReturnsMultiExec(): void
     {
         $client = new Client();
 
@@ -1046,7 +1075,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testTransactionWithArrayReturnsMultiExecTransactionWithOptions()
+    public function testTransactionWithArrayReturnsMultiExecTransactionWithOptions(): void
     {
         $options = array('cas' => true, 'retry' => 3);
 
@@ -1067,7 +1096,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testTransactionWithArrayAndCallableExecutesMultiExec()
+    public function testTransactionWithArrayAndCallableExecutesMultiExec(): void
     {
         // We use CAS here as we don't care about the actual MULTI/EXEC context.
         $options = array('cas' => true, 'retry' => 3);
@@ -1079,7 +1108,7 @@ class ClientTest extends PredisTestCase
             ->will($this->returnValue(new Response\Status('QUEUED')));
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -1093,7 +1122,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMonitorReturnsMonitorConsumer()
+    public function testMonitorReturnsMonitorConsumer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $client = new Client($connection);
@@ -1104,7 +1133,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testClientResendScriptCommandUsingEvalOnNoScriptErrors()
+    public function testClientResendScriptCommandUsingEvalOnNoScriptErrors(): void
     {
         $command = $this->getMockForAbstractClass('Predis\Command\ScriptCommand', array(), '', true, true, true, array('parseResponse'));
         $command
@@ -1137,7 +1166,7 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIteratorWithTraversableConnections()
+    public function testGetIteratorWithTraversableConnections(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6381');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382');
@@ -1151,6 +1180,7 @@ class ClientTest extends PredisTestCase
 
         $client = new Client($aggregate);
 
+        /** @var \Iterator */
         $iterator = $client->getIterator();
 
         $this->assertInstanceOf('\Predis\Client', $nodeClient = $iterator->current());
@@ -1173,11 +1203,12 @@ class ClientTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIteratorWithNonTraversableConnectionNoException()
+    public function testGetIteratorWithNonTraversableConnectionNoException(): void
     {
         $connection = $this->getMockConnection('tcp://127.0.0.1:6381');
         $client = new Client($connection);
 
+        /** @var \Iterator */
         $iterator = $client->getIterator();
 
         $this->assertInstanceOf('\Predis\Client', $nodeClient = $iterator->current());
@@ -1196,7 +1227,7 @@ class ClientTest extends PredisTestCase
      *
      * @return string URI string.
      */
-    protected function getParametersString(array $parameters)
+    protected function getParametersString(array $parameters): string
     {
         $defaults = $this->getDefaultParametersArray();
 
@@ -1215,18 +1246,18 @@ class ClientTest extends PredisTestCase
     }
 
     /**
-     * Returns a mock callable simulating an aggregate connection initializer.
+     * Returns a mock object simulating an aggregate connection initializer.
      *
-     * @param mixed $parameters Expected connection parameters
+     * @param ParametersInterface|array|string $parameters Expected connection parameters
      *
-     * @return callable
+     * @return callable|MockObject
      */
     protected function getAggregateInitializer($parameters)
     {
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())

--- a/tests/Predis/Cluster/Distributor/EmptyRingExceptionTest.php
+++ b/tests/Predis/Cluster/Distributor/EmptyRingExceptionTest.php
@@ -21,10 +21,11 @@ class EmptyRingExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionMessage()
+    public function testExceptionMessage(): void
     {
         $this->expectException('Predis\Cluster\Distributor\EmptyRingException');
         $this->expectExceptionMessage('Empty Ring');
+
         throw new EmptyRingException('Empty Ring');
     }
 }

--- a/tests/Predis/Cluster/Distributor/HashRingTest.php
+++ b/tests/Predis/Cluster/Distributor/HashRingTest.php
@@ -204,7 +204,7 @@ class HashRingTest extends PredisDistributorTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($node)
-            ->will($this->returnValue($node));
+            ->willReturn($node);
 
         $distributor = new HashRing(HashRing::DEFAULT_REPLICAS, $callable);
         $distributor->add($node);

--- a/tests/Predis/Cluster/Distributor/HashRingTest.php
+++ b/tests/Predis/Cluster/Distributor/HashRingTest.php
@@ -19,7 +19,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * {@inheritdoc}
      */
-    public function getDistributorInstance()
+    public function getDistributorInstance(): DistributorInterface
     {
         return new HashRing();
     }
@@ -27,8 +27,9 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testHash()
+    public function testHash(): void
     {
+        /** @var HashGeneratorInterface */
         $ring = $this->getDistributorInstance();
 
         $this->assertEquals(crc32('foobar'), $ring->hash('foobar'));
@@ -37,7 +38,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testSingleNodeInRing()
+    public function testSingleNodeInRing(): void
     {
         $node = '127.0.0.1:7000';
 
@@ -53,7 +54,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testMultipleNodesInRing()
+    public function testMultipleNodesInRing(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -92,7 +93,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testSubsequendAddAndRemoveFromRing()
+    public function testSubsequendAddAndRemoveFromRing(): void
     {
         $ring = $this->getDistributorInstance();
 
@@ -128,7 +129,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetByValue()
+    public function testGetByValue(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -147,7 +148,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetByHash()
+    public function testGetByHash(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -166,7 +167,7 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetBySlot()
+    public function testGetBySlot(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -192,11 +193,11 @@ class HashRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testCallbackToGetNodeHash()
+    public function testCallbackToGetNodeHash(): void
     {
         $node = '127.0.0.1:7000';
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
 
         $callable

--- a/tests/Predis/Cluster/Distributor/KetamaRingTest.php
+++ b/tests/Predis/Cluster/Distributor/KetamaRingTest.php
@@ -205,7 +205,7 @@ class KetamaRingTest extends PredisDistributorTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($node)
-            ->will($this->returnValue($node));
+            ->willReturn($node);
 
         $distributor = new KetamaRing($callable);
         $distributor->add($node);

--- a/tests/Predis/Cluster/Distributor/KetamaRingTest.php
+++ b/tests/Predis/Cluster/Distributor/KetamaRingTest.php
@@ -19,7 +19,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * {@inheritdoc}
      */
-    public function getDistributorInstance()
+    public function getDistributorInstance(): DistributorInterface
     {
         return new KetamaRing();
     }
@@ -27,8 +27,9 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testHash()
+    public function testHash(): void
     {
+        /** @var HashGeneratorInterface */
         $ring = $this->getDistributorInstance();
         list(, $hash) = unpack('V', md5('foobar', true));
 
@@ -38,7 +39,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testSingleNodeInRing()
+    public function testSingleNodeInRing(): void
     {
         $node = '127.0.0.1:7000';
 
@@ -54,7 +55,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testMultipleNodesInRing()
+    public function testMultipleNodesInRing(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -93,7 +94,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testSubsequendAddAndRemoveFromRing()
+    public function testSubsequendAddAndRemoveFromRing(): void
     {
         $ring = $this->getDistributorInstance();
 
@@ -129,7 +130,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetByValue()
+    public function testGetByValue(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -148,7 +149,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetByHash()
+    public function testGetByHash(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -167,7 +168,7 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testGetBySlot()
+    public function testGetBySlot(): void
     {
         $ring = $this->getSampleDistribution(array(
             '127.0.0.1:7000',
@@ -193,11 +194,11 @@ class KetamaRingTest extends PredisDistributorTestCase
     /**
      * @group disconnected
      */
-    public function testCallbackToGetNodeHash()
+    public function testCallbackToGetNodeHash(): void
     {
         $node = '127.0.0.1:7000';
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
 
         $callable

--- a/tests/Predis/Cluster/Hash/CRC16Test.php
+++ b/tests/Predis/Cluster/Hash/CRC16Test.php
@@ -21,7 +21,7 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHashGeneration()
+    public function testHashGeneration(): void
     {
         $crc16 = new CRC16();
 
@@ -40,7 +40,7 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHashGenerationWithIntegerValues()
+    public function testHashGenerationWithIntegerValues(): void
     {
         $crc16 = new CRC16();
 

--- a/tests/Predis/Cluster/Hash/PhpiredisCRC16Test.php
+++ b/tests/Predis/Cluster/Hash/PhpiredisCRC16Test.php
@@ -23,7 +23,7 @@ class PhpiredisCRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHashGeneration()
+    public function testHashGeneration(): void
     {
         $crc16 = new PhpiredisCRC16();
 

--- a/tests/Predis/Cluster/PredisStrategyTest.php
+++ b/tests/Predis/Cluster/PredisStrategyTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Cluster;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  *
@@ -21,7 +22,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsKeyTags()
+    public function testSupportsKeyTags(): void
     {
         // NOTE: 32 and 64 bits PHP runtimes can produce different hash values.
         $expected = PHP_INT_SIZE == 4 ? -1954026732 : 2340940564;
@@ -43,8 +44,9 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportedCommands()
+    public function testSupportedCommands(): void
     {
+        /** @var PredisStrategy */
         $strategy = $this->getClusterStrategy();
 
         $this->assertSame($this->getExpectedCommands(), $strategy->getSupportedCommands());
@@ -53,7 +55,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsNullOnUnsupportedCommand()
+    public function testReturnsNullOnUnsupportedCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $command = $this->getCommandFactory()->create('ping');
@@ -64,7 +66,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFirstKeyCommands()
+    public function testFirstKeyCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -79,7 +81,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAllKeysCommands()
+    public function testAllKeysCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -94,7 +96,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInterleavedKeysCommands()
+    public function testInterleavedKeysCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -109,7 +111,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForSortCommand()
+    public function testKeysForSortCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -127,7 +129,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForBlockingListCommands()
+    public function testKeysForBlockingListCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -142,7 +144,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForZsetAggregationCommands()
+    public function testKeysForZsetAggregationCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -157,7 +159,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForBitOpCommand()
+    public function testKeysForBitOpCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -172,7 +174,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForGeoradiusCommand()
+    public function testKeysForGeoradiusCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -188,7 +190,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForGeoradiusByMemberCommand()
+    public function testKeysForGeoradiusByMemberCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -204,7 +206,7 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForEvalCommand()
+    public function testKeysForEvalCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -219,13 +221,14 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForScriptCommand()
+    public function testKeysForScriptCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $arguments = array('{key}:1', '{key}:2', 'value1', 'value2');
 
+        /** @var \Predis\Command\CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -243,13 +246,14 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnsettingCommandHandler()
+    public function testUnsettingCommandHandler(): void
     {
+        /** @var PredisStrategy */
         $strategy = $this->getClusterStrategy();
-        $commands = $this->getCommandFactory();
-
         $strategy->setCommandHandler('set');
         $strategy->setCommandHandler('get', null);
+
+        $commands = $this->getCommandFactory();
 
         $command = $commands->create('set', array('key', 'value'));
         $this->assertNull($strategy->getSlot($command));
@@ -261,13 +265,10 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSettingCustomCommandHandler()
+    public function testSettingCustomCommandHandler(): void
     {
-        $strategy = $this->getClusterStrategy();
-        $commands = $this->getCommandFactory();
-
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -275,9 +276,13 @@ class PredisStrategyTest extends PredisTestCase
             ->with($this->isInstanceOf('Predis\Command\CommandInterface'))
             ->will($this->returnValue('key'));
 
+        /** @var PredisStrategy */
+        $strategy = $this->getClusterStrategy();
         $strategy->setCommandHandler('get', $callable);
 
+        $commands = $this->getCommandFactory();
         $command = $commands->create('get', array('key'));
+
         $this->assertNotNull($strategy->getSlot($command));
     }
 
@@ -290,7 +295,7 @@ class PredisStrategyTest extends PredisTestCase
      *
      * @return StrategyInterface
      */
-    protected function getClusterStrategy()
+    protected function getClusterStrategy(): StrategyInterface
     {
         $strategy = new PredisStrategy();
 
@@ -303,11 +308,11 @@ class PredisStrategyTest extends PredisTestCase
     /**
      * Returns the list of expected supported commands.
      *
-     * @param string $type Optional type of command (based on its keys)
+     * @param ?string $type Optional type of command (based on its keys)
      *
      * @return array
      */
-    protected function getExpectedCommands($type = null)
+    protected function getExpectedCommands(?string $type = null): array
     {
         $commands = array(
             /* commands operating on the key space */
@@ -444,7 +449,7 @@ class PredisStrategyTest extends PredisTestCase
         );
 
         if (isset($type)) {
-            $commands = array_filter($commands, function ($expectedType) use ($type) {
+            $commands = array_filter($commands, function (string $expectedType) use ($type) {
                 return $expectedType === $type;
             });
         }

--- a/tests/Predis/Cluster/PredisStrategyTest.php
+++ b/tests/Predis/Cluster/PredisStrategyTest.php
@@ -233,11 +233,11 @@ class PredisStrategyTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue('return true'));
+            ->willReturn('return true');
         $command
             ->expects($this->exactly(2))
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
         $command->setArguments($arguments);
 
         $this->assertNotNull($strategy->getSlot($command), "Script Command [{$command->getId()}]");
@@ -274,7 +274,7 @@ class PredisStrategyTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Command\CommandInterface'))
-            ->will($this->returnValue('key'));
+            ->willReturn('key');
 
         /** @var PredisStrategy */
         $strategy = $this->getClusterStrategy();

--- a/tests/Predis/Cluster/RedisStrategyTest.php
+++ b/tests/Predis/Cluster/RedisStrategyTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Cluster;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  *
@@ -21,7 +22,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsKeyTags()
+    public function testSupportsKeyTags(): void
     {
         $strategy = $this->getClusterStrategy();
 
@@ -41,8 +42,9 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportedCommands()
+    public function testSupportedCommands(): void
     {
+        /** @var RedisStrategy */
         $strategy = $this->getClusterStrategy();
 
         $this->assertSame($this->getExpectedCommands(), $strategy->getSupportedCommands());
@@ -51,7 +53,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsNullOnUnsupportedCommand()
+    public function testReturnsNullOnUnsupportedCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $command = $this->getCommandFactory()->create('ping');
@@ -62,7 +64,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFirstKeyCommands()
+    public function testFirstKeyCommands(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -77,7 +79,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAllKeysCommandsWithOneKey()
+    public function testAllKeysCommandsWithOneKey(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -92,7 +94,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAllKeysCommandsWithMoreKeys()
+    public function testAllKeysCommandsWithMoreKeys(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -107,7 +109,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInterleavedKeysCommandsWithOneKey()
+    public function testInterleavedKeysCommandsWithOneKey(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -122,7 +124,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInterleavedKeysCommandsWithMoreKeys()
+    public function testInterleavedKeysCommandsWithMoreKeys(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -137,7 +139,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForSortCommand()
+    public function testKeysForSortCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -155,7 +157,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForBlockingListCommandsWithOneKey()
+    public function testKeysForBlockingListCommandsWithOneKey(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -170,7 +172,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForBlockingListCommandsWithMoreKeys()
+    public function testKeysForBlockingListCommandsWithMoreKeys(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -185,7 +187,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForGeoradiusCommand()
+    public function testKeysForGeoradiusCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -202,7 +204,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForGeoradiusByMemberCommand()
+    public function testKeysForGeoradiusByMemberCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -219,7 +221,7 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForEvalCommand()
+    public function testKeysForEvalCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $commands = $this->getCommandFactory();
@@ -234,13 +236,14 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testKeysForScriptCommand()
+    public function testKeysForScriptCommand(): void
     {
         $strategy = $this->getClusterStrategy();
         $arguments = array('key:1', 'value1');
 
+        /** @var \Predis\Command\CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -258,14 +261,14 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnsettingCommandHandler()
+    public function testUnsettingCommandHandler(): void
     {
+        /** @var RedisStrategy */
         $strategy = $this->getClusterStrategy();
-        $commands = $this->getCommandFactory();
-
         $strategy->setCommandHandler('set');
         $strategy->setCommandHandler('get', null);
 
+        $commands = $this->getCommandFactory();
         $command = $commands->create('set', array('key', 'value'));
         $this->assertNull($strategy->getSlot($command));
 
@@ -276,13 +279,10 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSettingCustomCommandHandler()
+    public function testSettingCustomCommandHandler(): void
     {
-        $strategy = $this->getClusterStrategy();
-        $commands = $this->getCommandFactory();
-
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -290,16 +290,20 @@ class RedisStrategyTest extends PredisTestCase
             ->with($this->isInstanceOf('Predis\Command\CommandInterface'))
             ->will($this->returnValue('key'));
 
+        /** @var RedisStrategy */
+        $strategy = $this->getClusterStrategy();
         $strategy->setCommandHandler('get', $callable);
 
+        $commands = $this->getCommandFactory();
         $command = $commands->create('get', array('key'));
+
         $this->assertNotNull($strategy->getSlot($command));
     }
 
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnGetDistributorMethod()
+    public function testThrowsExceptionOnGetDistributorMethod(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('Predis\Cluster\RedisStrategy does not provide an external distributor');
@@ -317,7 +321,7 @@ class RedisStrategyTest extends PredisTestCase
      *
      * @return StrategyInterface
      */
-    protected function getClusterStrategy()
+    protected function getClusterStrategy(): StrategyInterface
     {
         $strategy = new RedisStrategy();
 
@@ -327,11 +331,11 @@ class RedisStrategyTest extends PredisTestCase
     /**
      * Returns the list of expected supported commands.
      *
-     * @param string $type Optional type of command (based on its keys)
+     * @param ?string $type Optional type of command (based on its keys)
      *
      * @return array
      */
-    protected function getExpectedCommands($type = null)
+    protected function getExpectedCommands(?string $type = null): array
     {
         $commands = array(
             /* commands operating on the key space */
@@ -468,7 +472,7 @@ class RedisStrategyTest extends PredisTestCase
         );
 
         if (isset($type)) {
-            $commands = array_filter($commands, function ($expectedType) use ($type) {
+            $commands = array_filter($commands, function (string $expectedType) use ($type) {
                 return $expectedType === $type;
             });
         }

--- a/tests/Predis/Cluster/RedisStrategyTest.php
+++ b/tests/Predis/Cluster/RedisStrategyTest.php
@@ -248,11 +248,11 @@ class RedisStrategyTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue('return true'));
+            ->willReturn('return true');
         $command
             ->expects($this->exactly(2))
             ->method('getKeysCount')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
         $command->setArguments($arguments);
 
         $this->assertNotNull($strategy->getSlot($command), "Script Command [{$command->getId()}]");
@@ -288,7 +288,7 @@ class RedisStrategyTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Command\CommandInterface'))
-            ->will($this->returnValue('key'));
+            ->willReturn('key');
 
         /** @var RedisStrategy */
         $strategy = $this->getClusterStrategy();

--- a/tests/Predis/Cluster/SlotMapTest.php
+++ b/tests/Predis/Cluster/SlotMapTest.php
@@ -130,7 +130,7 @@ class SlotMapTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('__toString')
-            ->will($this->returnValue('127.0.0.1:6379'));
+            ->willReturn('127.0.0.1:6379');
 
         $slotmap->setSlots(10, 10, $connection);
 
@@ -433,7 +433,7 @@ class SlotMapTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('__toString')
-            ->will($this->returnValue('127.0.0.1:6379'));
+            ->willReturn('127.0.0.1:6379');
 
         $this->assertSame($connection, $slotmap[0] = $connection);
         $this->assertSame('127.0.0.1:6379', $slotmap[0]);

--- a/tests/Predis/Cluster/SlotMapTest.php
+++ b/tests/Predis/Cluster/SlotMapTest.php
@@ -21,7 +21,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsValidReturnsTrueOnValidSlot()
+    public function testIsValidReturnsTrueOnValidSlot(): void
     {
         $this->assertTrue(SlotMap::isValid(0));
         $this->assertTrue(SlotMap::isValid(16383));
@@ -33,7 +33,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsValidReturnsFalseOnInvalidSlot()
+    public function testIsValidReturnsFalseOnInvalidSlot(): void
     {
         $this->assertFalse(SlotMap::isValid(-1));
         $this->assertFalse(SlotMap::isValid(16384));
@@ -42,7 +42,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsValidRangeReturnsTrueOnValidSlotRange()
+    public function testIsValidRangeReturnsTrueOnValidSlotRange(): void
     {
         $this->assertTrue(SlotMap::isValidRange(0, 16383));
         $this->assertTrue(SlotMap::isValidRange(2000, 2999));
@@ -52,7 +52,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsValidRangeReturnsFalseOnInvalidSlotRange()
+    public function testIsValidRangeReturnsFalseOnInvalidSlotRange(): void
     {
         $this->assertFalse(SlotMap::isValidRange(0, 16384));
         $this->assertFalse(SlotMap::isValidRange(-1, 16383));
@@ -63,7 +63,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToArrayReturnsEmptyArrayOnEmptySlotMap()
+    public function testToArrayReturnsEmptyArrayOnEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -73,7 +73,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetSlotsAssignsSpecifiedNodeToSlotRange()
+    public function testSetSlotsAssignsSpecifiedNodeToSlotRange(): void
     {
         $slotmap = new SlotMap();
 
@@ -93,7 +93,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetSlotsOverwritesSlotRange()
+    public function testSetSlotsOverwritesSlotRange(): void
     {
         $slotmap = new SlotMap();
 
@@ -110,7 +110,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetSlotsAssignsSingleSlotWhenFirstAndLastSlotMatch()
+    public function testSetSlotsAssignsSingleSlotWhenFirstAndLastSlotMatch(): void
     {
         $slotmap = new SlotMap();
 
@@ -122,7 +122,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetSlotsCastsValueToString()
+    public function testSetSlotsCastsValueToString(): void
     {
         $slotmap = new SlotMap();
 
@@ -140,7 +140,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetSlotsThrowsExceptionOnInvalidSlotRange()
+    public function testSetSlotsThrowsExceptionOnInvalidSlotRange(): void
     {
         $this->expectException('OutOfBoundsException');
         $this->expectExceptionMessage('Invalid slot range 0-16384 for `127.0.0.1:6379`');
@@ -153,7 +153,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetSlotsReturnsEmptyArrayOnEmptySlotMap()
+    public function testGetSlotsReturnsEmptyArrayOnEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -163,7 +163,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetSlotsReturnsDictionaryOfSlotsWithAssignedNodes()
+    public function testGetSlotsReturnsDictionaryOfSlotsWithAssignedNodes(): void
     {
         $slotmap = new SlotMap();
 
@@ -184,7 +184,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetSlotsReturnsEmptyArrayOnEmptySlotRange()
+    public function testGetSlotsReturnsEmptyArrayOnEmptySlotRange(): void
     {
         $slotmap = new SlotMap();
 
@@ -197,7 +197,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetSlotsThrowsExceptionOnInvalidSlotRange()
+    public function testGetSlotsThrowsExceptionOnInvalidSlotRange(): void
     {
         $this->expectException('OutOfBoundsException');
         $this->expectExceptionMessage('Invalid slot range 0-16384');
@@ -210,7 +210,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsEmptyReturnsTrueOnEmptySlotMap()
+    public function testIsEmptyReturnsTrueOnEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -220,7 +220,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsEmptyReturnsFalseOnNonEmptySlotMap()
+    public function testIsEmptyReturnsFalseOnNonEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -232,7 +232,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCountReturnsZeroOnEmptySlotMap()
+    public function testCountReturnsZeroOnEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -242,7 +242,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCountReturnsAssignedSlotsInSlotMap()
+    public function testCountReturnsAssignedSlotsInSlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -259,7 +259,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testResetEmptiesSlotMap()
+    public function testResetEmptiesSlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -277,7 +277,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetNodesReturnsEmptyArrayOnEmptySlotMap()
+    public function testGetNodesReturnsEmptyArrayOnEmptySlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -287,7 +287,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetNodesReturnsArrayOfNodesInSlotMap()
+    public function testGetNodesReturnsArrayOfNodesInSlotMap(): void
     {
         $slotmap = new SlotMap();
 
@@ -301,7 +301,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetExistsReturnsTrueOnAssignedSlot()
+    public function testOffsetExistsReturnsTrueOnAssignedSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -314,7 +314,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetExistsReturnsFalseOnAssignedSlot()
+    public function testOffsetExistsReturnsFalseOnAssignedSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -326,7 +326,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetExistsReturnsFalseOnInvalidSlot()
+    public function testOffsetExistsReturnsFalseOnInvalidSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -339,7 +339,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetGetReturnsNodeOfAssignedSlot()
+    public function testOffsetGetReturnsNodeOfAssignedSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -355,7 +355,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetGetReturnsNullOnUnassignedSlot()
+    public function testOffsetGetReturnsNullOnUnassignedSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -367,7 +367,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetGetReturnsNullOnInvalidSlot()
+    public function testOffsetGetReturnsNullOnInvalidSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -380,7 +380,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetUnsetRemovesSlotAssignment()
+    public function testOffsetUnsetRemovesSlotAssignment(): void
     {
         $slotmap = new SlotMap();
 
@@ -394,7 +394,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetUnsetDoesNotDoAnythingOnUnassignedSlot()
+    public function testOffsetUnsetDoesNotDoAnythingOnUnassignedSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -408,7 +408,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetSetAssignsNodeToSlot()
+    public function testOffsetSetAssignsNodeToSlot(): void
     {
         $slotmap = new SlotMap();
 
@@ -425,7 +425,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetSetCastsValueToString()
+    public function testOffsetSetCastsValueToString(): void
     {
         $slotmap = new SlotMap();
 
@@ -442,7 +442,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetSetThrowsExceptionOnInvalidSlot()
+    public function testOffsetSetThrowsExceptionOnInvalidSlot(): void
     {
         $this->expectException('OutOfBoundsException');
         $this->expectExceptionMessage('Invalid slot 16384 for `127.0.0.1:6379`');
@@ -455,7 +455,7 @@ class SlotMapTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIteratorReturnsIteratorOverSlotMap()
+    public function testGetIteratorReturnsIteratorOverSlotMap(): void
     {
         $slotmap = new SlotMap();
 

--- a/tests/Predis/Collection/Iterator/HashKeyTest.php
+++ b/tests/Predis/Collection/Iterator/HashKeyTest.php
@@ -30,14 +30,14 @@ class HashKeyTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         new HashKey($client, 'key:hash');
     }
@@ -55,14 +55,14 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('hscan')
             ->with('key:hash', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array(),
-            )));
+            ));
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -85,14 +85,14 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('hscan')
             ->with('key:hash', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array(1 => 'a', 2 => 'b', 3 => 100, 'foo' => 'bar'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -133,14 +133,14 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('hscan')
             ->with('key:hash', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd', 'field:3rd' => 'value:3rd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -176,7 +176,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -226,7 +226,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -271,7 +271,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -328,7 +328,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -366,7 +366,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -411,7 +411,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -449,7 +449,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -494,7 +494,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -532,7 +532,7 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('hscan')
@@ -577,14 +577,14 @@ class HashKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->exactly(2))
             ->method('hscan')
             ->with('key:hash', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 

--- a/tests/Predis/Collection/Iterator/HashKeyTest.php
+++ b/tests/Predis/Collection/Iterator/HashKeyTest.php
@@ -178,19 +178,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array())
-            ->will($this->returnValue(
-                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 2, array())
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array()),
+                array('key:hash', 2, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd')),
                 array(0, array('field:3rd' => 'value:3rd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -228,19 +225,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array())
-            ->will($this->returnValue(
-                array(4, array())
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 4, array())
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array()),
+                array('key:hash', 4, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(4, array()),
                 array(0, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -273,26 +267,18 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(3))
             ->method('hscan')
-            ->with('key:hash', 0, array())
-            ->will($this->returnValue(
-                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 2, array())
-            ->will($this->returnValue(
-                array(5, array())
-            ));
-        $client
-            ->expects($this->at(3))
-            ->method('hscan')
-            ->with('key:hash', 5, array())
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array()),
+                array('key:hash', 2, array()),
+                array('key:hash', 5, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd')),
+                array(5, array()),
                 array(0, array('field:3rd' => 'value:3rd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash');
 
@@ -330,12 +316,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array('MATCH' => 'field:*'))
-            ->will($this->returnValue(
-                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
+            ->withConsecutive(
+                array('key:hash', 0, array('MATCH' => 'field:*')),
+                array('key:hash', 2, array('MATCH' => 'field:*'))
+            )
+            ->willReturn(
+                array(2, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd')),
+                array(0, array())
+            );
 
         $iterator = new HashKey($client, 'key:hash', 'field:*');
 
@@ -368,19 +358,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array('MATCH' => 'field:*'))
-            ->will($this->returnValue(
-                array(1, array('field:1st' => 'value:1st'))
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 1, array('MATCH' => 'field:*'))
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array('MATCH' => 'field:*')),
+                array('key:hash', 1, array('MATCH' => 'field:*'))
+            )
+            ->willReturn(
+                array(1, array('field:1st' => 'value:1st')),
                 array(0, array('field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash', 'field:*');
 
@@ -413,12 +400,14 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('hscan')
-            ->with('key:hash', 0, array('COUNT' => 2))
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array('COUNT' => 2))
+            )
+            ->willReturn(
                 array(0, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash', null, 2);
 
@@ -451,19 +440,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array('COUNT' => 1))
-            ->will($this->returnValue(
-                array(1, array('field:1st' => 'value:1st'))
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 1, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array('COUNT' => 1)),
+                array('key:hash', 1, array('COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('field:1st' => 'value:1st')),
                 array(0, array('field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash', null, 1);
 
@@ -496,12 +482,14 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once(1))
             ->method('hscan')
-            ->with('key:hash', 0, array('MATCH' => 'field:*', 'COUNT' => 2))
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array('MATCH' => 'field:*', 'COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('field:1st' => 'value:1st', 'field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash', 'field:*', 2);
 
@@ -534,19 +522,16 @@ class HashKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('hscan')
-            ->with('key:hash', 0, array('MATCH' => 'field:*', 'COUNT' => 1))
-            ->will($this->returnValue(
-                array(1, array('field:1st' => 'value:1st'))
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('hscan')
-            ->with('key:hash', 1, array('MATCH' => 'field:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:hash', 0, array('MATCH' => 'field:*', 'COUNT' => 1)),
+                array('key:hash', 1, array('MATCH' => 'field:*', 'COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('field:1st' => 'value:1st')),
                 array(0, array('field:2nd' => 'value:2nd'))
-            ));
+            );
 
         $iterator = new HashKey($client, 'key:hash', 'field:*', 1);
 

--- a/tests/Predis/Collection/Iterator/HashKeyTest.php
+++ b/tests/Predis/Collection/Iterator/HashKeyTest.php
@@ -21,7 +21,7 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnMissingCommand()
+    public function testThrowsExceptionOnMissingCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'HSCAN' is not supported by the current command factory.");
@@ -32,6 +32,7 @@ class HashKeyTest extends PredisTestCase
             ->method('supports')
             ->will($this->returnValue(false));
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
@@ -44,10 +45,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithNoResults()
+    public function testIterationWithNoResults(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -72,10 +75,12 @@ class HashKeyTest extends PredisTestCase
      * @see https://github.com/predis/predis/issues/331
      * @group disconnected
      */
-    public function testIterationWithIntegerFields()
+    public function testIterationWithIntegerFields(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -118,10 +123,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnSingleFetch()
+    public function testIterationOnSingleFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -159,10 +166,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetches()
+    public function testIterationOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -207,10 +216,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInFirstFetch()
+    public function testIterationOnMultipleFetchesAndHoleInFirstFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -250,10 +261,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInMidFetch()
+    public function testIterationOnMultipleFetchesAndHoleInMidFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -305,10 +318,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatch()
+    public function testIterationWithOptionMatch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -341,10 +356,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatchOnMultipleFetches()
+    public function testIterationWithOptionMatchOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -384,10 +401,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCount()
+    public function testIterationWithOptionCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -420,10 +439,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCountOnMultipleFetches()
+    public function testIterationWithOptionCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -463,10 +484,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCount()
+    public function testIterationWithOptionsMatchAndCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -499,10 +522,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCountOnMultipleFetches()
+    public function testIterationWithOptionsMatchAndCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -542,10 +567,12 @@ class HashKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationRewindable()
+    public function testIterationRewindable(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'hscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('hscan'))
             ->getMock();
         $client
             ->expects($this->any())

--- a/tests/Predis/Collection/Iterator/KeyspaceTest.php
+++ b/tests/Predis/Collection/Iterator/KeyspaceTest.php
@@ -128,17 +128,14 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('scan')
-            ->with(0, array())
-            ->willReturn(
-                array(2, array('key:1st', 'key:2nd'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(2, array())
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array()),
+                array(2, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('key:1st', 'key:2nd')),
                 array(0, array('key:3rd'))
             );
 
@@ -178,17 +175,14 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('scan')
-            ->with(0, array())
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array()),
                 array(4, array())
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(4, array())
-            ->willReturn(
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(4, array()),
                 array(0, array('key:1st', 'key:2nd'))
             );
 
@@ -223,24 +217,16 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(3))
             ->method('scan')
-            ->with(0, array())
-            ->willReturn(
-                array(2, array('key:1st', 'key:2nd'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(2, array())
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array()),
+                array(2, array()),
                 array(5, array())
-            );
-        $client
-            ->expects($this->at(3))
-            ->method('scan')
-            ->with(5, array())
-            ->willReturn(
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('key:1st', 'key:2nd')),
+                array(5, array()),
                 array(0, array('key:3rd'))
             );
 
@@ -280,10 +266,12 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('scan')
-            ->with(0, array('MATCH' => 'key:*'))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('MATCH' => 'key:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('key:1st', 'key:2nd'))
             );
 
@@ -318,17 +306,14 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('scan')
-            ->with(0, array('MATCH' => 'key:*'))
-            ->willReturn(
-                array(1, array('key:1st'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(1, array('MATCH' => 'key:*'))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('MATCH' => 'key:*')),
+                array(1, array('MATCH' => 'key:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('key:1st')),
                 array(0, array('key:2nd'))
             );
 
@@ -363,10 +348,12 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('scan')
-            ->with(0, array('COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('key:1st', 'key:2nd'))
             );
 
@@ -400,16 +387,17 @@ class KeyspaceTest extends PredisTestCase
             ->expects($this->any())
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
+
+
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('scan')
-            ->with(0, array('COUNT' => 1))
-            ->willReturn(array(1, array('key:1st')));
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(1, array('COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('COUNT' => 1)),
+                array(1, array('COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('key:1st')),
                 array(0, array('key:2nd'))
             );
 
@@ -444,10 +432,12 @@ class KeyspaceTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('scan')
-            ->with(0, array('MATCH' => 'key:*', 'COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('MATCH' => 'key:*', 'COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('key:1st', 'key:2nd'))
             );
 
@@ -481,18 +471,17 @@ class KeyspaceTest extends PredisTestCase
             ->expects($this->any())
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
+
+
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('scan')
-            ->with(0, array('MATCH' => 'key:*', 'COUNT' => 1))
-            ->willReturn(
-                array(1, array('key:1st'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('scan')
-            ->with(1, array('MATCH' => 'key:*', 'COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array(0, array('MATCH' => 'key:*', 'COUNT' => 1)),
+                array(1, array('MATCH' => 'key:*', 'COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('key:1st')),
                 array(0, array('key:2nd'))
             );
 

--- a/tests/Predis/Collection/Iterator/KeyspaceTest.php
+++ b/tests/Predis/Collection/Iterator/KeyspaceTest.php
@@ -30,14 +30,14 @@ class KeyspaceTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         new Keyspace($client);
     }
@@ -55,14 +55,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array())
-            ));
+            );
 
         $iterator = new Keyspace($client);
 
@@ -83,14 +83,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd', 'key:3rd'))
-            ));
+            );
 
         $iterator = new Keyspace($client);
 
@@ -126,21 +126,21 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('key:1st', 'key:2nd'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:3rd'))
-            ));
+            );
 
         $iterator = new Keyspace($client);
 
@@ -176,21 +176,21 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(4, array())
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(4, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client);
 
@@ -221,28 +221,28 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('key:1st', 'key:2nd'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(5, array())
-            ));
+            );
         $client
             ->expects($this->at(3))
             ->method('scan')
             ->with(5, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:3rd'))
-            ));
+            );
 
         $iterator = new Keyspace($client);
 
@@ -278,14 +278,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('MATCH' => 'key:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, 'key:*');
 
@@ -316,21 +316,21 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('MATCH' => 'key:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('key:1st'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(1, array('MATCH' => 'key:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, 'key:*');
 
@@ -361,14 +361,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, null, 2);
 
@@ -399,19 +399,19 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('COUNT' => 1))
-            ->will($this->returnValue(array(1, array('key:1st'))));
+            ->willReturn(array(1, array('key:1st')));
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(1, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, null, 1);
 
@@ -442,14 +442,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('MATCH' => 'key:*', 'COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, 'key:*', 2);
 
@@ -480,21 +480,21 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('scan')
             ->with(0, array('MATCH' => 'key:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('key:1st'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('scan')
             ->with(1, array('MATCH' => 'key:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client, 'key:*', 1);
 
@@ -525,14 +525,14 @@ class KeyspaceTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->exactly(2))
             ->method('scan')
             ->with(0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('key:1st', 'key:2nd'))
-            ));
+            );
 
         $iterator = new Keyspace($client);
 

--- a/tests/Predis/Collection/Iterator/KeyspaceTest.php
+++ b/tests/Predis/Collection/Iterator/KeyspaceTest.php
@@ -21,7 +21,7 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnMissingCommand()
+    public function testThrowsExceptionOnMissingCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'SCAN' is not supported by the current command factory.");
@@ -32,6 +32,7 @@ class KeyspaceTest extends PredisTestCase
             ->method('supports')
             ->will($this->returnValue(false));
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
@@ -44,10 +45,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithNoResults()
+    public function testIterationWithNoResults(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -70,10 +73,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnSingleFetch()
+    public function testIterationOnSingleFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -111,10 +116,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetches()
+    public function testIterationOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -159,10 +166,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInFirstFetch()
+    public function testIterationOnMultipleFetchesAndHoleInFirstFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -202,10 +211,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInMidFetch()
+    public function testIterationOnMultipleFetchesAndHoleInMidFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -257,10 +268,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatch()
+    public function testIterationWithOptionMatch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -293,10 +306,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatchOnMultipleFetches()
+    public function testIterationWithOptionMatchOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -336,10 +351,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCount()
+    public function testIterationWithOptionCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -372,10 +389,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCountOnMultipleFetches()
+    public function testIterationWithOptionCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -413,10 +432,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCount()
+    public function testIterationWithOptionsMatchAndCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -449,10 +470,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCountOnMultipleFetches()
+    public function testIterationWithOptionsMatchAndCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -492,10 +515,12 @@ class KeyspaceTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationRewindable()
+    public function testIterationRewindable(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'scan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('scan'))
             ->getMock();
         $client
             ->expects($this->any())

--- a/tests/Predis/Collection/Iterator/ListKeyTest.php
+++ b/tests/Predis/Collection/Iterator/ListKeyTest.php
@@ -131,20 +131,19 @@ class ListKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('lrange')
-            ->with('key:list', 0, 9)
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:list', 0, 9),
+                array('key:list', 10, 19)
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(
                     'item:1', 'item:2', 'item:3', 'item:4', 'item:5',
                     'item:6', 'item:7', 'item:8', 'item:9', 'item:10',
-                )
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('lrange')
-            ->with('key:list', 10, 19)
-            ->willReturn(array('item:11', 'item:12'));
+                ),
+                array('item:11', 'item:12')
+            );
 
         $iterator = new ListKey($client, 'key:list');
 
@@ -212,12 +211,12 @@ class ListKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('lrange')
             ->with('key:list', 0, 4)
-            ->will($this->returnValue(
+            ->willReturn(
                 array('item:1', 'item:2')
-            ));
+            );
 
         $iterator = new ListKey($client, 'key:list', 5);
 
@@ -250,19 +249,16 @@ class ListKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('lrange')
-            ->with('key:list', 0, 1)
-            ->will($this->returnValue(
-                array('item:1', 'item:2')
-            ));
-        $client
-            ->expects($this->at(2))
-            ->method('lrange')
-            ->with('key:list', 2, 3)
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('key:list', 0, 1),
+                array('key:list', 2, 3)
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('item:1', 'item:2'),
                 array('item:3')
-            ));
+            );
 
         $iterator = new ListKey($client, 'key:list', 2);
 

--- a/tests/Predis/Collection/Iterator/ListKeyTest.php
+++ b/tests/Predis/Collection/Iterator/ListKeyTest.php
@@ -30,7 +30,7 @@ class ListKeyTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
@@ -40,7 +40,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         new ListKey($client, 'key:list');
     }
@@ -58,14 +58,14 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('lrange')
             ->with('key:list', 0, 9)
-            ->will($this->returnValue(
+            ->willReturn(
                 array()
-            ));
+            );
 
         $iterator = new ListKey($client, 'key:list');
 
@@ -86,14 +86,14 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('lrange')
             ->with('key:list', 0, 9)
-            ->will($this->returnValue(
+            ->willReturn(
                 array('item:1', 'item:2', 'item:3')
-            ));
+            );
 
         $iterator = new ListKey($client, 'key:list');
 
@@ -129,7 +129,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('lrange')
@@ -144,7 +144,7 @@ class ListKeyTest extends PredisTestCase
             ->expects($this->at(2))
             ->method('lrange')
             ->with('key:list', 10, 19)
-            ->will($this->returnValue(array('item:11', 'item:12')));
+            ->willReturn(array('item:11', 'item:12'));
 
         $iterator = new ListKey($client, 'key:list');
 
@@ -172,7 +172,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
 
         new ListKey($client, 'key:list', 'wrong');
     }
@@ -192,7 +192,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
 
         new ListKey($client, 'key:list', 'wrong');
     }
@@ -210,7 +210,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('lrange')
@@ -248,7 +248,7 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('lrange')
@@ -298,14 +298,14 @@ class ListKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->exactly(2))
             ->method('lrange')
             ->with('key:list', 0, 9)
-            ->will($this->returnValue(
+            ->willReturn(
                 array('item:1', 'item:2')
-            ));
+            );
 
         $iterator = new ListKey($client, 'key:list');
 

--- a/tests/Predis/Collection/Iterator/ListKeyTest.php
+++ b/tests/Predis/Collection/Iterator/ListKeyTest.php
@@ -21,7 +21,7 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnMissingCommand()
+    public function testThrowsExceptionOnMissingCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'LRANGE' is not supported by the current command factory.");
@@ -32,8 +32,10 @@ class ListKeyTest extends PredisTestCase
             ->method('supports')
             ->will($this->returnValue(false));
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -46,10 +48,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithNoResults()
+    public function testIterationWithNoResults(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -72,10 +76,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnSingleFetch()
+    public function testIterationOnSingleFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -113,10 +119,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetches()
+    public function testIterationOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -152,13 +160,14 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnConstructorWithNonIntegerCountParameter()
+    public function testThrowsExceptionOnConstructorWithNonIntegerCountParameter(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The $count argument must be a positive integer');
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory'))
+            ->onlyMethods(array('getCommandFactory'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -171,13 +180,14 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnConstructorWithNegativeCountParameter()
+    public function testThrowsExceptionOnConstructorWithNegativeCountParameter(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The $count argument must be a positive integer');
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory'))
+            ->onlyMethods(array('getCommandFactory'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -190,10 +200,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithCountParameter()
+    public function testIterationWithCountParameter(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -226,10 +238,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithCountParameterOnMultipleFetches()
+    public function testIterationWithCountParameterOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -274,10 +288,12 @@ class ListKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationRewindable()
+    public function testIterationRewindable(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'lrange'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('lrange'))
             ->getMock();
         $client
             ->expects($this->any())

--- a/tests/Predis/Collection/Iterator/SetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SetKeyTest.php
@@ -21,7 +21,7 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnMissingCommand()
+    public function testThrowsExceptionOnMissingCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'SSCAN' is not supported by the current command factory.");
@@ -32,6 +32,7 @@ class SetKeyTest extends PredisTestCase
             ->method('supports')
             ->will($this->returnValue(false));
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
@@ -44,10 +45,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithNoResults()
+    public function testIterationWithNoResults(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -70,10 +73,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnSingleFetch()
+    public function testIterationOnSingleFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -111,10 +116,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetches()
+    public function testIterationOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -159,10 +166,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInFirstFetch()
+    public function testIterationOnMultipleFetchesAndHoleInFirstFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -202,10 +211,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInMidFetch()
+    public function testIterationOnMultipleFetchesAndHoleInMidFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -257,10 +268,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatch()
+    public function testIterationWithOptionMatch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -293,10 +306,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatchOnMultipleFetches()
+    public function testIterationWithOptionMatchOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -336,10 +351,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCount()
+    public function testIterationWithOptionCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -372,10 +389,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCountOnMultipleFetches()
+    public function testIterationWithOptionCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -415,10 +434,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCount()
+    public function testIterationWithOptionsMatchAndCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -451,10 +472,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCountOnMultipleFetches()
+    public function testIterationWithOptionsMatchAndCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -494,10 +517,12 @@ class SetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationRewindable()
+    public function testIterationRewindable(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'sscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('sscan'))
             ->getMock();
         $client
             ->expects($this->any())

--- a/tests/Predis/Collection/Iterator/SetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SetKeyTest.php
@@ -128,17 +128,14 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('sscan')
-            ->with('key:set', 0, array())
-            ->willReturn(
-                array(2, array('member:1st', 'member:2nd'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 2, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array()),
+                array('key:set', 2, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('member:1st', 'member:2nd')),
                 array(0, array('member:3rd'))
             );
 
@@ -178,17 +175,14 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('sscan')
-            ->with('key:set', 0, array())
-            ->willReturn(
-                array(4, array())
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 4, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array()),
+                array('key:set', 4, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(4, array()),
                 array(0, array('member:1st', 'member:2nd'))
             );
 
@@ -223,24 +217,16 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(3))
             ->method('sscan')
-            ->with('key:set', 0, array())
-            ->willReturn(
-                array(2, array('member:1st', 'member:2nd'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 2, array())
-            ->willReturn(
-                array(5, array())
-            );
-        $client
-            ->expects($this->at(3))
-            ->method('sscan')
-            ->with('key:set', 5, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array()),
+                array('key:set', 2, array()),
+                array('key:set', 5, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('member:1st', 'member:2nd')),
+                array(5, array()),
                 array(0, array('member:3rd'))
             );
 
@@ -280,10 +266,12 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('sscan')
-            ->with('key:set', 0, array('MATCH' => 'member:*'))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('MATCH' => 'member:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('member:1st', 'member:2nd'))
             );
 
@@ -318,17 +306,14 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('sscan')
-            ->with('key:set', 0, array('MATCH' => 'member:*'))
-            ->willReturn(
-                array(1, array('member:1st'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 1, array('MATCH' => 'member:*'))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('MATCH' => 'member:*')),
+                array('key:set', 1, array('MATCH' => 'member:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st')),
                 array(0, array('member:2nd'))
             );
 
@@ -363,10 +348,12 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('sscan')
-            ->with('key:set', 0, array('COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('member:1st', 'member:2nd'))
             );
 
@@ -401,17 +388,14 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('sscan')
-            ->with('key:set', 0, array('COUNT' => 1))
-            ->willReturn(
-                array(1, array('member:1st'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 1, array('COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('COUNT' => 1)),
+                array('key:set', 1, array('COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st')),
                 array(0, array('member:2nd'))
             );
 
@@ -446,10 +430,12 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('sscan')
-            ->with('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('member:1st', 'member:2nd'))
             );
 
@@ -484,17 +470,14 @@ class SetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('sscan')
-            ->with('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->willReturn(
-                array(1, array('member:1st'))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('sscan')
-            ->with('key:set', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 1)),
+                array('key:set', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st')),
                 array(0, array('member:2nd'))
             );
 

--- a/tests/Predis/Collection/Iterator/SetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SetKeyTest.php
@@ -30,14 +30,14 @@ class SetKeyTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         new SetKey($client, 'key:set');
     }
@@ -55,14 +55,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array())
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 
@@ -83,14 +83,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd', 'member:3rd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 
@@ -126,21 +126,21 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('member:1st', 'member:2nd'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:3rd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 
@@ -176,21 +176,21 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(4, array())
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 4, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 
@@ -221,28 +221,28 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('member:1st', 'member:2nd'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(5, array())
-            ));
+            );
         $client
             ->expects($this->at(3))
             ->method('sscan')
             ->with('key:set', 5, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:3rd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 
@@ -278,14 +278,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', 'member:*');
 
@@ -316,21 +316,21 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 1, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', 'member:*');
 
@@ -361,14 +361,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', null, 2);
 
@@ -399,21 +399,21 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 1, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', null, 1);
 
@@ -444,14 +444,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', 'member:*', 2);
 
@@ -482,21 +482,21 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('sscan')
             ->with('key:set', 0, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st'))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('sscan')
             ->with('key:set', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set', 'member:*', 1);
 
@@ -527,14 +527,14 @@ class SetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->exactly(2))
             ->method('sscan')
             ->with('key:set', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st', 'member:2nd'))
-            ));
+            );
 
         $iterator = new SetKey($client, 'key:set');
 

--- a/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
@@ -173,17 +173,14 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array())
-            ->willReturn(
-                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 2, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array()),
+                array('key:zset', 2, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0)),
                 array(0, array('member:3rd' => 3.0))
             );
 
@@ -223,17 +220,14 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array())
-            ->willReturn(
-                array(4, array())
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 4, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array()),
+                array('key:zset', 4, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(4, array()),
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
             );
 
@@ -268,24 +262,16 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(3))
             ->method('zscan')
-            ->with('key:zset', 0, array())
-            ->willReturn(
-                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 2, array())
-            ->willReturn(
-                array(5, array())
-            );
-        $client
-            ->expects($this->at(3))
-            ->method('zscan')
-            ->with('key:zset', 5, array())
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array()),
+                array('key:zset', 2, array()),
+                array('key:zset', 5, array())
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0)),
+                array(5, array()),
                 array(0, array('member:3rd' => 3.0))
             );
 
@@ -325,11 +311,15 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array('MATCH' => 'member:*'))
-            ->willReturn(
-                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
+            ->withConsecutive(
+                array('key:zset', 0, array('MATCH' => 'member:*')),
+                array('key:zset', 2, array('MATCH' => 'member:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0)),
+                array(0, array())
             );
 
         $iterator = new SortedSetKey($client, 'key:zset', 'member:*');
@@ -363,17 +353,14 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array('MATCH' => 'member:*'))
-            ->willReturn(
-                array(1, array('member:1st' => 1.0))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 1, array('MATCH' => 'member:*'))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array('MATCH' => 'member:*')),
+                array('key:zset', 1, array('MATCH' => 'member:*'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st' => 1.0)),
                 array(0, array('member:2nd' => 2.0))
             );
 
@@ -408,10 +395,12 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('zscan')
-            ->with('key:zset', 0, array('COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array('COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
             );
 
@@ -446,17 +435,14 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array('COUNT' => 1))
-            ->willReturn(
-                array(1, array('member:1st' => 1.0))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 1, array('COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array('COUNT' => 1)),
+                array('key:zset', 1, array('COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st' => 1.0)),
                 array(0, array('member:2nd' => 2.0))
             );
 
@@ -491,10 +477,12 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('zscan')
-            ->with('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
             );
 
@@ -529,17 +517,14 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('getCommandFactory')
             ->willReturn($this->getCommandFactory());
         $client
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('zscan')
-            ->with('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->willReturn(
-                array(1, array('member:1st' => 1.0))
-            );
-        $client
-            ->expects($this->at(2))
-            ->method('zscan')
-            ->with('key:zset', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->willReturn(
+            ->withConsecutive(
+                array('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 1)),
+                array('key:zset', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(1, array('member:1st' => 1.0)),
                 array(0, array('member:2nd' => 2.0))
             );
 

--- a/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
@@ -21,7 +21,7 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnMissingCommand()
+    public function testThrowsExceptionOnMissingCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'ZSCAN' is not supported by the current command factory.");
@@ -33,6 +33,7 @@ class SortedSetKeyTest extends PredisTestCase
             ->method('supports')
             ->will($this->returnValue(false));
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
@@ -45,10 +46,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithNoResults()
+    public function testIterationWithNoResults(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -72,10 +75,12 @@ class SortedSetKeyTest extends PredisTestCase
      * @see https://github.com/predis/predis/issues/216
      * @group disconnected
      */
-    public function testIterationWithIntegerMembers()
+    public function testIterationWithIntegerMembers(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -113,10 +118,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnSingleFetch()
+    public function testIterationOnSingleFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -154,10 +161,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetches()
+    public function testIterationOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -202,10 +211,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInFirstFetch()
+    public function testIterationOnMultipleFetchesAndHoleInFirstFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -245,10 +256,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationOnMultipleFetchesAndHoleInMidFetch()
+    public function testIterationOnMultipleFetchesAndHoleInMidFetch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -300,10 +313,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatch()
+    public function testIterationWithOptionMatch(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -336,10 +351,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionMatchOnMultipleFetches()
+    public function testIterationWithOptionMatchOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -379,10 +396,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCount()
+    public function testIterationWithOptionCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -415,10 +434,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionCountOnMultipleFetches()
+    public function testIterationWithOptionCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -458,10 +479,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCount()
+    public function testIterationWithOptionsMatchAndCount(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -494,10 +517,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationWithOptionsMatchAndCountOnMultipleFetches()
+    public function testIterationWithOptionsMatchAndCountOnMultipleFetches(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())
@@ -537,10 +562,12 @@ class SortedSetKeyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterationRewindable()
+    public function testIterationRewindable(): void
     {
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('getCommandFactory', 'zscan'))
+            ->onlyMethods(array('getCommandFactory'))
+            ->addMethods(array('zscan'))
             ->getMock();
         $client
             ->expects($this->any())

--- a/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
+++ b/tests/Predis/Collection/Iterator/SortedSetKeyTest.php
@@ -31,14 +31,14 @@ class SortedSetKeyTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\ClientInterface')->getMock();
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         new SortedSetKey($client, 'key:zset');
     }
@@ -56,14 +56,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array())
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -85,14 +85,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array(0 => 0, 101 => 1, 102 => 2))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -128,14 +128,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->once())
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0, 'member:3rd' => 3.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -171,21 +171,21 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:3rd' => 3.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -221,21 +221,21 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(4, array())
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 4, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -266,28 +266,28 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 2, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(5, array())
-            ));
+            );
         $client
             ->expects($this->at(3))
             ->method('zscan')
             ->with('key:zset', 5, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:3rd' => 3.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 
@@ -323,14 +323,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(2, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', 'member:*');
 
@@ -361,21 +361,21 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st' => 1.0))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 1, array('MATCH' => 'member:*'))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', 'member:*');
 
@@ -406,14 +406,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', null, 2);
 
@@ -444,21 +444,21 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st' => 1.0))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 1, array('COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', null, 1);
 
@@ -489,14 +489,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 2))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', 'member:*', 2);
 
@@ -527,21 +527,21 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->at(1))
             ->method('zscan')
             ->with('key:zset', 0, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(1, array('member:1st' => 1.0))
-            ));
+            );
         $client
             ->expects($this->at(2))
             ->method('zscan')
             ->with('key:zset', 1, array('MATCH' => 'member:*', 'COUNT' => 1))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset', 'member:*', 1);
 
@@ -572,14 +572,14 @@ class SortedSetKeyTest extends PredisTestCase
         $client
             ->expects($this->any())
             ->method('getCommandFactory')
-            ->will($this->returnValue($this->getCommandFactory()));
+            ->willReturn($this->getCommandFactory());
         $client
             ->expects($this->exactly(2))
             ->method('zscan')
             ->with('key:zset', 0, array())
-            ->will($this->returnValue(
+            ->willReturn(
                 array(0, array('member:1st' => 1.0, 'member:2nd' => 2.0))
-            ));
+            );
 
         $iterator = new SortedSetKey($client, 'key:zset');
 

--- a/tests/Predis/Command/CommandTest.php
+++ b/tests/Predis/Command/CommandTest.php
@@ -21,7 +21,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testImplementsCorrectInterface()
+    public function testImplementsCorrectInterface(): void
     {
         $command = $this->getMockForAbstractClass('Predis\Command\Command');
 
@@ -31,7 +31,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetEmptyArguments()
+    public function testGetEmptyArguments(): void
     {
         $command = $this->getMockForAbstractClass('Predis\Command\Command');
 
@@ -41,7 +41,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetRawArguments()
+    public function testSetRawArguments(): void
     {
         $arguments = array('1st', '2nd', '3rd');
 
@@ -57,7 +57,7 @@ class CommandTest extends PredisTestCase
      * @todo We cannot set an expectation for Command::filterArguments() when we
      *       invoke Command::setArguments() because it is protected.
      */
-    public function testSetArguments()
+    public function testSetArguments(): void
     {
         $arguments = array('1st', '2nd', '3rd');
 
@@ -70,7 +70,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetArgumentAtIndex()
+    public function testGetArgumentAtIndex(): void
     {
         $arguments = array('1st', '2nd', '3rd');
 
@@ -85,7 +85,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $response = 'response-buffer';
         $command = $this->getMockForAbstractClass('Predis\Command\Command');
@@ -96,7 +96,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetAndGetSlot()
+    public function testSetAndGetSlot(): void
     {
         $slot = 1024;
 
@@ -119,7 +119,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNormalizeArguments()
+    public function testNormalizeArguments(): void
     {
         $arguments = array('arg1', 'arg2', 'arg3', 'arg4');
 
@@ -136,7 +136,7 @@ class CommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNormalizeVariadic()
+    public function testNormalizeVariadic(): void
     {
         $arguments = array('key', 'value1', 'value2', 'value3');
 

--- a/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
+++ b/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
@@ -79,7 +79,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command->expects($this->once())
             ->method('getId')
-            ->will($this->returnValue('unknown'));
+            ->willReturn('unknown');
         $command
             ->expects($this->never())
             ->method('getArguments');
@@ -304,9 +304,9 @@ class KeyPrefixProcessorTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($command, 'prefix:')
-            ->will($this->returnCallback(function ($command, $prefix) {
+            ->willReturnCallback(function ($command, $prefix) {
                 $command->setRawArguments(array('prefix:key', 'value'));
-            }));
+            });
 
         $processor = new KeyPrefixProcessor('prefix:');
         $processor->setCommandHandler('NEWCMD', $callable);
@@ -329,9 +329,9 @@ class KeyPrefixProcessorTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($command, 'prefix:')
-            ->will($this->returnCallback(function ($command, $prefix) {
+            ->willReturnCallback(function ($command, $prefix) {
                 $command->setRawArguments(array('prefix:key', 'value'));
-            }));
+            });
 
         $processor = new KeyPrefixProcessor('prefix:');
         $processor->setCommandHandler('SET', $callable);

--- a/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
+++ b/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
@@ -11,8 +11,10 @@
 
 namespace Predis\Command\Processor;
 
-use Predis\Command\RawCommand;
 use PredisTestCase;
+use Predis\Command\RawCommand;
+use Predis\Command\CommandInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  *
@@ -22,7 +24,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithPrefix()
+    public function testConstructorWithPrefix(): void
     {
         $prefix = 'prefix:';
         $processor = new KeyPrefixProcessor($prefix);
@@ -34,7 +36,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testChangePrefix()
+    public function testChangePrefix(): void
     {
         $prefix1 = 'prefix:';
         $prefix2 = 'prefix:new:';
@@ -49,10 +51,11 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testProcessPrefixableCommandInterface()
+    public function testProcessPrefixableCommandInterface(): void
     {
         $prefix = 'prefix:';
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\PrefixableCommandInterface')->getMock();
         $command
             ->expects($this->never())
@@ -70,8 +73,9 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSkipNotPrefixableCommands()
+    public function testSkipNotPrefixableCommands(): void
     {
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command->expects($this->once())
             ->method('getId')
@@ -88,7 +92,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInstanceCanBeCastedToString()
+    public function testInstanceCanBeCastedToString(): void
     {
         $prefix = 'prefix:';
         $processor = new KeyPrefixProcessor($prefix);
@@ -99,7 +103,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixFirst()
+    public function testPrefixFirst(): void
     {
         $arguments = array('1st', '2nd', '3rd', '4th');
         $expected = array('prefix:1st', '2nd', '3rd', '4th');
@@ -120,7 +124,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixAll()
+    public function testPrefixAll(): void
     {
         $arguments = array('1st', '2nd', '3rd', '4th');
         $expected = array('prefix:1st', 'prefix:2nd', 'prefix:3rd', 'prefix:4th');
@@ -141,7 +145,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixInterleaved()
+    public function testPrefixInterleaved(): void
     {
         $arguments = array('1st', '2nd', '3rd', '4th');
         $expected = array('prefix:1st', '2nd', 'prefix:3rd', '4th');
@@ -162,7 +166,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixSkipLast()
+    public function testPrefixSkipLast(): void
     {
         $arguments = array('1st', '2nd', '3rd', '4th');
         $expected = array('prefix:1st', 'prefix:2nd', 'prefix:3rd', '4th');
@@ -183,7 +187,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixSort()
+    public function testPrefixSort(): void
     {
         $arguments = array('key', 'BY', 'by_key_*', 'STORE', 'destination_key');
         $expected = array('prefix:key', 'BY', 'prefix:by_key_*', 'STORE', 'prefix:destination_key');
@@ -204,7 +208,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixZSetStore()
+    public function testPrefixZSetStore(): void
     {
         $arguments = array('key:destination', 2, 'key1', 'key2', 'WEIGHTS', 10, 100, 'AGGREGATE', 'sum');
         $expected = array(
@@ -227,7 +231,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixEval()
+    public function testPrefixEval(): void
     {
         $arguments = array('return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', 2, 'foo', 'hoge', 'bar', 'piyo');
         $expected = array(
@@ -250,7 +254,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPrefixMigrate()
+    public function testPrefixMigrate(): void
     {
         $arguments = array('127.0.0.1', '6379', 'key', '0', '10', 'COPY', 'REPLACE');
         $expected = array('127.0.0.1', '6379', 'prefix:key', '0', '10', 'COPY', 'REPLACE');
@@ -276,7 +280,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
      * @param array  $arguments
      * @param array  $expected
      */
-    public function testApplyPrefixToCommand($commandID, array $arguments, array $expected)
+    public function testApplyPrefixToCommand($commandID, array $arguments, array $expected): void
     {
         $processor = new KeyPrefixProcessor('prefix:');
         $command = $this->getCommandInstance($commandID, $arguments);
@@ -289,12 +293,12 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanDefineNewCommandHandlers()
+    public function testCanDefineNewCommandHandlers(): void
     {
         $command = $this->getCommandInstance('NEWCMD', array('key', 'value'));
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -314,12 +318,12 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanOverrideExistingCommandHandlers()
+    public function testCanOverrideExistingCommandHandlers(): void
     {
         $command = $this->getCommandInstance('SET', array('key', 'value'));
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -339,7 +343,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanUndefineCommandHandlers()
+    public function testCanUndefineCommandHandlers(): void
     {
         $command = $this->getCommandInstance('SET', array('key', 'value'));
 
@@ -353,7 +357,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCannotDefineCommandHandlerWithInvalidType()
+    public function testCannotDefineCommandHandlerWithInvalidType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Callback must be a valid callable object or NULL');
@@ -366,7 +370,15 @@ class KeyPrefixProcessorTest extends PredisTestCase
     // ---- HELPER METHODS ------------------------------------------------ //
     // ******************************************************************** //
 
-    public function getCommandInstance($commandID, array $arguments)
+    /**
+     * Returns a command instance by ID populated with the specified arguments.
+     *
+     * @param string $commandID ID of the Redis command
+     * @param array $arguments  List of arguments for the command
+     *
+     * @return CommandInterface
+     */
+    public function getCommandInstance(string $commandID, array $arguments): CommandInterface
     {
         $command = new RawCommand($commandID);
         $command->setRawArguments($arguments);
@@ -379,7 +391,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
      *
      * @return array
      */
-    public function commandArgumentsDataProvider()
+    public function commandArgumentsDataProvider(): array
     {
         return array(
             /* ---------------- Redis 1.2 ---------------- */

--- a/tests/Predis/Command/Processor/ProcessorChainTest.php
+++ b/tests/Predis/Command/Processor/ProcessorChainTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Command\Processor;
 
 use PredisTestCase;
+use Predis\Command\CommandInterface;
 
 /**
  *
@@ -21,7 +22,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $chain = new ProcessorChain();
 
@@ -32,7 +33,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithProcessorsArray()
+    public function testConstructorWithProcessorsArray(): void
     {
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -47,7 +48,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCountProcessors()
+    public function testCountProcessors(): void
     {
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -62,8 +63,9 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddProcessors()
+    public function testAddProcessors(): void
     {
+        /** @var ProcessorInterface[] */
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -79,13 +81,15 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddMoreProcessors()
+    public function testAddMoreProcessors(): void
     {
+        /** @var ProcessorInterface */
         $processors1 = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
         );
 
+        /** @var ProcessorInterface */
         $processors2 = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -101,8 +105,9 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemoveProcessors()
+    public function testRemoveProcessors(): void
     {
+        /** @var ProcessorInterface */
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -120,9 +125,11 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemoveProcessorNotInChain()
+    public function testRemoveProcessorNotInChain(): void
     {
+        /** @var ProcessorInterface */
         $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock();
+
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -137,8 +144,9 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemoveProcessorFromEmptyChain()
+    public function testRemoveProcessorFromEmptyChain(): void
     {
+        /** @var ProcessorInterface */
         $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock();
 
         $chain = new ProcessorChain();
@@ -151,7 +159,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetGet()
+    public function testOffsetGet(): void
     {
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -167,7 +175,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetIsset()
+    public function testOffsetIsset(): void
     {
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -184,7 +192,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetSet()
+    public function testOffsetSet(): void
     {
         $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock();
 
@@ -197,7 +205,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOffsetSetWithInvalidType()
+    public function testOffsetSetWithInvalidType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Processor chain accepts only instances of `Predis\Command\Processor\ProcessorInterface`');
@@ -209,7 +217,7 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIterator()
+    public function testGetIterator(): void
     {
         $processors = array(
             $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock(),
@@ -224,8 +232,9 @@ class ProcessorChainTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testProcessChain()
+    public function testProcessChain(): void
     {
+        /** @var CommandInterface */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
 
         $processor1 = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock();

--- a/tests/Predis/Command/RawCommandTest.php
+++ b/tests/Predis/Command/RawCommandTest.php
@@ -21,7 +21,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithCommandID()
+    public function testConstructorWithCommandID(): void
     {
         $commandID = 'PING';
         $command = new RawCommand($commandID);
@@ -33,7 +33,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithCommandIDAndArguments()
+    public function testConstructorWithCommandIDAndArguments(): void
     {
         $commandID = 'SET';
         $commandArgs = array('foo', 'bar');
@@ -47,7 +47,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStaticCreate()
+    public function testStaticCreate(): void
     {
         $command = RawCommand::create('SET');
         $this->assertSame('SET', $command->getId());
@@ -65,7 +65,7 @@ class RawCommandTest extends PredisTestCase
      *
      * @group disconnected
      */
-    public function testPHPExceptionOnMissingCommandIDWithStaticCreate()
+    public function testPHPExceptionOnMissingCommandIDWithStaticCreate(): void
     {
         $this->expectException('ArgumentCountError');
 
@@ -75,7 +75,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetArguments()
+    public function testSetArguments(): void
     {
         $commandID = 'SET';
         $command = new RawCommand($commandID);
@@ -90,7 +90,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetRawArguments()
+    public function testSetRawArguments(): void
     {
         $commandID = 'SET';
         $command = new RawCommand($commandID);
@@ -105,7 +105,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetArgumentAtIndex()
+    public function testGetArgumentAtIndex(): void
     {
         $command = new RawCommand('GET', array('key'));
 
@@ -116,7 +116,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetAndGetHash()
+    public function testSetAndGetHash(): void
     {
         $slot = 1024;
         $arguments = array('key', 'value');
@@ -134,7 +134,7 @@ class RawCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNormalizesCommandIdentifiersToUppercase()
+    public function testNormalizesCommandIdentifiersToUppercase(): void
     {
         $command = new RawCommand('set', array('key', 'value'));
 

--- a/tests/Predis/Command/Redis/APPEND_Test.php
+++ b/tests/Predis/Command/Redis/APPEND_Test.php
@@ -20,7 +20,7 @@ class APPEND_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\APPEND';
     }
@@ -28,7 +28,7 @@ class APPEND_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'APPEND';
     }
@@ -36,7 +36,7 @@ class APPEND_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value');
         $expected = array('key', 'value');
@@ -50,7 +50,7 @@ class APPEND_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(10, $this->getCommand()->parseResponse(10));
     }
@@ -59,7 +59,7 @@ class APPEND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class APPEND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsTheLenghtOfTheStringAfterAppend()
+    public function testReturnsTheLenghtOfTheStringAfterAppend(): void
     {
         $redis = $this->getClient();
 
@@ -86,7 +86,7 @@ class APPEND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/AUTH_Test.php
+++ b/tests/Predis/Command/Redis/AUTH_Test.php
@@ -20,7 +20,7 @@ class AUTH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\AUTH';
     }
@@ -28,7 +28,7 @@ class AUTH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'AUTH';
     }
@@ -36,7 +36,7 @@ class AUTH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('password');
         $expected = array('password');
@@ -50,7 +50,7 @@ class AUTH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = null;
         $expected = null;

--- a/tests/Predis/Command/Redis/BGREWRITEAOF_Test.php
+++ b/tests/Predis/Command/Redis/BGREWRITEAOF_Test.php
@@ -20,7 +20,7 @@ class BGREWRITEAOF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BGREWRITEAOF';
     }
@@ -28,7 +28,7 @@ class BGREWRITEAOF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BGREWRITEAOF';
     }
@@ -36,7 +36,7 @@ class BGREWRITEAOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class BGREWRITEAOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertTrue($this->getCommand()->parseResponse(true));
     }

--- a/tests/Predis/Command/Redis/BGSAVE_Test.php
+++ b/tests/Predis/Command/Redis/BGSAVE_Test.php
@@ -20,7 +20,7 @@ class BGSAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BGSAVE';
     }
@@ -28,7 +28,7 @@ class BGSAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BGSAVE';
     }
@@ -36,7 +36,7 @@ class BGSAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class BGSAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertTrue($this->getCommand()->parseResponse(true));
     }

--- a/tests/Predis/Command/Redis/BITCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/BITCOUNT_Test.php
@@ -20,7 +20,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BITCOUNT';
     }
@@ -28,7 +28,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BITCOUNT';
     }
@@ -36,7 +36,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 10);
         $expected = array('key', 0, 10);
@@ -50,7 +50,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 10;
         $expected = 10;
@@ -64,7 +64,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsNumberOfBitsSet()
+    public function testReturnsNumberOfBitsSet(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class BITCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/BITFIELD_Test.php
+++ b/tests/Predis/Command/Redis/BITFIELD_Test.php
@@ -20,7 +20,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BITFIELD';
     }
@@ -28,7 +28,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BITFIELD';
     }
@@ -36,7 +36,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterMultipleArguments()
+    public function testFilterMultipleArguments(): void
     {
         $arguments = array('key', 'incrby', 'u2', '100', '1', 'OVERFLOW', 'SAT', 'incrby', 'u2', '102', '1', 'GET', 'u2', '100');
         $expected = array('key', 'incrby', 'u2', '100', '1', 'OVERFLOW', 'SAT', 'incrby', 'u2', '102', '1', 'GET', 'u2', '100');
@@ -64,7 +64,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array(1);
         $expected = array(1);
@@ -77,7 +77,7 @@ class BITFIELD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseComplex()
+    public function testParseResponseComplex(): void
     {
         $raw = array(1, 0, 3);
         $expected = array(1, 0, 3);
@@ -91,7 +91,7 @@ class BITFIELD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testBitfieldWithGetModifier()
+    public function testBitfieldWithGetModifier(): void
     {
         $redis = $this->getClient();
 
@@ -106,7 +106,7 @@ class BITFIELD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testBitfieldWithSetModifier()
+    public function testBitfieldWithSetModifier(): void
     {
         $redis = $this->getClient();
 
@@ -124,7 +124,7 @@ class BITFIELD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testBitfieldWithIncrbyModifier()
+    public function testBitfieldWithIncrbyModifier(): void
     {
         $redis = $this->getClient();
 
@@ -141,7 +141,7 @@ class BITFIELD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -20,7 +20,7 @@ class BITOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BITOP';
     }
@@ -28,7 +28,7 @@ class BITOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BITOP';
     }
@@ -36,7 +36,7 @@ class BITOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('AND', 'key:dst', 'key:01', 'key:02');
         $expected = array('AND', 'key:dst', 'key:01', 'key:02');
@@ -50,7 +50,7 @@ class BITOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsKeysAsSingleArray()
+    public function testFilterArgumentsKeysAsSingleArray(): void
     {
         $arguments = array('AND', 'key:dst', array('key:01', 'key:02'));
         $expected = array('AND', 'key:dst', 'key:01', 'key:02');
@@ -64,7 +64,7 @@ class BITOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 10;
         $expected = 10;
@@ -78,7 +78,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCanPerformBitwiseAND()
+    public function testCanPerformBitwiseAND(): void
     {
         $redis = $this->getClient();
 
@@ -93,7 +93,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCanPerformBitwiseOR()
+    public function testCanPerformBitwiseOR(): void
     {
         $redis = $this->getClient();
 
@@ -108,7 +108,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCanPerformBitwiseXOR()
+    public function testCanPerformBitwiseXOR(): void
     {
         $redis = $this->getClient();
 
@@ -123,7 +123,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCanPerformBitwiseNOT()
+    public function testCanPerformBitwiseNOT(): void
     {
         $redis = $this->getClient();
 
@@ -137,7 +137,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testBitwiseNOTAcceptsOnlyOneSourceKey()
+    public function testBitwiseNOTAcceptsOnlyOneSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR BITOP NOT must be called with a single source key');
@@ -149,7 +149,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnInvalidOperation()
+    public function testThrowsExceptionOnInvalidOperation(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR syntax error');
@@ -161,7 +161,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnInvalidSourceKey()
+    public function testThrowsExceptionOnInvalidSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -176,7 +176,7 @@ class BITOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testDoesNotThrowExceptionOnInvalidDestinationKey()
+    public function testDoesNotThrowExceptionOnInvalidDestinationKey(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/BITPOS_Test.php
+++ b/tests/Predis/Command/Redis/BITPOS_Test.php
@@ -20,7 +20,7 @@ class BITPOS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BITPOS';
     }
@@ -28,7 +28,7 @@ class BITPOS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BITPOS';
     }
@@ -36,7 +36,7 @@ class BITPOS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 1, 10);
         $expected = array('key', 0, 1, 10);
@@ -50,7 +50,7 @@ class BITPOS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 10;
         $expected = 10;
@@ -63,7 +63,7 @@ class BITPOS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.7
      */
-    public function testReturnsBitPosition()
+    public function testReturnsBitPosition(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class BITPOS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.7
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/BLPOP_Test.php
+++ b/tests/Predis/Command/Redis/BLPOP_Test.php
@@ -20,7 +20,7 @@ class BLPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BLPOP';
     }
@@ -28,7 +28,7 @@ class BLPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BLPOP';
     }
@@ -36,7 +36,7 @@ class BLPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3', 10);
         $expected = array('key1', 'key2', 'key3', 10);
@@ -50,7 +50,7 @@ class BLPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsKeysAsSingleArray()
+    public function testFilterArgumentsKeysAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'), 10);
         $expected = array('key1', 'key2', 'key3', 10);
@@ -64,7 +64,7 @@ class BLPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('key', 'value');
         $expected = array('key', 'value');

--- a/tests/Predis/Command/Redis/BRPOPLPUSH_Test.php
+++ b/tests/Predis/Command/Redis/BRPOPLPUSH_Test.php
@@ -20,7 +20,7 @@ class BRPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BRPOPLPUSH';
     }
@@ -28,7 +28,7 @@ class BRPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BRPOPLPUSH';
     }
@@ -36,7 +36,7 @@ class BRPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:source', 'key:destination', 10);
         $expected = array('key:source', 'key:destination', 10);
@@ -50,7 +50,7 @@ class BRPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('element', $this->getCommand()->parseResponse('element'));
     }

--- a/tests/Predis/Command/Redis/BRPOP_Test.php
+++ b/tests/Predis/Command/Redis/BRPOP_Test.php
@@ -20,7 +20,7 @@ class BRPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\BRPOP';
     }
@@ -28,7 +28,7 @@ class BRPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'BRPOP';
     }
@@ -36,7 +36,7 @@ class BRPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3', 10);
         $expected = array('key1', 'key2', 'key3', 10);
@@ -50,7 +50,7 @@ class BRPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsKeysAsSingleArray()
+    public function testFilterArgumentsKeysAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'), 10);
         $expected = array('key1', 'key2', 'key3', 10);
@@ -64,7 +64,7 @@ class BRPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('key', 'value');
         $expected = array('key', 'value');

--- a/tests/Predis/Command/Redis/CLIENT_Test.php
+++ b/tests/Predis/Command/Redis/CLIENT_Test.php
@@ -20,7 +20,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\CLIENT';
     }
@@ -28,7 +28,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'CLIENT';
     }
@@ -36,7 +36,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsOfClientKill()
+    public function testFilterArgumentsOfClientKill(): void
     {
         $arguments = array('kill', '127.0.0.1:45393');
         $expected = array('kill', '127.0.0.1:45393');
@@ -50,7 +50,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsOfClientList()
+    public function testFilterArgumentsOfClientList(): void
     {
         $arguments = array('list');
         $expected = array('list');
@@ -64,7 +64,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsOfClientGetname()
+    public function testFilterArgumentsOfClientGetname(): void
     {
         $arguments = $expected = array('getname');
 
@@ -77,7 +77,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsOfClientSetname()
+    public function testFilterArgumentsOfClientSetname(): void
     {
         $arguments = $expected = array('setname', 'connection-a');
 
@@ -90,7 +90,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseOfClientKill()
+    public function testParseResponseOfClientKill(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array('kill'));
@@ -101,7 +101,7 @@ class CLIENT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseOfClientList()
+    public function testParseResponseOfClientList(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array('list'));
@@ -126,7 +126,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testReturnsListOfConnectedClients()
+    public function testReturnsListOfConnectedClients(): void
     {
         $redis = $this->getClient();
 
@@ -146,7 +146,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.6.9
      */
-    public function testGetsNameOfConnection()
+    public function testGetsNameOfConnection(): void
     {
         $redis = $this->getClient();
         $clientName = $redis->client('GETNAME');
@@ -161,7 +161,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.6.9
      */
-    public function testSetsNameOfConnection()
+    public function testSetsNameOfConnection(): void
     {
         $redis = $this->getClient();
 
@@ -201,7 +201,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testThrowsExceptioOnWrongModifier()
+    public function testThrowsExceptioOnWrongModifier(): void
     {
         $this->expectException('Predis\Response\ServerException');
 
@@ -214,7 +214,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testThrowsExceptionWhenKillingUnknownClient()
+    public function testThrowsExceptionWhenKillingUnknownClient(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR No such client');

--- a/tests/Predis/Command/Redis/COMMAND_Test.php
+++ b/tests/Predis/Command/Redis/COMMAND_Test.php
@@ -22,7 +22,7 @@ class COMMAND_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\COMMAND';
     }
@@ -30,7 +30,7 @@ class COMMAND_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'COMMAND';
     }
@@ -38,7 +38,7 @@ class COMMAND_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('INFO', 'DEL');
         $expected = array('INFO', 'DEL');
@@ -52,7 +52,7 @@ class COMMAND_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array(
             array('get', 2, array(new Status('readonly'), new Status('fast')), 1, 1, 1),
@@ -72,7 +72,7 @@ class COMMAND_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseEmptyResponse()
+    public function testParseEmptyResponse(): void
     {
         $raw = array(null);
         $expected = array(null);
@@ -86,7 +86,7 @@ class COMMAND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.13
      */
-    public function testReturnsEmptyCommandInfoOnNonExistingCommand()
+    public function testReturnsEmptyCommandInfoOnNonExistingCommand(): void
     {
         $redis = $this->getClient();
 
@@ -98,7 +98,7 @@ class COMMAND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.13
      */
-    public function testReturnsCommandInfoOnExistingCommand()
+    public function testReturnsCommandInfoOnExistingCommand(): void
     {
         $redis = $this->getClient();
 
@@ -127,7 +127,7 @@ class COMMAND_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.13
      */
-    public function testReturnsListOfCommandInfoWithNoArguments()
+    public function testReturnsListOfCommandInfoWithNoArguments(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/CONFIG_Test.php
+++ b/tests/Predis/Command/Redis/CONFIG_Test.php
@@ -20,7 +20,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\CONFIG';
     }
@@ -28,7 +28,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'CONFIG';
     }
@@ -36,7 +36,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('GET', 'slowlog');
         $expected = array('GET', 'slowlog');
@@ -50,7 +50,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseOfConfigGet()
+    public function testParseResponseOfConfigGet(): void
     {
         $raw = array('slowlog-log-slower-than', '10000', 'slowlog-max-len', '64', 'loglevel', 'verbose');
         $expected = array(
@@ -67,7 +67,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseOfConfigSet()
+    public function testParseResponseOfConfigSet(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -75,7 +75,7 @@ class CONFIG_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseOfConfigResetstat()
+    public function testParseResponseOfConfigResetstat(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -84,7 +84,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsListOfConfigurationValues()
+    public function testReturnsListOfConfigurationValues(): void
     {
         $redis = $this->getClient();
 
@@ -99,7 +99,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsListOfOneConfigurationEntry()
+    public function testReturnsListOfOneConfigurationEntry(): void
     {
         $redis = $this->getClient();
 
@@ -112,7 +112,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsEmptyListOnUnknownConfigurationEntry()
+    public function testReturnsEmptyListOnUnknownConfigurationEntry(): void
     {
         $redis = $this->getClient();
 
@@ -123,7 +123,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsTrueOnSuccessfulConfiguration()
+    public function testReturnsTrueOnSuccessfulConfiguration(): void
     {
         $redis = $this->getClient();
 
@@ -140,7 +140,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionWhenSettingUnknownConfiguration()
+    public function testThrowsExceptionWhenSettingUnknownConfiguration(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR Unsupported CONFIG parameter: foo');
@@ -154,7 +154,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsTrueOnResetstat()
+    public function testReturnsTrueOnResetstat(): void
     {
         $redis = $this->getClient();
 
@@ -165,7 +165,7 @@ class CONFIG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnUnknownSubcommand()
+    public function testThrowsExceptionOnUnknownSubcommand(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/DBSIZE_Test.php
+++ b/tests/Predis/Command/Redis/DBSIZE_Test.php
@@ -20,7 +20,7 @@ class DBSIZE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DBSIZE';
     }
@@ -28,7 +28,7 @@ class DBSIZE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DBSIZE';
     }
@@ -36,7 +36,7 @@ class DBSIZE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class DBSIZE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(100, $this->getCommand()->parseResponse(100));
     }
@@ -55,7 +55,7 @@ class DBSIZE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsCurrentSizeOfDatabase()
+    public function testReturnsCurrentSizeOfDatabase(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/DECRBY_Test.php
+++ b/tests/Predis/Command/Redis/DECRBY_Test.php
@@ -20,7 +20,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DECRBY';
     }
@@ -28,7 +28,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DECRBY';
     }
@@ -36,7 +36,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5);
         $expected = array('key', 5);
@@ -50,7 +50,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(5, $this->getCommand()->parseResponse(5));
     }
@@ -58,7 +58,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -69,7 +69,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTheValueOfTheKeyAfterDecrement()
+    public function testReturnsTheValueOfTheKeyAfterDecrement(): void
     {
         $redis = $this->getClient();
 
@@ -83,7 +83,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnDecrementValueNotInteger()
+    public function testThrowsExceptionOnDecrementValueNotInteger(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -96,7 +96,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnKeyValueNotInteger()
+    public function testThrowsExceptionOnKeyValueNotInteger(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -110,7 +110,7 @@ class DECRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/DECR_Test.php
+++ b/tests/Predis/Command/Redis/DECR_Test.php
@@ -20,7 +20,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DECR';
     }
@@ -28,7 +28,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DECR';
     }
@@ -36,7 +36,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(5, $this->getCommand()->parseResponse(5));
     }
@@ -58,7 +58,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -69,7 +69,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTheValueOfTheKeyAfterDecrement()
+    public function testReturnsTheValueOfTheKeyAfterDecrement(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnKeyValueNotInteger()
+    public function testThrowsExceptionOnKeyValueNotInteger(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -96,7 +96,7 @@ class DECR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/DEL_Test.php
+++ b/tests/Predis/Command/Redis/DEL_Test.php
@@ -20,7 +20,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DEL';
     }
@@ -28,7 +28,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DEL';
     }
@@ -36,7 +36,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -49,7 +49,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -63,7 +63,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -73,7 +73,7 @@ class DEL_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNumberOfDeletedKeys()
+    public function testReturnsNumberOfDeletedKeys(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/DISCARD_Test.php
+++ b/tests/Predis/Command/Redis/DISCARD_Test.php
@@ -20,7 +20,7 @@ class DISCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DISCARD';
     }
@@ -28,7 +28,7 @@ class DISCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DISCARD';
     }
@@ -36,7 +36,7 @@ class DISCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class DISCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -56,7 +56,7 @@ class DISCARD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testAbortsTransactionAndRestoresNormalFlow()
+    public function testAbortsTransactionAndRestoresNormalFlow(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class DISCARD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionWhenCallingOutsideTransaction()
+    public function testThrowsExceptionWhenCallingOutsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR DISCARD without MULTI');

--- a/tests/Predis/Command/Redis/DUMP_Test.php
+++ b/tests/Predis/Command/Redis/DUMP_Test.php
@@ -20,7 +20,7 @@ class DUMP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\DUMP';
     }
@@ -28,7 +28,7 @@ class DUMP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'DUMP';
     }
@@ -36,7 +36,7 @@ class DUMP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class DUMP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = "\x00\xC0\n\x06\x00\xF8r?\xC5\xFB\xFB_(";
         $expected = "\x00\xC0\n\x06\x00\xF8r?\xC5\xFB\xFB_(";

--- a/tests/Predis/Command/Redis/ECHO_Test.php
+++ b/tests/Predis/Command/Redis/ECHO_Test.php
@@ -20,7 +20,7 @@ class ECHO_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ECHO_';
     }
@@ -28,7 +28,7 @@ class ECHO_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ECHO';
     }
@@ -36,7 +36,7 @@ class ECHO_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('message');
         $expected = array('message');
@@ -50,7 +50,7 @@ class ECHO_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 'message';
         $expected = 'message';
@@ -63,7 +63,7 @@ class ECHO_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testAlwaysReturnsThePassedMessage()
+    public function testAlwaysReturnsThePassedMessage(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/EVALSHA_Test.php
+++ b/tests/Predis/Command/Redis/EVALSHA_Test.php
@@ -20,7 +20,7 @@ class EVALSHA_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EVALSHA';
     }
@@ -28,7 +28,7 @@ class EVALSHA_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EVALSHA';
     }
@@ -36,7 +36,7 @@ class EVALSHA_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('9d0c0826bde023cc39eebaaf832c32a890f3b088', 1, 'foo', 'bar');
         $expected = array('9d0c0826bde023cc39eebaaf832c32a890f3b088', 1, 'foo', 'bar');
@@ -50,7 +50,7 @@ class EVALSHA_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('bar', $this->getCommand()->parseResponse('bar'));
     }
@@ -58,7 +58,7 @@ class EVALSHA_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testGetScriptHash()
+    public function testGetScriptHash(): void
     {
         $command = $this->getCommandWithArgumentsArray(array($sha1 = sha1('return true')), 0);
         $this->assertSame($sha1, $command->getScriptHash());
@@ -68,7 +68,7 @@ class EVALSHA_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testExecutesSpecifiedLuaScript()
+    public function testExecutesSpecifiedLuaScript(): void
     {
         $redis = $this->getClient();
 
@@ -84,7 +84,7 @@ class EVALSHA_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnWrongNumberOfKeys()
+    public function testThrowsExceptionOnWrongNumberOfKeys(): void
     {
         $this->expectException('Predis\Response\ServerException');
 
@@ -101,7 +101,7 @@ class EVALSHA_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnInvalidScript()
+    public function testThrowsExceptionOnInvalidScript(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/EVAL_Test.php
+++ b/tests/Predis/Command/Redis/EVAL_Test.php
@@ -20,7 +20,7 @@ class EVAL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EVAL_';
     }
@@ -28,7 +28,7 @@ class EVAL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EVAL';
     }
@@ -36,7 +36,7 @@ class EVAL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('return redis.call("SET", KEYS[1], ARGV[1])', 1, 'foo', 'bar');
         $expected = array('return redis.call("SET", KEYS[1], ARGV[1])', 1, 'foo', 'bar');
@@ -50,7 +50,7 @@ class EVAL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('bar', $this->getCommand()->parseResponse('bar'));
     }
@@ -58,7 +58,7 @@ class EVAL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testGetScriptHash()
+    public function testGetScriptHash(): void
     {
         $command = $this->getCommandWithArgumentsArray(array($lua = 'return true', 0));
         $this->assertSame(sha1($lua), $command->getScriptHash());
@@ -68,7 +68,7 @@ class EVAL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testExecutesSpecifiedLuaScript()
+    public function testExecutesSpecifiedLuaScript(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class EVAL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnWrongNumberOfKeys()
+    public function testThrowsExceptionOnWrongNumberOfKeys(): void
     {
         $this->expectException('Predis\Response\ServerException');
 
@@ -96,7 +96,7 @@ class EVAL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnInvalidScript()
+    public function testThrowsExceptionOnInvalidScript(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/EXEC_Test.php
+++ b/tests/Predis/Command/Redis/EXEC_Test.php
@@ -20,7 +20,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EXEC';
     }
@@ -28,7 +28,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EXEC';
     }
@@ -36,7 +36,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('tx1', 'tx2');
         $expected = array('tx1', 'tx2');
@@ -60,7 +60,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testExecutesTransactionAndReturnsArrayOfResponses()
+    public function testExecutesTransactionAndReturnsArrayOfResponses(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsEmptyArrayOnEmptyTransactions()
+    public function testReturnsEmptyArrayOnEmptyTransactions(): void
     {
         $redis = $this->getClient();
 
@@ -86,7 +86,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testResponsesOfTransactionsAreNotParsed()
+    public function testResponsesOfTransactionsAreNotParsed(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class EXEC_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionWhenCallingOutsideTransaction()
+    public function testThrowsExceptionWhenCallingOutsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR EXEC without MULTI');

--- a/tests/Predis/Command/Redis/EXISTS_Test.php
+++ b/tests/Predis/Command/Redis/EXISTS_Test.php
@@ -20,7 +20,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EXISTS';
     }
@@ -28,7 +28,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EXISTS';
     }
@@ -36,7 +36,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsMultipleKeys()
+    public function testFilterArgumentsMultipleKeys(): void
     {
         $arguments = array('key:1', 'key:2', 'key:3');
         $expected = array('key:1', 'key:2', 'key:3');
@@ -64,7 +64,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -76,7 +76,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnValueWhenKeyExists()
+    public function testReturnValueWhenKeyExists(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class EXISTS_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnValueWhenKeyDoesNotExist()
+    public function testReturnValueWhenKeyDoesNotExist(): void
     {
         $redis = $this->getClient();
 
@@ -98,7 +98,7 @@ class EXISTS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.3
      */
-    public function testReturnValueWhenKeysExist()
+    public function testReturnValueWhenKeysExist(): void
     {
         $redis = $this->getClient();
 
@@ -110,7 +110,7 @@ class EXISTS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.3
      */
-    public function testReturnValueWhenKeyDoNotExist()
+    public function testReturnValueWhenKeyDoNotExist(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/EXPIREAT_Test.php
+++ b/tests/Predis/Command/Redis/EXPIREAT_Test.php
@@ -20,7 +20,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EXPIREAT';
     }
@@ -28,7 +28,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EXPIREAT';
     }
@@ -36,7 +36,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'ttl');
         $expected = array('key', 'ttl');
@@ -50,7 +50,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -61,7 +61,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnNonExistingKeys()
+    public function testReturnsZeroOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
      * @group connected
      * @group slow
      */
-    public function testCanExpireKeys()
+    public function testCanExpireKeys(): void
     {
         $redis = $this->getClient();
 
@@ -92,7 +92,7 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testDeletesKeysOnPastUnixTime()
+    public function testDeletesKeysOnPastUnixTime(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/EXPIRE_Test.php
+++ b/tests/Predis/Command/Redis/EXPIRE_Test.php
@@ -20,7 +20,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\EXPIRE';
     }
@@ -28,7 +28,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'EXPIRE';
     }
@@ -36,7 +36,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'ttl');
         $expected = array('key', 'ttl');
@@ -50,7 +50,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -61,7 +61,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnNonExistingKeys()
+    public function testReturnsZeroOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class EXPIRE_Test extends PredisCommandTestCase
      * @group connected
      * @group slow
      */
-    public function testCanExpireKeys()
+    public function testCanExpireKeys(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testDeletesKeysOnNegativeTTL()
+    public function testDeletesKeysOnNegativeTTL(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/FLUSHALL_Test.php
+++ b/tests/Predis/Command/Redis/FLUSHALL_Test.php
@@ -20,7 +20,7 @@ class FLUSHALL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\FLUSHALL';
     }
@@ -28,7 +28,7 @@ class FLUSHALL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'FLUSHALL';
     }
@@ -36,7 +36,7 @@ class FLUSHALL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class FLUSHALL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }

--- a/tests/Predis/Command/Redis/FLUSHDB_Test.php
+++ b/tests/Predis/Command/Redis/FLUSHDB_Test.php
@@ -20,7 +20,7 @@ class FLUSHDB_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\FLUSHDB';
     }
@@ -28,7 +28,7 @@ class FLUSHDB_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'FLUSHDB';
     }
@@ -36,7 +36,7 @@ class FLUSHDB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class FLUSHDB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -55,7 +55,7 @@ class FLUSHDB_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testFlushesTheEntireLogicalDatabase()
+    public function testFlushesTheEntireLogicalDatabase(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/GEOADD_Test.php
+++ b/tests/Predis/Command/Redis/GEOADD_Test.php
@@ -20,7 +20,7 @@ class GEOADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEOADD';
     }
@@ -28,7 +28,7 @@ class GEOADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEOADD';
     }
@@ -36,7 +36,7 @@ class GEOADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('Sicily', '13.361389', '38.115556', 'Palermo', '15.087269', '37.502669', 'Catania');
         $expected = array('Sicily', '13.361389', '38.115556', 'Palermo', '15.087269', '37.502669', 'Catania');
@@ -50,7 +50,7 @@ class GEOADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithMembersAsSingleArray()
+    public function testFilterArgumentsWithMembersAsSingleArray(): void
     {
         $arguments = array('Sicily', array(
             array('13.361389', '38.115556', 'Palermo'),
@@ -68,7 +68,7 @@ class GEOADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 1;
         $expected = 1;
@@ -82,7 +82,7 @@ class GEOADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandFillsSortedSet()
+    public function testCommandFillsSortedSet(): void
     {
         $redis = $this->getClient();
 
@@ -94,7 +94,7 @@ class GEOADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GEODIST_Test.php
+++ b/tests/Predis/Command/Redis/GEODIST_Test.php
@@ -20,7 +20,7 @@ class GEODIST_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEODIST';
     }
@@ -28,7 +28,7 @@ class GEODIST_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEODIST';
     }
@@ -36,7 +36,7 @@ class GEODIST_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member:1', 'member:2', 'km');
         $expected = array('key', 'member:1', 'member:2', 'km');
@@ -50,7 +50,7 @@ class GEODIST_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('103.31822459492736');
         $expected = array('103.31822459492736');
@@ -64,7 +64,7 @@ class GEODIST_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoDistance()
+    public function testCommandReturnsGeoDistance(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class GEODIST_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GEOHASH_Test.php
+++ b/tests/Predis/Command/Redis/GEOHASH_Test.php
@@ -20,7 +20,7 @@ class GEOHASH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEOHASH';
     }
@@ -28,7 +28,7 @@ class GEOHASH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEOHASH';
     }
@@ -36,7 +36,7 @@ class GEOHASH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member:1', 'member:2');
         $expected = array('key', 'member:1', 'member:2');
@@ -50,7 +50,7 @@ class GEOHASH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithMembersAsSingleArray()
+    public function testFilterArgumentsWithMembersAsSingleArray(): void
     {
         $arguments = array('key', array('member:1', 'member:2'));
         $expected = array('key', 'member:1', 'member:2');
@@ -64,7 +64,7 @@ class GEOHASH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('sqc8b49rny0', 'sqdtr74hyu0');
         $expected = array('sqc8b49rny0', 'sqdtr74hyu0');
@@ -78,7 +78,7 @@ class GEOHASH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoHashes()
+    public function testCommandReturnsGeoHashes(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class GEOHASH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GEOPOS_Test.php
+++ b/tests/Predis/Command/Redis/GEOPOS_Test.php
@@ -20,7 +20,7 @@ class GEOPOS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEOPOS';
     }
@@ -28,7 +28,7 @@ class GEOPOS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEOPOS';
     }
@@ -36,7 +36,7 @@ class GEOPOS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member:1', 'member:2');
         $expected = array('key', 'member:1', 'member:2');
@@ -50,7 +50,7 @@ class GEOPOS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithMembersAsSingleArray()
+    public function testFilterArgumentsWithMembersAsSingleArray(): void
     {
         $arguments = array('key', array('member:1', 'member:2'));
         $expected = array('key', 'member:1', 'member:2');
@@ -64,7 +64,7 @@ class GEOPOS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array(
             array('13.36138933897018433', '38.11555639549629859'),
@@ -85,7 +85,7 @@ class GEOPOS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoPositions()
+    public function testCommandReturnsGeoPositions(): void
     {
         $redis = $this->getClient();
 
@@ -100,7 +100,7 @@ class GEOPOS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GEORADIUSBYMEMBER_Test.php
+++ b/tests/Predis/Command/Redis/GEORADIUSBYMEMBER_Test.php
@@ -20,7 +20,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEORADIUSBYMEMBER';
     }
@@ -28,7 +28,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEORADIUSBYMEMBER';
     }
@@ -36,7 +36,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array(
             'Sicily', 'Agrigento', 100, 'km',
@@ -57,7 +57,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithComplexOptions()
+    public function testFilterArgumentsWithComplexOptions(): void
     {
         $arguments = array(
             'Sicily', 'Agrigento', 100, 'km', array(
@@ -85,7 +85,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithSpecificOptionsSetToFalse()
+    public function testFilterArgumentsWithSpecificOptionsSetToFalse(): void
     {
         $arguments = array(
             'Sicily', 'Agrigento', 100, 'km', array(
@@ -110,7 +110,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithNoOptions()
+    public function testParseResponseWithNoOptions(): void
     {
         $raw = array(
             array('Agrigento', 'Palermo'),
@@ -129,7 +129,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoRadiusInfoWithNoOptions()
+    public function testCommandReturnsGeoRadiusInfoWithNoOptions(): void
     {
         $redis = $this->getClient();
 
@@ -141,7 +141,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoRadiusInfoWithOptions()
+    public function testCommandReturnsGeoRadiusInfoWithOptions(): void
     {
         $redis = $this->getClient();
 
@@ -156,7 +156,7 @@ class GEORADIUSBYMEMBER_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GEORADIUS_Test.php
+++ b/tests/Predis/Command/Redis/GEORADIUS_Test.php
@@ -20,7 +20,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GEORADIUS';
     }
@@ -28,7 +28,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GEORADIUS';
     }
@@ -36,7 +36,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array(
             'Sicily', 15, 37, 200, 'km',
@@ -57,7 +57,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithComplexOptions()
+    public function testFilterArgumentsWithComplexOptions(): void
     {
         $arguments = array(
             'Sicily', 15, 37, 200, 'km', array(
@@ -85,7 +85,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithSpecificOptionsSetToFalse()
+    public function testFilterArgumentsWithSpecificOptionsSetToFalse(): void
     {
         $arguments = array(
             'Sicily', 15, 37, 200, 'km', array(
@@ -110,7 +110,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithNoOptions()
+    public function testParseResponseWithNoOptions(): void
     {
         $raw = array(
             array('Palermo', '190.4424'),
@@ -131,7 +131,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoRadiusInfoWithNoOptions()
+    public function testCommandReturnsGeoRadiusInfoWithNoOptions(): void
     {
         $redis = $this->getClient();
 
@@ -143,7 +143,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testCommandReturnsGeoRadiusInfoWithOptions()
+    public function testCommandReturnsGeoRadiusInfoWithOptions(): void
     {
         $redis = $this->getClient();
 
@@ -158,7 +158,7 @@ class GEORADIUS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GETBIT_Test.php
+++ b/tests/Predis/Command/Redis/GETBIT_Test.php
@@ -20,7 +20,7 @@ class GETBIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GETBIT';
     }
@@ -28,7 +28,7 @@ class GETBIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GETBIT';
     }
@@ -36,7 +36,7 @@ class GETBIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 100);
         $expected = array('key', 100);
@@ -50,7 +50,7 @@ class GETBIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
         $this->assertSame(0, $command->parseResponse(0));
@@ -61,7 +61,7 @@ class GETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCanGetBitsFromString()
+    public function testCanGetBitsFromString(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class GETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnNegativeOffset()
+    public function testThrowsExceptionOnNegativeOffset(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
@@ -92,7 +92,7 @@ class GETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnInvalidOffset()
+    public function testThrowsExceptionOnInvalidOffset(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
@@ -107,7 +107,7 @@ class GETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GETRANGE_Test.php
+++ b/tests/Predis/Command/Redis/GETRANGE_Test.php
@@ -20,7 +20,7 @@ class GETRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GETRANGE';
     }
@@ -28,7 +28,7 @@ class GETRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GETRANGE';
     }
@@ -36,7 +36,7 @@ class GETRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5, 10);
         $expected = array('key', 5, 10);
@@ -50,7 +50,7 @@ class GETRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('substring', $this->getCommand()->parseResponse('substring'));
     }
@@ -59,7 +59,7 @@ class GETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testReturnsSubstring()
+    public function testReturnsSubstring(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class GETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testReturnsEmptyStringOnNonExistingKey()
+    public function testReturnsEmptyStringOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class GETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GETSET_Test.php
+++ b/tests/Predis/Command/Redis/GETSET_Test.php
@@ -20,7 +20,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GETSET';
     }
@@ -28,7 +28,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GETSET';
     }
@@ -36,7 +36,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value');
         $expected = array('key', 'value');
@@ -50,7 +50,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('value', $this->getCommand()->parseResponse('value'));
     }
@@ -58,7 +58,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsPreviousValueOfKey()
+    public function testReturnsPreviousValueOfKey(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class GETSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/GET_Test.php
+++ b/tests/Predis/Command/Redis/GET_Test.php
@@ -20,7 +20,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\GET';
     }
@@ -28,7 +28,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'GET';
     }
@@ -36,7 +36,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('foo');
         $expected = array('foo');
@@ -50,7 +50,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('bar', $this->getCommand()->parseResponse('bar'));
     }
@@ -58,7 +58,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsStringValue()
+    public function testReturnsStringValue(): void
     {
         $redis = $this->getClient();
 
@@ -69,7 +69,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsEmptyStringOnEmptyStrings()
+    public function testReturnsEmptyStringOnEmptyStrings(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnNonExistingKeys()
+    public function testReturnsNullOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -93,7 +93,7 @@ class GET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HDEL_Test.php
+++ b/tests/Predis/Command/Redis/HDEL_Test.php
@@ -20,7 +20,7 @@ class HDEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HDEL';
     }
@@ -28,7 +28,7 @@ class HDEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HDEL';
     }
@@ -36,7 +36,7 @@ class HDEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field1', 'field2', 'field3');
         $expected = array('key', 'field1', 'field2', 'field3');
@@ -50,7 +50,7 @@ class HDEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsAsSingleArray()
+    public function testFilterArgumentsFieldsAsSingleArray(): void
     {
         $arguments = array('key', array('field1', 'field2', 'field3'));
         $expected = array('key', 'field1', 'field2', 'field3');
@@ -64,7 +64,7 @@ class HDEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -73,7 +73,7 @@ class HDEL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDeletesSpecifiedFieldsFromHash()
+    public function testDeletesSpecifiedFieldsFromHash(): void
     {
         $redis = $this->getClient();
 
@@ -88,7 +88,7 @@ class HDEL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/HEXISTS_Test.php
@@ -20,7 +20,7 @@ class HEXISTS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HEXISTS';
     }
@@ -28,7 +28,7 @@ class HEXISTS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HEXISTS';
     }
@@ -36,7 +36,7 @@ class HEXISTS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field');
         $expected = array('key', 'field');
@@ -50,7 +50,7 @@ class HEXISTS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -62,7 +62,7 @@ class HEXISTS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsExistenceOfSpecifiedField()
+    public function testReturnsExistenceOfSpecifiedField(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class HEXISTS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HGETALL_Test.php
+++ b/tests/Predis/Command/Redis/HGETALL_Test.php
@@ -20,7 +20,7 @@ class HGETALL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HGETALL';
     }
@@ -28,7 +28,7 @@ class HGETALL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HGETALL';
     }
@@ -36,7 +36,7 @@ class HGETALL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class HGETALL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('foo', 'bar', 'hoge', 'piyo', 'lol', 'wut');
         $expected = array('foo' => 'bar', 'hoge' => 'piyo', 'lol' => 'wut');
@@ -64,7 +64,7 @@ class HGETALL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsAllTheFieldsAndTheirValues()
+    public function testReturnsAllTheFieldsAndTheirValues(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class HGETALL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HGET_Test.php
+++ b/tests/Predis/Command/Redis/HGET_Test.php
@@ -20,7 +20,7 @@ class HGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HGET';
     }
@@ -28,7 +28,7 @@ class HGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HGET';
     }
@@ -36,7 +36,7 @@ class HGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field');
         $expected = array('key', 'field');
@@ -50,7 +50,7 @@ class HGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('value', $this->getCommand()->parseResponse('value'));
     }
@@ -59,7 +59,7 @@ class HGET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsValueOfSpecifiedField()
+    public function testReturnsValueOfSpecifiedField(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class HGET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HINCRBYFLOAT_Test.php
+++ b/tests/Predis/Command/Redis/HINCRBYFLOAT_Test.php
@@ -20,7 +20,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HINCRBYFLOAT';
     }
@@ -28,7 +28,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HINCRBYFLOAT';
     }
@@ -36,7 +36,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field', 10.5);
         $expected = array('key', 'field', 10.5);
@@ -50,7 +50,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(10.5, $this->getCommand()->parseResponse(10.5));
     }
@@ -59,7 +59,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testIncrementsValueOfFieldByFloat()
+    public function testIncrementsValueOfFieldByFloat(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testDecrementsValueOfFieldByFloat()
+    public function testDecrementsValueOfFieldByFloat(): void
     {
         $redis = $this->getClient();
 
@@ -91,7 +91,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnStringField()
+    public function testThrowsExceptionOnStringField(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessageMatches('/ERR hash value is not a( valid)? float/');
@@ -106,7 +106,7 @@ class HINCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/HINCRBY_Test.php
@@ -20,7 +20,7 @@ class HINCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HINCRBY';
     }
@@ -28,7 +28,7 @@ class HINCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HINCRBY';
     }
@@ -36,7 +36,7 @@ class HINCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field', 10);
         $expected = array('key', 'field', 10);
@@ -50,7 +50,7 @@ class HINCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(10, $this->getCommand()->parseResponse(10));
     }
@@ -59,7 +59,7 @@ class HINCRBY_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testIncrementsValueOfFieldByInteger()
+    public function testIncrementsValueOfFieldByInteger(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class HINCRBY_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDecrementsValueOfFieldByInteger()
+    public function testDecrementsValueOfFieldByInteger(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class HINCRBY_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnStringField()
+    public function testThrowsExceptionOnStringField(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR hash value is not an integer');
@@ -102,7 +102,7 @@ class HINCRBY_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HKEYS_Test.php
+++ b/tests/Predis/Command/Redis/HKEYS_Test.php
@@ -20,7 +20,7 @@ class HKEYS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HKEYS';
     }
@@ -28,7 +28,7 @@ class HKEYS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HKEYS';
     }
@@ -36,7 +36,7 @@ class HKEYS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class HKEYS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('foo', 'hoge', 'lol');
         $expected = array('foo', 'hoge', 'lol');
@@ -64,7 +64,7 @@ class HKEYS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsKeysOfHash()
+    public function testReturnsKeysOfHash(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class HKEYS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HLEN_Test.php
+++ b/tests/Predis/Command/Redis/HLEN_Test.php
@@ -20,7 +20,7 @@ class HLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HLEN';
     }
@@ -28,7 +28,7 @@ class HLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HLEN';
     }
@@ -36,7 +36,7 @@ class HLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class HLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class HLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsLengthOfHash()
+    public function testReturnsLengthOfHash(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class HLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HMGET_Test.php
+++ b/tests/Predis/Command/Redis/HMGET_Test.php
@@ -20,7 +20,7 @@ class HMGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HMGET';
     }
@@ -28,7 +28,7 @@ class HMGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HMGET';
     }
@@ -36,7 +36,7 @@ class HMGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field1', 'field2', 'field3');
         $expected = array('key', 'field1', 'field2', 'field3');
@@ -50,7 +50,7 @@ class HMGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsAsSingleArray()
+    public function testFilterArgumentsFieldsAsSingleArray(): void
     {
         $arguments = array('key', array('field1', 'field2', 'field3'));
         $expected = array('key', 'field1', 'field2', 'field3');
@@ -64,7 +64,7 @@ class HMGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('bar', 'piyo', 'wut');
         $expected = array('bar', 'piyo', 'wut');
@@ -78,7 +78,7 @@ class HMGET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsValuesOfSpecifiedFields()
+    public function testReturnsValuesOfSpecifiedFields(): void
     {
         $redis = $this->getClient();
 
@@ -94,7 +94,7 @@ class HMGET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HMSET_Test.php
+++ b/tests/Predis/Command/Redis/HMSET_Test.php
@@ -20,7 +20,7 @@ class HMSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HMSET';
     }
@@ -28,7 +28,7 @@ class HMSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HMSET';
     }
@@ -36,7 +36,7 @@ class HMSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field1', 'value1', 'field2', 'value2');
         $expected = array('key', 'field1', 'value1', 'field2', 'value2');
@@ -50,7 +50,7 @@ class HMSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsValuesAsSingleArray()
+    public function testFilterArgumentsFieldsValuesAsSingleArray(): void
     {
         $arguments = array('key', array('field1' => 'value1', 'field2' => 'value2'));
         $expected = array('key', 'field1', 'value1', 'field2', 'value2');
@@ -64,7 +64,7 @@ class HMSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -73,7 +73,7 @@ class HMSET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testSetsSpecifiedFieldsOfHash()
+    public function testSetsSpecifiedFieldsOfHash(): void
     {
         $redis = $this->getClient();
 
@@ -88,7 +88,7 @@ class HMSET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testSetsTheSpecifiedField()
+    public function testSetsTheSpecifiedField(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class HMSET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HSCAN_Test.php
+++ b/tests/Predis/Command/Redis/HSCAN_Test.php
@@ -20,7 +20,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HSCAN';
     }
@@ -28,7 +28,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HSCAN';
     }
@@ -36,7 +36,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 'MATCH', 'field:*', 'COUNT', 10);
         $expected = array('key', 0, 'MATCH', 'field:*', 'COUNT', 10);
@@ -50,7 +50,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsBasicUsage()
+    public function testFilterArgumentsBasicUsage(): void
     {
         $arguments = array('key', 0);
         $expected = array('key', 0);
@@ -64,7 +64,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithOptionsArray()
+    public function testFilterArgumentsWithOptionsArray(): void
     {
         $arguments = array('key', 0, array('match' => 'field:*', 'count' => 10));
         $expected = array('key', 0, 'MATCH', 'field:*', 'COUNT', 10);
@@ -78,7 +78,7 @@ class HSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('3', array('field:1', '1', 'field:2', '2', 'field:3', '3'));
         $expected = array('3', array('field:1' => '1', 'field:2' => '2', 'field:3' => '3'));
@@ -92,7 +92,7 @@ class HSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithoutMatch()
+    public function testScanWithoutMatch(): void
     {
         $expectedFields = array('field:one', 'field:two', 'field:three', 'field:four');
         $expectedValues = array('one', 'two', 'three', 'four');
@@ -111,7 +111,7 @@ class HSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithMatchingMembers()
+    public function testScanWithMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->hmset('key', array('field:one' => 'one', 'field:two' => 'two', 'field:three' => 'three', 'field:four' => 'four'));
@@ -126,7 +126,7 @@ class HSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithNoMatchingMembers()
+    public function testScanWithNoMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->hmset('key', array('field:one' => 'one', 'field:two' => 'two', 'field:three' => 'three', 'field:four' => 'four'));

--- a/tests/Predis/Command/Redis/HSETNX_Test.php
+++ b/tests/Predis/Command/Redis/HSETNX_Test.php
@@ -20,7 +20,7 @@ class HSETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HSETNX';
     }
@@ -28,7 +28,7 @@ class HSETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HSETNX';
     }
@@ -36,7 +36,7 @@ class HSETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field', 'value');
         $expected = array('key', 'field', 'value');
@@ -50,7 +50,7 @@ class HSETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -62,7 +62,7 @@ class HSETNX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testSetsNewFieldsAndPreserversExistingOnes()
+    public function testSetsNewFieldsAndPreserversExistingOnes(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class HSETNX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HSET_Test.php
+++ b/tests/Predis/Command/Redis/HSET_Test.php
@@ -20,7 +20,7 @@ class HSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HSET';
     }
@@ -28,7 +28,7 @@ class HSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HSET';
     }
@@ -36,7 +36,7 @@ class HSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field', 'value');
         $expected = array('key', 'field', 'value');
@@ -50,7 +50,7 @@ class HSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -62,7 +62,7 @@ class HSET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testSetsValueOfSpecifiedField()
+    public function testSetsValueOfSpecifiedField(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class HSET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HSTRLEN_Test.php
+++ b/tests/Predis/Command/Redis/HSTRLEN_Test.php
@@ -20,7 +20,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HSTRLEN';
     }
@@ -28,7 +28,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HSTRLEN';
     }
@@ -36,7 +36,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'field');
         $expected = array('key', 'field');
@@ -50,7 +50,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -63,7 +63,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testReturnsStringLengthOfSpecifiedField()
+    public function testReturnsStringLengthOfSpecifiedField(): void
     {
         $redis = $this->getClient();
 
@@ -84,7 +84,7 @@ class HSTRLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/HVALS_Test.php
+++ b/tests/Predis/Command/Redis/HVALS_Test.php
@@ -20,7 +20,7 @@ class HVALS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\HVALS';
     }
@@ -28,7 +28,7 @@ class HVALS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'HVALS';
     }
@@ -36,7 +36,7 @@ class HVALS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class HVALS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('foo', 'hoge', 'lol');
         $expected = array('foo', 'hoge', 'lol');
@@ -64,7 +64,7 @@ class HVALS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsValuesOfHash()
+    public function testReturnsValuesOfHash(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class HVALS_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/INCRBYFLOAT_Test.php
+++ b/tests/Predis/Command/Redis/INCRBYFLOAT_Test.php
@@ -20,7 +20,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\INCRBYFLOAT';
     }
@@ -28,7 +28,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'INCRBYFLOAT';
     }
@@ -36,7 +36,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5.0);
         $expected = array('key', 5.0);
@@ -50,7 +50,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(5.0, $this->getCommand()->parseResponse(5.0));
     }
@@ -59,7 +59,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsTheValueOfTheKeyAfterIncrement()
+    public function testReturnsTheValueOfTheKeyAfterIncrement(): void
     {
         $redis = $this->getClient();
 
@@ -88,7 +88,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnDecrementValueNotFloat()
+    public function testThrowsExceptionOnDecrementValueNotFloat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not a valid float');
@@ -102,7 +102,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnKeyValueNotFloat()
+    public function testThrowsExceptionOnKeyValueNotFloat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not a valid float');
@@ -117,7 +117,7 @@ class INCRBYFLOAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/INCRBY_Test.php
+++ b/tests/Predis/Command/Redis/INCRBY_Test.php
@@ -20,7 +20,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\INCRBY';
     }
@@ -28,7 +28,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'INCRBY';
     }
@@ -36,7 +36,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5);
         $expected = array('key', 5);
@@ -50,7 +50,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(5, $this->getCommand()->parseResponse(5));
     }
@@ -58,7 +58,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -69,7 +69,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTheValueOfTheKeyAfterIncrement()
+    public function testReturnsTheValueOfTheKeyAfterIncrement(): void
     {
         $redis = $this->getClient();
 
@@ -83,7 +83,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnDecrementValueNotInteger()
+    public function testThrowsExceptionOnDecrementValueNotInteger(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -96,7 +96,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnKeyValueNotInteger()
+    public function testThrowsExceptionOnKeyValueNotInteger(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -110,7 +110,7 @@ class INCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/INCR_Test.php
+++ b/tests/Predis/Command/Redis/INCR_Test.php
@@ -20,7 +20,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\INCR';
     }
@@ -28,7 +28,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'INCR';
     }
@@ -36,7 +36,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(5, $this->getCommand()->parseResponse(5));
     }
@@ -58,7 +58,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -69,7 +69,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTheValueOfTheKeyAfterIncrement()
+    public function testReturnsTheValueOfTheKeyAfterIncrement(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class INCR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/INFO_Test.php
+++ b/tests/Predis/Command/Redis/INFO_Test.php
@@ -20,7 +20,7 @@ class INFO_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\INFO';
     }
@@ -28,7 +28,7 @@ class INFO_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'INFO';
     }
@@ -36,7 +36,7 @@ class INFO_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class INFO_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testCanParseNewResponseFormat()
+    public function testCanParseNewResponseFormat(): void
     {
         $raw = <<<BUFFER
 # Server
@@ -191,7 +191,7 @@ BUFFER;
     /**
      * @group disconnected
      */
-    public function testCanParseOldResponsesFormat()
+    public function testCanParseOldResponsesFormat(): void
     {
         $raw = <<<BUFFER
 redis_version:2.4.4
@@ -294,7 +294,7 @@ BUFFER;
     /**
      * @group disconnected
      */
-    public function testDoesNotEmitPhpNoticeOnEmptyResponse()
+    public function testDoesNotEmitPhpNoticeOnEmptyResponse(): void
     {
         $this->assertSame(array(), $this->getCommand()->parseResponse(''));
     }
@@ -303,7 +303,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsAnArrayOfInfo()
+    public function testReturnsAnArrayOfInfo(): void
     {
         $redis = $this->getClient();
         $command = $this->getCommand();
@@ -315,7 +315,7 @@ BUFFER;
      * @group connected
      * @requiresRedisVersion < 2.6.0
      */
-    public function testReturnsAnArrayOfInfoOnOlderRedisVersions()
+    public function testReturnsAnArrayOfInfoOnOlderRedisVersions(): void
     {
         $redis = $this->getClient();
         $command = $this->getCommand();

--- a/tests/Predis/Command/Redis/KEYS_Test.php
+++ b/tests/Predis/Command/Redis/KEYS_Test.php
@@ -20,7 +20,7 @@ class KEYS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\KEYS';
     }
@@ -28,7 +28,7 @@ class KEYS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'KEYS';
     }
@@ -36,7 +36,7 @@ class KEYS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('pattern:*');
         $expected = array('pattern:*');
@@ -50,7 +50,7 @@ class KEYS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('key1', 'key2', 'key3');
         $parsed = array('key1', 'key2', 'key3');
@@ -61,7 +61,7 @@ class KEYS_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsArrayOfMatchingKeys()
+    public function testReturnsArrayOfMatchingKeys(): void
     {
         $keys = array('aaa' => 1, 'aba' => 2, 'aca' => 3);
         $keysNS = array('metavar:foo' => 'bar', 'metavar:hoge' => 'piyo');

--- a/tests/Predis/Command/Redis/LASTSAVE_Test.php
+++ b/tests/Predis/Command/Redis/LASTSAVE_Test.php
@@ -20,7 +20,7 @@ class LASTSAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LASTSAVE';
     }
@@ -28,7 +28,7 @@ class LASTSAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LASTSAVE';
     }
@@ -36,7 +36,7 @@ class LASTSAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class LASTSAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(100, $this->getCommand()->parseResponse(100));
     }
@@ -55,7 +55,7 @@ class LASTSAVE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsIntegerValue()
+    public function testReturnsIntegerValue(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/LINDEX_Test.php
+++ b/tests/Predis/Command/Redis/LINDEX_Test.php
@@ -20,7 +20,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LINDEX';
     }
@@ -28,7 +28,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LINDEX';
     }
@@ -36,7 +36,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 1);
         $expected = array('key', 1);
@@ -50,7 +50,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(0, $this->getCommand()->parseResponse(0));
     }
@@ -58,7 +58,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementAtIndex()
+    public function testReturnsElementAtIndex(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementAtNegativeIndex()
+    public function testReturnsElementAtNegativeIndex(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class LINDEX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LINSERT_Test.php
+++ b/tests/Predis/Command/Redis/LINSERT_Test.php
@@ -20,7 +20,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LINSERT';
     }
@@ -28,7 +28,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LINSERT';
     }
@@ -36,7 +36,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'before', 'value1', 'value2');
         $expected = array('key', 'before', 'value1', 'value2');
@@ -50,7 +50,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsLengthOfListAfterInser()
+    public function testReturnsLengthOfListAfterInser(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNegativeLengthOnFailedInsert()
+    public function testReturnsNegativeLengthOnFailedInsert(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroLengthOnNonExistingList()
+    public function testReturnsZeroLengthOnNonExistingList(): void
     {
         $redis = $this->getClient();
 
@@ -95,7 +95,7 @@ class LINSERT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LLEN_Test.php
+++ b/tests/Predis/Command/Redis/LLEN_Test.php
@@ -20,7 +20,7 @@ class LLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LLEN';
     }
@@ -28,7 +28,7 @@ class LLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LLEN';
     }
@@ -36,7 +36,7 @@ class LLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class LLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class LLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsLengthOfList()
+    public function testReturnsLengthOfList(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class LLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsZeroLengthOnNonExistingList()
+    public function testReturnsZeroLengthOnNonExistingList(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class LLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LPOP_Test.php
+++ b/tests/Predis/Command/Redis/LPOP_Test.php
@@ -20,7 +20,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LPOP';
     }
@@ -28,7 +28,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LPOP';
     }
@@ -36,7 +36,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('element', $this->getCommand()->parseResponse('element'));
     }
@@ -58,7 +58,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testPopsTheFirstElementFromList()
+    public function testPopsTheFirstElementFromList(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnEmptyList()
+    public function testReturnsNullOnEmptyList(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class LPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LPUSHX_Test.php
+++ b/tests/Predis/Command/Redis/LPUSHX_Test.php
@@ -20,7 +20,7 @@ class LPUSHX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LPUSHX';
     }
@@ -28,7 +28,7 @@ class LPUSHX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LPUSHX';
     }
@@ -36,7 +36,7 @@ class LPUSHX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value');
         $expected = array('key', 'value');
@@ -50,7 +50,7 @@ class LPUSHX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class LPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testPushesElementsToHeadOfExistingList()
+    public function testPushesElementsToHeadOfExistingList(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class LPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testDoesNotPushElementOnNonExistingKey()
+    public function testDoesNotPushElementOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -86,7 +86,7 @@ class LPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LPUSH_Test.php
+++ b/tests/Predis/Command/Redis/LPUSH_Test.php
@@ -20,7 +20,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LPUSH';
     }
@@ -28,7 +28,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LPUSH';
     }
@@ -36,7 +36,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value1', 'value2', 'value3');
         $expected = array('key', 'value1', 'value2', 'value3');
@@ -50,7 +50,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsValuesAsSingleArray()
+    public function testFilterArgumentsValuesAsSingleArray(): void
     {
         $arguments = array('key', array('value1', 'value2', 'value3'));
         $expected = array('key', 'value1', 'value2', 'value3');
@@ -64,7 +64,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testPushesElementsToHeadOfList()
+    public function testPushesElementsToHeadOfList(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class LPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LRANGE_Test.php
+++ b/tests/Predis/Command/Redis/LRANGE_Test.php
@@ -20,7 +20,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LRANGE';
     }
@@ -28,7 +28,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LRANGE';
     }
@@ -36,7 +36,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, -1);
         $expected = array('key', 0, -1);
@@ -50,7 +50,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('value1', 'value2', 'value3');
         $expected = array('value1', 'value2', 'value3');
@@ -63,7 +63,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsListSliceWithPositiveStartAndStop()
+    public function testReturnsListSliceWithPositiveStartAndStop(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsListSliceWithPositiveStartAndNegativeStop()
+    public function testReturnsListSliceWithPositiveStartAndNegativeStop(): void
     {
         $redis = $this->getClient();
 
@@ -92,7 +92,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsListSliceWithNegativeStartAndStop()
+    public function testReturnsListSliceWithNegativeStartAndStop(): void
     {
         $redis = $this->getClient();
 
@@ -104,7 +104,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testHandlesStartAndStopOverflow()
+    public function testHandlesStartAndStopOverflow(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsEmptyArrayOnNonExistingList()
+    public function testReturnsEmptyArrayOnNonExistingList(): void
     {
         $redis = $this->getClient();
 
@@ -126,7 +126,7 @@ class LRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LREM_Test.php
+++ b/tests/Predis/Command/Redis/LREM_Test.php
@@ -20,7 +20,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LREM';
     }
@@ -28,7 +28,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LREM';
     }
@@ -36,7 +36,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 1, 'value');
         $expected = array('key', 1, 'value');
@@ -50,7 +50,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesMatchingElementsFromHeadToTail()
+    public function testRemovesMatchingElementsFromHeadToTail(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesMatchingElementsFromTailToHead()
+    public function testRemovesMatchingElementsFromTailToHead(): void
     {
         $redis = $this->getClient();
 
@@ -84,7 +84,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesAllMatchingElements()
+    public function testRemovesAllMatchingElements(): void
     {
         $redis = $this->getClient();
 
@@ -97,7 +97,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnNonMatchingElementsOrEmptyList()
+    public function testReturnsZeroOnNonMatchingElementsOrEmptyList(): void
     {
         $redis = $this->getClient();
 
@@ -110,7 +110,7 @@ class LREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LSET_Test.php
+++ b/tests/Predis/Command/Redis/LSET_Test.php
@@ -20,7 +20,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LSET';
     }
@@ -28,7 +28,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LSET';
     }
@@ -36,7 +36,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 'value');
         $expected = array('key', 0, 'value');
@@ -50,7 +50,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -58,7 +58,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSetsElementAtSpecifiedIndex()
+    public function testSetsElementAtSpecifiedIndex(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnIndexOutOfRange()
+    public function testThrowsExceptionOnIndexOutOfRange(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR index out of range');
@@ -85,7 +85,7 @@ class LSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/LTRIM_Test.php
+++ b/tests/Predis/Command/Redis/LTRIM_Test.php
@@ -20,7 +20,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\LTRIM';
     }
@@ -28,7 +28,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'LTRIM';
     }
@@ -36,7 +36,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 1);
         $expected = array('key', 0, 1);
@@ -50,7 +50,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -58,7 +58,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testTrimsListWithPositiveStartAndStop()
+    public function testTrimsListWithPositiveStartAndStop(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testTrimsListWithPositiveStartAndNegativeStop()
+    public function testTrimsListWithPositiveStartAndNegativeStop(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testTrimsListWithNegativeStartAndStop()
+    public function testTrimsListWithNegativeStartAndStop(): void
     {
         $redis = $this->getClient();
 
@@ -103,7 +103,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testHandlesStartAndStopOverflow()
+    public function testHandlesStartAndStopOverflow(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class LTRIM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/MGET_Test.php
+++ b/tests/Predis/Command/Redis/MGET_Test.php
@@ -20,7 +20,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MGET';
     }
@@ -28,7 +28,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MGET';
     }
@@ -36,7 +36,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -50,7 +50,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -64,7 +64,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('value1', 'value2', 'value3');
         $expected = array('value1', 'value2', 'value3');
@@ -77,7 +77,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsArrayOfValues()
+    public function testReturnsArrayOfValues(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsArrayWithNullValuesOnNonExistingKeys()
+    public function testReturnsArrayWithNullValuesOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -100,7 +100,7 @@ class MGET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testDoesNotThrowExceptionOnWrongType()
+    public function testDoesNotThrowExceptionOnWrongType(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/MIGRATE_Test.php
+++ b/tests/Predis/Command/Redis/MIGRATE_Test.php
@@ -20,7 +20,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MIGRATE';
     }
@@ -28,7 +28,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MIGRATE';
     }
@@ -36,7 +36,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('127.0.0.1', '6379', 'key', '0', '10');
         $expected = array('127.0.0.1', '6379', 'key', '0', '10');
@@ -50,7 +50,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsRedis300()
+    public function testFilterArgumentsRedis300(): void
     {
         $arguments = array('127.0.0.1', '6379', 'key', '0', '10', 'COPY', 'REPLACE');
         $expected = array('127.0.0.1', '6379', 'key', '0', '10', 'COPY', 'REPLACE');
@@ -64,7 +64,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithOptionsArray()
+    public function testFilterArgumentsWithOptionsArray(): void
     {
         $arguments = array('127.0.0.1', '6379', 'key', '0', '10', array('COPY' => true, 'REPLACE' => true));
         $expected = array('127.0.0.1', '6379', 'key', '0', '10', 'COPY', 'REPLACE');
@@ -78,7 +78,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -89,7 +89,7 @@ class MIGRATE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsStatusNOKEYOnNonExistingKey()
+    public function testReturnsStatusNOKEYOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -102,7 +102,7 @@ class MIGRATE_Test extends PredisCommandTestCase
      * @requiresRedisVersion >= 2.6.0
      * @group slow
      */
-    public function testReturnsErrorOnUnreacheableDestination()
+    public function testReturnsErrorOnUnreacheableDestination(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('IOERR');

--- a/tests/Predis/Command/Redis/MONITOR_Test.php
+++ b/tests/Predis/Command/Redis/MONITOR_Test.php
@@ -21,7 +21,7 @@ class MONITOR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MONITOR';
     }
@@ -29,7 +29,7 @@ class MONITOR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MONITOR';
     }
@@ -37,7 +37,7 @@ class MONITOR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -48,7 +48,7 @@ class MONITOR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -56,7 +56,7 @@ class MONITOR_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsStatusResponseAndReadsEventsFromTheConnection()
+    public function testReturnsStatusResponseAndReadsEventsFromTheConnection(): void
     {
         $connection = $this->getClient()->getConnection();
         $command = $this->getCommand();

--- a/tests/Predis/Command/Redis/MOVE_Test.php
+++ b/tests/Predis/Command/Redis/MOVE_Test.php
@@ -20,7 +20,7 @@ class MOVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MOVE';
     }
@@ -28,7 +28,7 @@ class MOVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MOVE';
     }
@@ -36,7 +36,7 @@ class MOVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 10);
         $expected = array('key', 10);
@@ -50,7 +50,7 @@ class MOVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -63,7 +63,7 @@ class MOVE_Test extends PredisCommandTestCase
      *
      * @todo Should be improved, this test fails when REDIS_SERVER_DBNUM is 0.
      */
-    public function testMovesKeysToDifferentDatabases()
+    public function testMovesKeysToDifferentDatabases(): void
     {
         $db = REDIS_SERVER_DBNUM - 1;
         $redis = $this->getClient();
@@ -82,7 +82,7 @@ class MOVE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnInvalidDatabases()
+    public function testThrowsExceptionOnInvalidDatabases(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR index out of range');

--- a/tests/Predis/Command/Redis/MSETNX_Test.php
+++ b/tests/Predis/Command/Redis/MSETNX_Test.php
@@ -20,7 +20,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MSETNX';
     }
@@ -28,7 +28,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MSETNX';
     }
@@ -36,7 +36,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('foo', 'bar', 'hoge', 'piyo');
         $expected = array('foo', 'bar', 'hoge', 'piyo');
@@ -50,7 +50,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleNamedArray()
+    public function testFilterArgumentsAsSingleNamedArray(): void
     {
         $arguments = array(array('foo' => 'bar', 'hoge' => 'piyo'));
         $expected = array('foo', 'bar', 'hoge', 'piyo');
@@ -64,7 +64,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(0, $this->getCommand()->parseResponse(0));
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
@@ -73,7 +73,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesMultipleKeys()
+    public function testCreatesMultipleKeys(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class MSETNX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesMultipleKeysAndPreservesExistingOnes()
+    public function testCreatesMultipleKeysAndPreservesExistingOnes(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/MSET_Test.php
+++ b/tests/Predis/Command/Redis/MSET_Test.php
@@ -20,7 +20,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MSET';
     }
@@ -28,7 +28,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MSET';
     }
@@ -36,7 +36,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('foo', 'bar', 'hoge', 'piyo');
         $expected = array('foo', 'bar', 'hoge', 'piyo');
@@ -50,7 +50,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleNamedArray()
+    public function testFilterArgumentsAsSingleNamedArray(): void
     {
         $arguments = array(array('foo' => 'bar', 'hoge' => 'piyo'));
         $expected = array('foo', 'bar', 'hoge', 'piyo');
@@ -64,7 +64,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -72,7 +72,7 @@ class MSET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCreatesMultipleKeys()
+    public function testCreatesMultipleKeys(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/MULTI_Test.php
+++ b/tests/Predis/Command/Redis/MULTI_Test.php
@@ -20,7 +20,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\MULTI';
     }
@@ -28,7 +28,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'MULTI';
     }
@@ -36,7 +36,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -55,7 +55,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testInitializesNewTransaction()
+    public function testInitializesNewTransaction(): void
     {
         $redis = $this->getClient();
 
@@ -67,7 +67,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testActuallyReturnsResponseObjectAbstraction()
+    public function testActuallyReturnsResponseObjectAbstraction(): void
     {
         $redis = $this->getClient();
 
@@ -79,7 +79,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionWhenCallingMultiInsideTransaction()
+    public function testThrowsExceptionWhenCallingMultiInsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR MULTI calls can not be nested');

--- a/tests/Predis/Command/Redis/OBJECT_Test.php
+++ b/tests/Predis/Command/Redis/OBJECT_Test.php
@@ -20,7 +20,7 @@ class OBJECT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\OBJECT_';
     }
@@ -28,7 +28,7 @@ class OBJECT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'OBJECT';
     }
@@ -36,7 +36,7 @@ class OBJECT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('REFCOUNT', 'key');
         $expected = array('REFCOUNT', 'key');
@@ -50,7 +50,7 @@ class OBJECT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('ziplist', $this->getCommand()->parseResponse('ziplist'));
     }
@@ -59,7 +59,7 @@ class OBJECT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.3
      */
-    public function testObjectRefcount()
+    public function testObjectRefcount(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class OBJECT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.3
      */
-    public function testObjectIdletime()
+    public function testObjectIdletime(): void
     {
         $redis = $this->getClient();
 
@@ -83,7 +83,7 @@ class OBJECT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.3
      */
-    public function testObjectEncoding()
+    public function testObjectEncoding(): void
     {
         $redis = $this->getClient();
 
@@ -95,7 +95,7 @@ class OBJECT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.3
      */
-    public function testReturnsNullOnNonExistingKey()
+    public function testReturnsNullOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -108,7 +108,7 @@ class OBJECT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.3
      */
-    public function testThrowsExceptionOnInvalidSubcommand()
+    public function testThrowsExceptionOnInvalidSubcommand(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/PERSIST_Test.php
+++ b/tests/Predis/Command/Redis/PERSIST_Test.php
@@ -20,7 +20,7 @@ class PERSIST_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PERSIST';
     }
@@ -28,7 +28,7 @@ class PERSIST_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PERSIST';
     }
@@ -36,7 +36,7 @@ class PERSIST_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class PERSIST_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -62,7 +62,7 @@ class PERSIST_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testRemovesExpireFromKey()
+    public function testRemovesExpireFromKey(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class PERSIST_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsZeroOnNonExpiringKeys()
+    public function testReturnsZeroOnNonExpiringKeys(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class PERSIST_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsZeroOnNonExistentKeys()
+    public function testReturnsZeroOnNonExistentKeys(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/PEXPIREAT_Test.php
+++ b/tests/Predis/Command/Redis/PEXPIREAT_Test.php
@@ -20,7 +20,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PEXPIREAT';
     }
@@ -28,7 +28,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PEXPIREAT';
     }
@@ -36,7 +36,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 100);
         $expected = array('key', 100);
@@ -50,7 +50,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -64,7 +64,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
      * @requiresRedisVersion >= 2.6.0
      * @group slow
      */
-    public function testCanExpireKeys()
+    public function testCanExpireKeys(): void
     {
         $ttl = 1.5;
         $redis = $this->getClient();
@@ -83,7 +83,7 @@ class PEXPIREAT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testDeletesKeysOnPastUnixTime()
+    public function testDeletesKeysOnPastUnixTime(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/PEXPIRE_Test.php
+++ b/tests/Predis/Command/Redis/PEXPIRE_Test.php
@@ -20,7 +20,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PEXPIRE';
     }
@@ -28,7 +28,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PEXPIRE';
     }
@@ -36,7 +36,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 100);
         $expected = array('key', 100);
@@ -50,7 +50,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -62,7 +62,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsZeroOnNonExistingKeys()
+    public function testReturnsZeroOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
      * @requiresRedisVersion >= 2.6.0
      * @group slow
      */
-    public function testCanExpireKeys()
+    public function testCanExpireKeys(): void
     {
         $ttl = 1000;
         $redis = $this->getClient();
@@ -93,7 +93,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
       * @requiresRedisVersion >= 2.6.0
       * @group slow
       */
-     public function testConsistencyWithTTL()
+     public function testConsistencyWithTTL(): void
      {
          $ttl = 1000;
          $redis = $this->getClient();
@@ -111,7 +111,7 @@ class PEXPIRE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testDeletesKeysOnNegativeTTL()
+    public function testDeletesKeysOnNegativeTTL(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/PFADD_Test.php
+++ b/tests/Predis/Command/Redis/PFADD_Test.php
@@ -22,7 +22,7 @@ class PFADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PFADD';
     }
@@ -30,7 +30,7 @@ class PFADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PFADD';
     }
@@ -38,7 +38,7 @@ class PFADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'a', 'b', 'c');
         $expected = array('key', 'a', 'b', 'c');
@@ -52,7 +52,7 @@ class PFADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsAsSingleArray()
+    public function testFilterArgumentsFieldsAsSingleArray(): void
     {
         $arguments = array('key', array('a', 'b', 'c'));
         $expected = array('key', 'a', 'b', 'c');
@@ -66,7 +66,7 @@ class PFADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -78,7 +78,7 @@ class PFADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/PFCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/PFCOUNT_Test.php
@@ -22,7 +22,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PFCOUNT';
     }
@@ -30,7 +30,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PFCOUNT';
     }
@@ -38,7 +38,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:1', 'key:2');
         $expected = array('key:1', 'key:2');
@@ -52,7 +52,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsAsSingleArray()
+    public function testFilterArgumentsFieldsAsSingleArray(): void
     {
         $arguments = array(array('key:1', 'key:2'));
         $expected = array('key:1', 'key:2');
@@ -66,7 +66,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -79,7 +79,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -94,7 +94,7 @@ class PFCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongTypeOfAtLeastOneKey()
+    public function testThrowsExceptionOnWrongTypeOfAtLeastOneKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/PFMERGE_Test.php
+++ b/tests/Predis/Command/Redis/PFMERGE_Test.php
@@ -22,7 +22,7 @@ class PFMERGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PFMERGE';
     }
@@ -30,7 +30,7 @@ class PFMERGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PFMERGE';
     }
@@ -38,7 +38,7 @@ class PFMERGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:1', 'key:2', 'key:3');
         $expected = array('key:1', 'key:2', 'key:3');
@@ -52,7 +52,7 @@ class PFMERGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsFieldsAsSingleArray()
+    public function testFilterArgumentsFieldsAsSingleArray(): void
     {
         $arguments = array(array('key:1', 'key:2', 'key:3'));
         $expected = array('key:1', 'key:2', 'key:3');
@@ -66,7 +66,7 @@ class PFMERGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -75,7 +75,7 @@ class PFMERGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/PING_Test.php
+++ b/tests/Predis/Command/Redis/PING_Test.php
@@ -20,7 +20,7 @@ class PING_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PING';
     }
@@ -28,7 +28,7 @@ class PING_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PING';
     }
@@ -36,7 +36,7 @@ class PING_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array();
         $expected = array();
@@ -50,7 +50,7 @@ class PING_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('PONG', $this->getCommand()->parseResponse('PONG'));
     }
@@ -58,7 +58,7 @@ class PING_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testAlwaysReturnsStatusResponse()
+    public function testAlwaysReturnsStatusResponse(): void
     {
         $redis = $this->getClient();
         $response = $redis->ping();

--- a/tests/Predis/Command/Redis/PSETEX_Test.php
+++ b/tests/Predis/Command/Redis/PSETEX_Test.php
@@ -20,7 +20,7 @@ class PSETEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PSETEX';
     }
@@ -28,7 +28,7 @@ class PSETEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PSETEX';
     }
@@ -36,7 +36,7 @@ class PSETEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 10, 'hello');
         $expected = array('key', 10, 'hello');
@@ -50,7 +50,7 @@ class PSETEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -59,7 +59,7 @@ class PSETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testCreatesNewKeyAndSetsTTL()
+    public function testCreatesNewKeyAndSetsTTL(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class PSETEX_Test extends PredisCommandTestCase
      * @group slow
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testKeyExpiresAfterTTL()
+    public function testKeyExpiresAfterTTL(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class PSETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnNonIntegerTTL()
+    public function testThrowsExceptionOnNonIntegerTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -99,7 +99,7 @@ class PSETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnZeroTTL()
+    public function testThrowsExceptionOnZeroTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR invalid expire time');
@@ -111,7 +111,7 @@ class PSETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnNegativeTTL()
+    public function testThrowsExceptionOnNegativeTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR invalid expire time');

--- a/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
@@ -20,7 +20,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PSUBSCRIBE';
     }
@@ -28,7 +28,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PSUBSCRIBE';
     }
@@ -36,7 +36,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channel:foo:*', 'channel:hoge:*');
         $expected = array('channel:foo:*', 'channel:hoge:*');
@@ -50,7 +50,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('channel:foo:*', 'channel:hoge:*'));
         $expected = array('channel:foo:*', 'channel:hoge:*');
@@ -64,7 +64,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('psubscribe', 'channel:*', 1);
         $expected = array('psubscribe', 'channel:*', 1);
@@ -78,7 +78,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsTheFirstPsubscribedChannelDetails()
+    public function testReturnsTheFirstPsubscribedChannelDetails(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendPsubscribeAfterPsubscribe()
+    public function testCanSendPsubscribeAfterPsubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendSubscribeAfterPsubscribe()
+    public function testCanSendSubscribeAfterPsubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -113,7 +113,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendUnsubscribeAfterPsubscribe()
+    public function testCanSendUnsubscribeAfterPsubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -126,7 +126,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendPunsubscribeAfterPsubscribe()
+    public function testCanSendPunsubscribeAfterPsubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -139,7 +139,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendQuitAfterPsubscribe()
+    public function testCanSendQuitAfterPsubscribe(): void
     {
         $redis = $this->getClient();
         $quit = $this->getCommandFactory()->create('quit');
@@ -152,7 +152,7 @@ class PSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCannotSendOtherCommandsAfterPsubscribe()
+    public function testCannotSendOtherCommandsAfterPsubscribe(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessageMatches('/ERR.*only .* allowed in this context/');

--- a/tests/Predis/Command/Redis/PTTL_Test.php
+++ b/tests/Predis/Command/Redis/PTTL_Test.php
@@ -20,7 +20,7 @@ class PTTL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PTTL';
     }
@@ -28,7 +28,7 @@ class PTTL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PTTL';
     }
@@ -36,7 +36,7 @@ class PTTL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 10);
         $expected = array('key', 10);
@@ -50,7 +50,7 @@ class PTTL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -61,7 +61,7 @@ class PTTL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsTTL()
+    public function testReturnsTTL(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class PTTL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsLessThanZeroOnNonExpiringKeys()
+    public function testReturnsLessThanZeroOnNonExpiringKeys(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class PTTL_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsLessThanZeroOnNonExistingKeys()
+    public function testReturnsLessThanZeroOnNonExistingKeys(): void
     {
         if ($this->isRedisServerVersion('<', '2.8.0')) {
             $this->assertSame(-1, $this->getClient()->pttl('foo'));

--- a/tests/Predis/Command/Redis/PUBLISH_Test.php
+++ b/tests/Predis/Command/Redis/PUBLISH_Test.php
@@ -20,7 +20,7 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PUBLISH';
     }
@@ -28,7 +28,7 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PUBLISH';
     }
@@ -36,7 +36,7 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channel', 'message');
         $expected = array('channel', 'message');
@@ -50,7 +50,7 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class PUBLISH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testPublishesMessagesToChannel()
+    public function testPublishesMessagesToChannel(): void
     {
         $redis1 = $this->getClient();
         $redis2 = $this->getClient();

--- a/tests/Predis/Command/Redis/PUBSUB_Test.php
+++ b/tests/Predis/Command/Redis/PUBSUB_Test.php
@@ -20,7 +20,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PUBSUB';
     }
@@ -28,7 +28,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PUBSUB';
     }
@@ -36,7 +36,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channels', 'predis:*');
         $expected = array('channels', 'predis:*');
@@ -50,7 +50,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $response = array('predis:incoming', 'predis:outgoing');
         $expected = array('predis:incoming', 'predis:outgoing');
@@ -63,7 +63,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testPubsubNumsub()
+    public function testPubsubNumsub(): void
     {
         $response = array('predis:incoming', '10', 'predis:outgoing', '8');
         $expected = array('predis:incoming' => '10', 'predis:outgoing' => '8');
@@ -76,7 +76,7 @@ class PUBSUB_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testPubsubNumpat()
+    public function testPubsubNumpat(): void
     {
         $response = 6;
         $expected = 6;

--- a/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
@@ -20,7 +20,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\PUNSUBSCRIBE';
     }
@@ -28,7 +28,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'PUNSUBSCRIBE';
     }
@@ -36,7 +36,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channel:foo:*', 'channel:bar:*');
         $expected = array('channel:foo:*', 'channel:bar:*');
@@ -50,7 +50,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('channel:foo:*', 'channel:bar:*'));
         $expected = array('channel:foo:*', 'channel:bar:*');
@@ -64,7 +64,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('punsubscribe', 'channel:*', 1);
         $expected = array('punsubscribe', 'channel:*', 1);
@@ -78,7 +78,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDoesNotSwitchToSubscribeMode()
+    public function testDoesNotSwitchToSubscribeMode(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testUnsubscribesFromNotSubscribedChannels()
+    public function testUnsubscribesFromNotSubscribedChannels(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testUnsubscribesFromSubscribedChannels()
+    public function testUnsubscribesFromSubscribedChannels(): void
     {
         $redis = $this->getClient();
 
@@ -114,7 +114,7 @@ class PUNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testUnsubscribesFromAllSubscribedChannels()
+    public function testUnsubscribesFromAllSubscribedChannels(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/QUIT_Test.php
+++ b/tests/Predis/Command/Redis/QUIT_Test.php
@@ -20,7 +20,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\QUIT';
     }
@@ -28,7 +28,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'QUIT';
     }
@@ -36,7 +36,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array();
         $expected = array();
@@ -50,7 +50,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -58,7 +58,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsStatusResponseWhenClosingConnection()
+    public function testReturnsStatusResponseWhenClosingConnection(): void
     {
         $redis = $this->getClient();
         $command = $this->getCommand();

--- a/tests/Predis/Command/Redis/RANDOMKEY_Test.php
+++ b/tests/Predis/Command/Redis/RANDOMKEY_Test.php
@@ -20,7 +20,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RANDOMKEY';
     }
@@ -28,7 +28,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RANDOMKEY';
     }
@@ -36,7 +36,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array();
         $expected = array();
@@ -50,7 +50,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = 'key';
         $expected = 'key';
@@ -63,7 +63,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnNonExpiringKeys()
+    public function testReturnsZeroOnNonExpiringKeys(): void
     {
         $keys = array('key:1' => 1, 'key:2' => 2, 'key:3' => 3);
 
@@ -76,7 +76,7 @@ class RANDOMKEY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnEmptyDatabase()
+    public function testReturnsNullOnEmptyDatabase(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/RENAMENX_Test.php
+++ b/tests/Predis/Command/Redis/RENAMENX_Test.php
@@ -20,7 +20,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RENAMENX';
     }
@@ -28,7 +28,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RENAMENX';
     }
@@ -36,7 +36,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'newkey');
         $expected = array('key', 'newkey');
@@ -50,7 +50,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(0, $this->getCommand()->parseResponse(0));
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
@@ -59,7 +59,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRenamesKeys()
+    public function testRenamesKeys(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class RENAMENX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionWhenRenamingNonExistingKeys()
+    public function testThrowsExceptionWhenRenamingNonExistingKeys(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR no such key');

--- a/tests/Predis/Command/Redis/RENAME_Test.php
+++ b/tests/Predis/Command/Redis/RENAME_Test.php
@@ -20,7 +20,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RENAME';
     }
@@ -28,7 +28,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RENAME';
     }
@@ -36,7 +36,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'newkey');
         $expected = array('key', 'newkey');
@@ -50,7 +50,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -58,7 +58,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRenamesKeys()
+    public function testRenamesKeys(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class RENAME_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnNonExistingKeys()
+    public function testThrowsExceptionOnNonExistingKeys(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR no such key');

--- a/tests/Predis/Command/Redis/RESTORE_Test.php
+++ b/tests/Predis/Command/Redis/RESTORE_Test.php
@@ -20,7 +20,7 @@ class RESTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RESTORE';
     }
@@ -28,7 +28,7 @@ class RESTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RESTORE';
     }
@@ -36,7 +36,7 @@ class RESTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, "\x00\xC0\n\x06\x00\xF8r?\xC5\xFB\xFB_(");
         $expected = array('key', 0, "\x00\xC0\n\x06\x00\xF8r?\xC5\xFB\xFB_(");
@@ -50,7 +50,7 @@ class RESTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertTrue($this->getCommand()->parseResponse(true));
     }

--- a/tests/Predis/Command/Redis/RPOPLPUSH_Test.php
+++ b/tests/Predis/Command/Redis/RPOPLPUSH_Test.php
@@ -20,7 +20,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RPOPLPUSH';
     }
@@ -28,7 +28,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RPOPLPUSH';
     }
@@ -36,7 +36,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:source', 'key:destination');
         $expected = array('key:source', 'key:destination');
@@ -50,7 +50,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('element', $this->getCommand()->parseResponse('element'));
     }
@@ -58,7 +58,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementPoppedFromSourceAndPushesToDestination()
+    public function testReturnsElementPoppedFromSourceAndPushesToDestination(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementPoppedFromSourceAndPushesToSelf()
+    public function testReturnsElementPoppedFromSourceAndPushesToSelf(): void
     {
         $redis = $this->getClient();
 
@@ -91,7 +91,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnEmptySource()
+    public function testReturnsNullOnEmptySource(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfSourceKey()
+    public function testThrowsExceptionOnWrongTypeOfSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -115,7 +115,7 @@ class RPOPLPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfDestinationKey()
+    public function testThrowsExceptionOnWrongTypeOfDestinationKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/RPOP_Test.php
+++ b/tests/Predis/Command/Redis/RPOP_Test.php
@@ -20,7 +20,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RPOP';
     }
@@ -28,7 +28,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RPOP';
     }
@@ -36,7 +36,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('element', $this->getCommand()->parseResponse('element'));
     }
@@ -58,7 +58,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testPopsTheLastElementFromList()
+    public function testPopsTheLastElementFromList(): void
     {
         $redis = $this->getClient();
 
@@ -72,7 +72,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnEmptyList()
+    public function testReturnsNullOnEmptyList(): void
     {
         $redis = $this->getClient();
 
@@ -82,7 +82,7 @@ class RPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/RPUSHX_Test.php
+++ b/tests/Predis/Command/Redis/RPUSHX_Test.php
@@ -20,7 +20,7 @@ class RPUSHX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RPUSHX';
     }
@@ -28,7 +28,7 @@ class RPUSHX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RPUSHX';
     }
@@ -36,7 +36,7 @@ class RPUSHX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value');
         $expected = array('key', 'value');
@@ -50,7 +50,7 @@ class RPUSHX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class RPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testPushesElementsToHeadOfExistingList()
+    public function testPushesElementsToHeadOfExistingList(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class RPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testDoesNotPushElementOnNonExistingKey()
+    public function testDoesNotPushElementOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -86,7 +86,7 @@ class RPUSHX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/RPUSH_Test.php
+++ b/tests/Predis/Command/Redis/RPUSH_Test.php
@@ -20,7 +20,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\RPUSH';
     }
@@ -28,7 +28,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'RPUSH';
     }
@@ -36,7 +36,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'value1', 'value2', 'value3');
         $expected = array('key', 'value1', 'value2', 'value3');
@@ -50,7 +50,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsValuesAsSingleArray()
+    public function testFilterArgumentsValuesAsSingleArray(): void
     {
         $arguments = array('key', array('value1', 'value2', 'value3'));
         $expected = array('key', 'value1', 'value2', 'value3');
@@ -64,7 +64,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testPushesElementsToHeadOfList()
+    public function testPushesElementsToHeadOfList(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class RPUSH_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SADD_Test.php
+++ b/tests/Predis/Command/Redis/SADD_Test.php
@@ -20,7 +20,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SADD';
     }
@@ -28,7 +28,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SADD';
     }
@@ -36,7 +36,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member1', 'member2', 'member3');
         $expected = array('key', 'member1', 'member2', 'member3');
@@ -50,7 +50,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsValuesAsSingleArray()
+    public function testFilterArgumentsValuesAsSingleArray(): void
     {
         $arguments = array('key', array('member1', 'member2', 'member3'));
         $expected = array('key', 'member1', 'member2', 'member3');
@@ -64,7 +64,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testAddsMembersToSet()
+    public function testAddsMembersToSet(): void
     {
         $redis = $this->getClient();
 
@@ -95,7 +95,7 @@ class SADD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SAVE_Test.php
+++ b/tests/Predis/Command/Redis/SAVE_Test.php
@@ -20,7 +20,7 @@ class SAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SAVE';
     }
@@ -28,7 +28,7 @@ class SAVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SAVE';
     }
@@ -36,7 +36,7 @@ class SAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class SAVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertTrue($this->getCommand()->parseResponse(true));
     }

--- a/tests/Predis/Command/Redis/SCAN_Test.php
+++ b/tests/Predis/Command/Redis/SCAN_Test.php
@@ -20,7 +20,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SCAN';
     }
@@ -28,7 +28,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SCAN';
     }
@@ -36,7 +36,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array(0, 'MATCH', 'key:*', 'COUNT', 5);
         $expected = array(0, 'MATCH', 'key:*', 'COUNT', 5);
@@ -50,7 +50,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsBasicUsage()
+    public function testFilterArgumentsBasicUsage(): void
     {
         $arguments = array(0);
         $expected = array(0);
@@ -64,7 +64,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithOptionsArray()
+    public function testFilterArgumentsWithOptionsArray(): void
     {
         $arguments = array(0, array('match' => 'key:*', 'count' => 5));
         $expected = array(0, 'MATCH', 'key:*', 'COUNT', 5);
@@ -78,7 +78,7 @@ class SCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('3', array('key:1', 'key:2', 'key:3'));
         $expected = array('3', array('key:1', 'key:2', 'key:3'));
@@ -92,7 +92,7 @@ class SCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithoutMatch()
+    public function testScanWithoutMatch(): void
     {
         $kvs = array('key:one' => 'one', 'key:two' => 'two', 'key:three' => 'three', 'key:four' => 'four');
 
@@ -108,7 +108,7 @@ class SCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithMatchingKeys()
+    public function testScanWithMatchingKeys(): void
     {
         $kvs = array('key:one' => 'one', 'key:two' => 'two', 'key:three' => 'three', 'key:four' => 'four');
 
@@ -124,7 +124,7 @@ class SCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithNoMatchingKeys()
+    public function testScanWithNoMatchingKeys(): void
     {
         $kvs = array('key:one' => 'one', 'key:two' => 'two', 'key:three' => 'three', 'key:four' => 'four');
 

--- a/tests/Predis/Command/Redis/SCARD_Test.php
+++ b/tests/Predis/Command/Redis/SCARD_Test.php
@@ -20,7 +20,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SCARD';
     }
@@ -28,7 +28,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SCARD';
     }
@@ -36,7 +36,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNumberOfMembers()
+    public function testReturnsNumberOfMembers(): void
     {
         $redis = $this->getClient();
 
@@ -70,7 +70,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnEmptySet()
+    public function testReturnsZeroOnEmptySet(): void
     {
         $redis = $this->getClient();
 
@@ -80,7 +80,7 @@ class SCARD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SCRIPT_Test.php
+++ b/tests/Predis/Command/Redis/SCRIPT_Test.php
@@ -20,7 +20,7 @@ class SCRIPT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SCRIPT';
     }
@@ -28,7 +28,7 @@ class SCRIPT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SCRIPT';
     }
@@ -36,7 +36,7 @@ class SCRIPT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('EXISTS', '9d0c0826bde023cc39eebaaf832c32a890f3b088', 'ffffffffffffffffffffffffffffffffffffffff');
         $expected = array('EXISTS', '9d0c0826bde023cc39eebaaf832c32a890f3b088', 'ffffffffffffffffffffffffffffffffffffffff');
@@ -50,7 +50,7 @@ class SCRIPT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -59,7 +59,7 @@ class SCRIPT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testExistsReturnsAnArrayOfValues()
+    public function testExistsReturnsAnArrayOfValues(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class SCRIPT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testLoadReturnsHashOfScripts()
+    public function testLoadReturnsHashOfScripts(): void
     {
         $redis = $this->getClient();
 
@@ -87,7 +87,7 @@ class SCRIPT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testFlushesExistingScripts()
+    public function testFlushesExistingScripts(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class SCRIPT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testThrowsExceptionOnInvalidSubcommand()
+    public function testThrowsExceptionOnInvalidSubcommand(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/SDIFFSTORE_Test.php
+++ b/tests/Predis/Command/Redis/SDIFFSTORE_Test.php
@@ -20,7 +20,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SDIFFSTORE';
     }
@@ -28,7 +28,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SDIFFSTORE';
     }
@@ -36,7 +36,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:destination', 'key:source1', 'key:source:2');
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -50,7 +50,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsSourceKeysAsSingleArray()
+    public function testFilterArgumentsSourceKeysAsSingleArray(): void
     {
         $arguments = array('key:destination', array('key:source1', 'key:source:2'));
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -64,7 +64,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresMembersOfSetOnSingleSet()
+    public function testStoresMembersOfSetOnSingleSet(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresDifferenceOfMultipleSets()
+    public function testStoresDifferenceOfMultipleSets(): void
     {
         $redis = $this->getClient();
 
@@ -103,7 +103,7 @@ class SDIFFSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfSourceKey()
+    public function testThrowsExceptionOnWrongTypeOfSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SDIFF_Test.php
+++ b/tests/Predis/Command/Redis/SDIFF_Test.php
@@ -20,7 +20,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SDIFF';
     }
@@ -28,7 +28,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SDIFF';
     }
@@ -36,7 +36,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -50,7 +50,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -64,7 +64,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('member1', 'member2', 'member3');
         $expected = array('member1', 'member2', 'member3');
@@ -77,7 +77,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersOnSingleKeyOrNonExistingSetForDifference()
+    public function testReturnsMembersOnSingleKeyOrNonExistingSetForDifference(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersFromDifferenceAmongSets()
+    public function testReturnsMembersFromDifferenceAmongSets(): void
     {
         $redis = $this->getClient();
 
@@ -105,7 +105,7 @@ class SDIFF_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SELECT_Test.php
+++ b/tests/Predis/Command/Redis/SELECT_Test.php
@@ -20,7 +20,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SELECT';
     }
@@ -28,7 +28,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SELECT';
     }
@@ -36,7 +36,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array(10);
         $expected = array(10);
@@ -50,7 +50,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -58,7 +58,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testCanSelectDifferentDatabase()
+    public function testCanSelectDifferentDatabase(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnUnexpectedDatabaseRange()
+    public function testThrowsExceptionOnUnexpectedDatabaseRange(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessageMatches('/ERR.*DB index/');
@@ -84,7 +84,7 @@ class SELECT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnUnexpectedDatabaseName()
+    public function testThrowsExceptionOnUnexpectedDatabaseName(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR invalid DB index');

--- a/tests/Predis/Command/Redis/SENTINEL_Test.php
+++ b/tests/Predis/Command/Redis/SENTINEL_Test.php
@@ -20,7 +20,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SENTINEL';
     }
@@ -28,7 +28,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SENTINEL';
     }
@@ -36,7 +36,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('get-master-addr-by-name', 'predis:master');
         $expected = array('get-master-addr-by-name', 'predis:master');
@@ -49,7 +49,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $expected = array('127.0.0.1', '6379');
         $command = $this->getCommand();
@@ -60,7 +60,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testSentinelMastersResponse()
+    public function testSentinelMastersResponse(): void
     {
         $response = array(
             array(
@@ -104,7 +104,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testSentinelSlavesResponse()
+    public function testSentinelSlavesResponse(): void
     {
         $response = array(
             array(
@@ -152,7 +152,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testSentinelIsMasterDownByAddr()
+    public function testSentinelIsMasterDownByAddr(): void
     {
         $response = array('0', '7388832d5fdee6a2e301d6bbc5052bd1526d741c');
         $expected = array('0', '7388832d5fdee6a2e301d6bbc5052bd1526d741c');
@@ -165,7 +165,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testSentinelGetMasterAddrByName()
+    public function testSentinelGetMasterAddrByName(): void
     {
         $response = array('127.0.0.1', '6379');
         $expected = array('127.0.0.1', '6379');
@@ -178,7 +178,7 @@ class SENTINEL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testSentinelReset()
+    public function testSentinelReset(): void
     {
         $response = 1;
         $expected = 1;

--- a/tests/Predis/Command/Redis/SETBIT_Test.php
+++ b/tests/Predis/Command/Redis/SETBIT_Test.php
@@ -20,7 +20,7 @@ class SETBIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SETBIT';
     }
@@ -28,7 +28,7 @@ class SETBIT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SETBIT';
     }
@@ -36,7 +36,7 @@ class SETBIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 7, 1);
         $expected = array('key', 7, 1);
@@ -50,7 +50,7 @@ class SETBIT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
         $this->assertSame(0, $command->parseResponse(0));
@@ -61,7 +61,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCanSetBitsOfStrings()
+    public function testCanSetBitsOfStrings(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnInvalidBitValue()
+    public function testThrowsExceptionOnInvalidBitValue(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR bit is not an integer or out of range');
@@ -102,7 +102,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnNegativeOffset()
+    public function testThrowsExceptionOnNegativeOffset(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
@@ -114,7 +114,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnInvalidOffset()
+    public function testThrowsExceptionOnInvalidOffset(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
@@ -126,7 +126,7 @@ class SETBIT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SETEX_Test.php
+++ b/tests/Predis/Command/Redis/SETEX_Test.php
@@ -20,7 +20,7 @@ class SETEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SETEX';
     }
@@ -28,7 +28,7 @@ class SETEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SETEX';
     }
@@ -36,7 +36,7 @@ class SETEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 10, 'hello');
         $expected = array('key', 10, 'hello');
@@ -50,7 +50,7 @@ class SETEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -59,7 +59,7 @@ class SETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCreatesNewKeyAndSetsTTL()
+    public function testCreatesNewKeyAndSetsTTL(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class SETEX_Test extends PredisCommandTestCase
      * @group slow
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testKeyExpiresAfterTTL()
+    public function testKeyExpiresAfterTTL(): void
     {
         $redis = $this->getClient();
 
@@ -88,7 +88,7 @@ class SETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnNonIntegerTTL()
+    public function testThrowsExceptionOnNonIntegerTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR value is not an integer or out of range');
@@ -100,7 +100,7 @@ class SETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnZeroTTL()
+    public function testThrowsExceptionOnZeroTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR invalid expire time');
@@ -112,7 +112,7 @@ class SETEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnNegativeTTL()
+    public function testThrowsExceptionOnNegativeTTL(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR invalid expire time');

--- a/tests/Predis/Command/Redis/SETNX_Test.php
+++ b/tests/Predis/Command/Redis/SETNX_Test.php
@@ -20,7 +20,7 @@ class SETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SETNX';
     }
@@ -28,7 +28,7 @@ class SETNX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SETNX';
     }
@@ -36,7 +36,7 @@ class SETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('foo', 'bar');
         $expected = array('foo', 'bar');
@@ -50,7 +50,7 @@ class SETNX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(0, $this->getCommand()->parseResponse(0));
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
@@ -59,7 +59,7 @@ class SETNX_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSetStringValue()
+    public function testSetStringValue(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/SETRANGE_Test.php
+++ b/tests/Predis/Command/Redis/SETRANGE_Test.php
@@ -20,7 +20,7 @@ class SETRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SETRANGE';
     }
@@ -28,7 +28,7 @@ class SETRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SETRANGE';
     }
@@ -36,7 +36,7 @@ class SETRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5, 'range');
         $expected = array('key', 5, 'range');
@@ -50,7 +50,7 @@ class SETRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(10, $this->getCommand()->parseResponse(10));
     }
@@ -59,7 +59,7 @@ class SETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCreatesNewKeyOnNonExistingKey()
+    public function testCreatesNewKeyOnNonExistingKey(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class SETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testOverwritesOrAppendBytesInKeys()
+    public function testOverwritesOrAppendBytesInKeys(): void
     {
         $redis = $this->getClient();
 
@@ -91,7 +91,7 @@ class SETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testHandlesBinaryData()
+    public function testHandlesBinaryData(): void
     {
         $redis = $this->getClient();
 
@@ -105,7 +105,7 @@ class SETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnInvalidOffset()
+    public function testThrowsExceptionOnInvalidOffset(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR offset is out of range');
@@ -117,7 +117,7 @@ class SETRANGE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SET_Test.php
+++ b/tests/Predis/Command/Redis/SET_Test.php
@@ -20,7 +20,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SET';
     }
@@ -28,7 +28,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SET';
     }
@@ -36,7 +36,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('foo', 'bar');
         $expected = array('foo', 'bar');
@@ -50,7 +50,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsRedisWithModifiers()
+    public function testFilterArgumentsRedisWithModifiers(): void
     {
         $arguments = array('foo', 'bar', 'EX', '10', 'NX');
         $expected = array('foo', 'bar', 'EX', '10', 'NX');
@@ -64,7 +64,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -72,7 +72,7 @@ class SET_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSetStringValue()
+    public function testSetStringValue(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class SET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.12
      */
-    public function testSetStringValueWithModifierEX()
+    public function testSetStringValueWithModifierEX(): void
     {
         $redis = $this->getClient();
 
@@ -97,7 +97,7 @@ class SET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.12
      */
-    public function testSetStringValueWithModifierPX()
+    public function testSetStringValueWithModifierPX(): void
     {
         $redis = $this->getClient();
 
@@ -112,7 +112,7 @@ class SET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.12
      */
-    public function testSetStringValueWithModifierNX()
+    public function testSetStringValueWithModifierNX(): void
     {
         $redis = $this->getClient();
 
@@ -124,7 +124,7 @@ class SET_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.12
      */
-    public function testSetStringValueWithModifierXX()
+    public function testSetStringValueWithModifierXX(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/SHUTDOWN_Test.php
+++ b/tests/Predis/Command/Redis/SHUTDOWN_Test.php
@@ -20,7 +20,7 @@ class SHUTDOWN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SHUTDOWN';
     }
@@ -28,7 +28,7 @@ class SHUTDOWN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SHUTDOWN';
     }
@@ -36,7 +36,7 @@ class SHUTDOWN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());

--- a/tests/Predis/Command/Redis/SINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/SINTERSTORE_Test.php
@@ -20,7 +20,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SINTERSTORE';
     }
@@ -28,7 +28,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SINTERSTORE';
     }
@@ -36,7 +36,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:destination', 'key:source1', 'key:source:2');
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -50,7 +50,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsSourceKeysAsSingleArray()
+    public function testFilterArgumentsSourceKeysAsSingleArray(): void
     {
         $arguments = array('key:destination', array('key:source1', 'key:source:2'));
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -64,7 +64,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresMembersOfSetOnSingleKey()
+    public function testStoresMembersOfSetOnSingleKey(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testDoesNotStoreOnNonExistingSetForIntersection()
+    public function testDoesNotStoreOnNonExistingSetForIntersection(): void
     {
         $redis = $this->getClient();
 
@@ -98,7 +98,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresIntersectionOfMultipleSets()
+    public function testStoresIntersectionOfMultipleSets(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class SINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfSourceKey()
+    public function testThrowsExceptionOnWrongTypeOfSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SINTER_Test.php
+++ b/tests/Predis/Command/Redis/SINTER_Test.php
@@ -20,7 +20,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SINTER';
     }
@@ -28,7 +28,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SINTER';
     }
@@ -36,7 +36,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -50,7 +50,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -64,7 +64,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('member1', 'member2', 'member3');
         $expected = array('member1', 'member2', 'member3');
@@ -77,7 +77,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersOfSetOnSingleKey()
+    public function testReturnsMembersOfSetOnSingleKey(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsEmptyArrayOnNonExistingSetForIntersection()
+    public function testReturnsEmptyArrayOnNonExistingSetForIntersection(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersFromIntersectionAmongSets()
+    public function testReturnsMembersFromIntersectionAmongSets(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class SINTER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SISMEMBER_Test.php
+++ b/tests/Predis/Command/Redis/SISMEMBER_Test.php
@@ -20,7 +20,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SISMEMBER';
     }
@@ -28,7 +28,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SISMEMBER';
     }
@@ -36,7 +36,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member');
         $expected = array('key', 'member');
@@ -50,7 +50,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -61,7 +61,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMemberExistenceInSet()
+    public function testReturnsMemberExistenceInSet(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsZeroOnNonExistingSet()
+    public function testReturnsZeroOnNonExistingSet(): void
     {
         $redis = $this->getClient();
 
@@ -84,7 +84,7 @@ class SISMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SLAVEOF_Test.php
+++ b/tests/Predis/Command/Redis/SLAVEOF_Test.php
@@ -20,7 +20,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SLAVEOF';
     }
@@ -28,7 +28,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SLAVEOF';
     }
@@ -36,7 +36,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsHostPortArray()
+    public function testFilterArgumentsHostPortArray(): void
     {
         $arguments = array('127.0.0.1', '80');
         $expected = array('127.0.0.1', '80');
@@ -50,7 +50,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsNoOneArray()
+    public function testFilterArgumentsNoOneArray(): void
     {
         $arguments = array('NO', 'ONE');
         $expected = array('NO', 'ONE');
@@ -64,7 +64,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsNoOneString()
+    public function testFilterArgumentsNoOneString(): void
     {
         $arguments = array('NO ONE');
         $expected = array('NO', 'ONE');
@@ -78,7 +78,7 @@ class SLAVEOF_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertTrue($this->getCommand()->parseResponse(true));
     }

--- a/tests/Predis/Command/Redis/SLOWLOG_Test.php
+++ b/tests/Predis/Command/Redis/SLOWLOG_Test.php
@@ -23,7 +23,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SLOWLOG';
     }
@@ -31,7 +31,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SLOWLOG';
     }
@@ -39,7 +39,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('GET', '2');
         $expected = array('GET', '2');
@@ -55,7 +55,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
      *
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array(array(0, 1323163469, 12451, array('SORT', 'list:unordered')));
         $expected = array(
@@ -77,7 +77,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
      *
      * @group disconnected
      */
-    public function testParseResponseInteger()
+    public function testParseResponseInteger(): void
     {
         $command = $this->getCommand();
 
@@ -88,7 +88,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.12
      */
-    public function testReturnsAnArrayOfLoggedCommands()
+    public function testReturnsAnArrayOfLoggedCommands(): void
     {
         $redis = $this->getClient();
 
@@ -114,7 +114,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.12
      */
-    public function testCanResetTheLog()
+    public function testCanResetTheLog(): void
     {
         $redis = $this->getClient();
 
@@ -125,7 +125,7 @@ class SLOWLOG_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.12
      */
-    public function testThrowsExceptionOnInvalidSubcommand()
+    public function testThrowsExceptionOnInvalidSubcommand(): void
     {
         $this->expectException('Predis\Response\ServerException');
 

--- a/tests/Predis/Command/Redis/SMEMBERS_Test.php
+++ b/tests/Predis/Command/Redis/SMEMBERS_Test.php
@@ -20,7 +20,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SMEMBERS';
     }
@@ -28,7 +28,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SMEMBERS';
     }
@@ -36,7 +36,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('member1', 'member2', 'member3');
         $expected = array('member1', 'member2', 'member3');
@@ -63,7 +63,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsEmptyArrayOnNonExistingSet()
+    public function testReturnsEmptyArrayOnNonExistingSet(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class SMEMBERS_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SMOVE_Test.php
+++ b/tests/Predis/Command/Redis/SMOVE_Test.php
@@ -20,7 +20,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SMOVE';
     }
@@ -28,7 +28,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SMOVE';
     }
@@ -36,7 +36,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:source', 'key:destination', 'member');
         $expected = array('key:source', 'key:destination', 'member');
@@ -50,7 +50,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -61,7 +61,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMemberExistenceInSet()
+    public function testReturnsMemberExistenceInSet(): void
     {
         $redis = $this->getClient();
 
@@ -77,7 +77,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfSourceKey()
+    public function testThrowsExceptionOnWrongTypeOfSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');
@@ -92,7 +92,7 @@ class SMOVE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfDestinationKey()
+    public function testThrowsExceptionOnWrongTypeOfDestinationKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SORT_Test.php
+++ b/tests/Predis/Command/Redis/SORT_Test.php
@@ -22,7 +22,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SORT';
     }
@@ -30,7 +30,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SORT';
     }
@@ -54,7 +54,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'by' => 'by_key_*',
@@ -80,7 +80,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testGetModifierCanBeString()
+    public function testGetModifierCanBeString(): void
     {
         $arguments = array('key', array('get' => '#'));
         $expected = array('key', 'GET', '#');
@@ -94,7 +94,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('value1', 'value2', 'value3');
         $expected = array('value1', 'value2', 'value3');
@@ -107,7 +107,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testBasicSort()
+    public function testBasicSort(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -118,7 +118,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithAscOrDescModifier()
+    public function testSortWithAscOrDescModifier(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -141,7 +141,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithLimitModifier()
+    public function testSortWithLimitModifier(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -164,7 +164,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithAlphaModifier()
+    public function testSortWithAlphaModifier(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -180,7 +180,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithStoreModifier()
+    public function testSortWithStoreModifier(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -198,7 +198,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithCombinedModifiers()
+    public function testSortWithCombinedModifiers(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -216,7 +216,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testSortWithGetModifiers()
+    public function testSortWithGetModifiers(): void
     {
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
@@ -233,7 +233,7 @@ class SORT_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SPOP_Test.php
+++ b/tests/Predis/Command/Redis/SPOP_Test.php
@@ -20,7 +20,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SPOP';
     }
@@ -28,7 +28,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SPOP';
     }
@@ -36,7 +36,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 2);
         $expected = array('key', 2);
@@ -50,7 +50,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('member', $this->getCommand()->parseResponse('member'));
     }
@@ -58,7 +58,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testPopsRandomMemberFromSet()
+    public function testPopsRandomMemberFromSet(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class SPOP_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.2.0
      */
-    public function testPopsMoreRandomMembersFromSet()
+    public function testPopsMoreRandomMembersFromSet(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class SPOP_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SRANDMEMBER_Test.php
+++ b/tests/Predis/Command/Redis/SRANDMEMBER_Test.php
@@ -20,7 +20,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SRANDMEMBER';
     }
@@ -28,7 +28,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SRANDMEMBER';
     }
@@ -36,7 +36,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 1);
         $expected = array('key', 1);
@@ -50,7 +50,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('member', $this->getCommand()->parseResponse('member'));
     }
@@ -58,7 +58,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsRandomMemberFromSet()
+    public function testReturnsRandomMemberFromSet(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsNullOnNonExistingSet()
+    public function testReturnsNullOnNonExistingSet(): void
     {
         $this->assertNull($this->getClient()->srandmember('letters'));
     }
@@ -81,7 +81,7 @@ class SRANDMEMBER_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SREM_Test.php
+++ b/tests/Predis/Command/Redis/SREM_Test.php
@@ -20,7 +20,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SREM';
     }
@@ -28,7 +28,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SREM';
     }
@@ -36,7 +36,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member1', 'member2', 'member3');
         $expected = array('key', 'member1', 'member2', 'member3');
@@ -50,7 +50,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsMembersAsSingleArray()
+    public function testFilterArgumentsMembersAsSingleArray(): void
     {
         $arguments = array('key', array('member1', 'member2', 'member3'));
         $expected = array('key', 'member1', 'member2', 'member3');
@@ -64,7 +64,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesMembersFromSet()
+    public function testRemovesMembersFromSet(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class SREM_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.4.0
      */
-    public function testRemovesMembersFromSetVariadic()
+    public function testRemovesMembersFromSetVariadic(): void
     {
         $redis = $this->getClient();
 
@@ -104,7 +104,7 @@ class SREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SSCAN_Test.php
+++ b/tests/Predis/Command/Redis/SSCAN_Test.php
@@ -20,7 +20,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SSCAN';
     }
@@ -28,7 +28,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SSCAN';
     }
@@ -36,7 +36,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
         $expected = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
@@ -50,7 +50,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsBasicUsage()
+    public function testFilterArgumentsBasicUsage(): void
     {
         $arguments = array('key', 0);
         $expected = array('key', 0);
@@ -64,7 +64,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithOptionsArray()
+    public function testFilterArgumentsWithOptionsArray(): void
     {
         $arguments = array('key', 0, array('match' => 'member:*', 'count' => 10));
         $expected = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
@@ -78,7 +78,7 @@ class SSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('3', array('member:1', 'member:2', 'member:3'));
         $expected = array('3', array('member:1', 'member:2', 'member:3'));
@@ -92,7 +92,7 @@ class SSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithoutMatch()
+    public function testScanWithoutMatch(): void
     {
         $redis = $this->getClient();
         $redis->sadd('key', $members = array('member:one', 'member:two', 'member:three', 'member:four'));
@@ -107,7 +107,7 @@ class SSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithMatchingMembers()
+    public function testScanWithMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->sadd('key', $members = array('member:one', 'member:two', 'member:three', 'member:four'));
@@ -121,7 +121,7 @@ class SSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithNoMatchingMembers()
+    public function testScanWithNoMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->sadd('key', $members = array('member:one', 'member:two', 'member:three', 'member:four'));

--- a/tests/Predis/Command/Redis/STRLEN_Test.php
+++ b/tests/Predis/Command/Redis/STRLEN_Test.php
@@ -20,7 +20,7 @@ class STRLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\STRLEN';
     }
@@ -28,7 +28,7 @@ class STRLEN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'STRLEN';
     }
@@ -36,7 +36,7 @@ class STRLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class STRLEN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(4, $this->getCommand()->parseResponse(4));
     }
@@ -59,7 +59,7 @@ class STRLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsTheLengthOfString()
+    public function testReturnsTheLengthOfString(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class STRLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsZeroOnNonExistingKeys()
+    public function testReturnsZeroOnNonExistingKeys(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class STRLEN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
@@ -20,7 +20,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SUBSCRIBE';
     }
@@ -28,7 +28,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SUBSCRIBE';
     }
@@ -36,7 +36,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channel:foo', 'channel:bar');
         $expected = array('channel:foo', 'channel:bar');
@@ -50,7 +50,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('channel:foo', 'channel:bar'));
         $expected = array('channel:foo', 'channel:bar');
@@ -64,7 +64,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('subscribe', 'channel', 1);
         $expected = array('subscribe', 'channel', 1);
@@ -78,7 +78,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsTheFirstSubscribedChannelDetails()
+    public function testReturnsTheFirstSubscribedChannelDetails(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendSubscribeAfterSubscribe()
+    public function testCanSendSubscribeAfterSubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendPsubscribeAfterSubscribe()
+    public function testCanSendPsubscribeAfterSubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -113,7 +113,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendUnsubscribeAfterSubscribe()
+    public function testCanSendUnsubscribeAfterSubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -126,7 +126,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendPunsubscribeAfterSubscribe()
+    public function testCanSendPunsubscribeAfterSubscribe(): void
     {
         $redis = $this->getClient();
 
@@ -139,7 +139,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCanSendQuitAfterSubscribe()
+    public function testCanSendQuitAfterSubscribe(): void
     {
         $redis = $this->getClient();
         $quit = $this->getCommandFactory()->create('quit');
@@ -152,7 +152,7 @@ class SUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testCannotSendOtherCommandsAfterSubscribe()
+    public function testCannotSendOtherCommandsAfterSubscribe(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessageMatches('/ERR.*only .* allowed in this context/');

--- a/tests/Predis/Command/Redis/SUBSTR_Test.php
+++ b/tests/Predis/Command/Redis/SUBSTR_Test.php
@@ -24,7 +24,7 @@ class SUBSTR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SUBSTR';
     }
@@ -32,7 +32,7 @@ class SUBSTR_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SUBSTR';
     }
@@ -40,7 +40,7 @@ class SUBSTR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 5, 10);
         $expected = array('key', 5, 10);
@@ -54,7 +54,7 @@ class SUBSTR_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('substring', $this->getCommand()->parseResponse('substring'));
     }

--- a/tests/Predis/Command/Redis/SUNIONSTORE_Test.php
+++ b/tests/Predis/Command/Redis/SUNIONSTORE_Test.php
@@ -20,7 +20,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SUNIONSTORE';
     }
@@ -28,7 +28,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SUNIONSTORE';
     }
@@ -36,7 +36,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key:destination', 'key:source1', 'key:source:2');
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -50,7 +50,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsSourceKeysAsSingleArray()
+    public function testFilterArgumentsSourceKeysAsSingleArray(): void
     {
         $arguments = array('key:destination', array('key:source1', 'key:source:2'));
         $expected = array('key:destination', 'key:source1', 'key:source:2');
@@ -64,7 +64,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -72,7 +72,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresMembersOfSetOnSingleSet()
+    public function testStoresMembersOfSetOnSingleSet(): void
     {
         $redis = $this->getClient();
 
@@ -85,7 +85,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testStoresUnionOfMultipleSets()
+    public function testStoresUnionOfMultipleSets(): void
     {
         $redis = $this->getClient();
 
@@ -103,7 +103,7 @@ class SUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongTypeOfSourceKey()
+    public function testThrowsExceptionOnWrongTypeOfSourceKey(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/SUNION_Test.php
+++ b/tests/Predis/Command/Redis/SUNION_Test.php
@@ -20,7 +20,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\SUNION';
     }
@@ -28,7 +28,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'SUNION';
     }
@@ -36,7 +36,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -50,7 +50,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -64,7 +64,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('member1', 'member2', 'member3');
         $expected = array('member1', 'member2', 'member3');
@@ -77,7 +77,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersOnSingleKeyOrNonExistingSetForUnion()
+    public function testReturnsMembersOnSingleKeyOrNonExistingSetForUnion(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsMembersFromDifferenceAmongSets()
+    public function testReturnsMembersFromDifferenceAmongSets(): void
     {
         $redis = $this->getClient();
 
@@ -105,7 +105,7 @@ class SUNION_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/TIME_Test.php
+++ b/tests/Predis/Command/Redis/TIME_Test.php
@@ -20,7 +20,7 @@ class TIME_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\TIME';
     }
@@ -28,7 +28,7 @@ class TIME_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'TIME';
     }
@@ -36,7 +36,7 @@ class TIME_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array();
         $expected = array();
@@ -50,7 +50,7 @@ class TIME_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $expected = array(1331114908, 453990);
         $command = $this->getCommand();
@@ -62,7 +62,7 @@ class TIME_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
-    public function testReturnsServerTime()
+    public function testReturnsServerTime(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/TTL_Test.php
+++ b/tests/Predis/Command/Redis/TTL_Test.php
@@ -20,7 +20,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\TTL';
     }
@@ -28,7 +28,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'TTL';
     }
@@ -36,7 +36,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 10);
         $expected = array('key', 10);
@@ -50,7 +50,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $command = $this->getCommand();
 
@@ -60,7 +60,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTTL()
+    public function testReturnsTTL(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsLessThanZeroOnNonExpiringKeys()
+    public function testReturnsLessThanZeroOnNonExpiringKeys(): void
     {
         $redis = $this->getClient();
 
@@ -84,7 +84,7 @@ class TTL_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsLessThanZeroOnNonExistingKeys()
+    public function testReturnsLessThanZeroOnNonExistingKeys(): void
     {
         if ($this->isRedisServerVersion('<', '2.8.0')) {
             $this->assertSame(-1, $this->getClient()->ttl('foo'));

--- a/tests/Predis/Command/Redis/TYPE_Test.php
+++ b/tests/Predis/Command/Redis/TYPE_Test.php
@@ -20,7 +20,7 @@ class TYPE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\TYPE';
     }
@@ -28,7 +28,7 @@ class TYPE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'TYPE';
     }
@@ -36,7 +36,7 @@ class TYPE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class TYPE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('none', $this->getCommand()->parseResponse('none'));
     }
@@ -58,7 +58,7 @@ class TYPE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsTypeOfKey()
+    public function testReturnsTypeOfKey(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
@@ -20,7 +20,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\UNSUBSCRIBE';
     }
@@ -28,7 +28,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'UNSUBSCRIBE';
     }
@@ -36,7 +36,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('channel1', 'channel2', 'channel3');
         $expected = array('channel1', 'channel2', 'channel3');
@@ -50,7 +50,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('channel1', 'channel2', 'channel3'));
         $expected = array('channel1', 'channel2', 'channel3');
@@ -64,7 +64,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('unsubscribe', 'channel', 1);
         $expected = array('unsubscribe', 'channel', 1);
@@ -78,7 +78,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDoesNotSwitchToSubscribeMode()
+    public function testDoesNotSwitchToSubscribeMode(): void
     {
         $redis = $this->getClient();
 
@@ -90,7 +90,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testUnsubscribesFromNotSubscribedChannels()
+    public function testUnsubscribesFromNotSubscribedChannels(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testUnsubscribesFromSubscribedChannels()
+    public function testUnsubscribesFromSubscribedChannels(): void
     {
         $redis = $this->getClient();
 
@@ -113,7 +113,7 @@ class UNSUBSCRIBE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testUnsubscribesFromAllSubscribedChannels()
+    public function testUnsubscribesFromAllSubscribedChannels(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -20,7 +20,7 @@ class UNWATCH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\UNWATCH';
     }
@@ -28,7 +28,7 @@ class UNWATCH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'UNWATCH';
     }
@@ -36,7 +36,7 @@ class UNWATCH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $command = $this->getCommand();
         $command->setArguments(array());
@@ -47,7 +47,7 @@ class UNWATCH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -56,7 +56,7 @@ class UNWATCH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testUnwatchWatchedKeys()
+    public function testUnwatchWatchedKeys(): void
     {
         $redis1 = $this->getClient();
         $redis2 = $this->getClient();
@@ -76,7 +76,7 @@ class UNWATCH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCanBeCalledInsideTransaction()
+    public function testCanBeCalledInsideTransaction(): void
     {
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/WATCH_Test.php
+++ b/tests/Predis/Command/Redis/WATCH_Test.php
@@ -20,7 +20,7 @@ class WATCH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\WATCH';
     }
@@ -28,7 +28,7 @@ class WATCH_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'WATCH';
     }
@@ -36,7 +36,7 @@ class WATCH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key1', 'key2', 'key3');
         $expected = array('key1', 'key2', 'key3');
@@ -50,7 +50,7 @@ class WATCH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsAsSingleArray()
+    public function testFilterArgumentsAsSingleArray(): void
     {
         $arguments = array(array('key1', 'key2', 'key3'));
         $expected = array('key1', 'key2', 'key3');
@@ -64,7 +64,7 @@ class WATCH_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('OK', $this->getCommand()->parseResponse('OK'));
     }
@@ -73,7 +73,7 @@ class WATCH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testAbortsTransactionOnExternalWriteOperations()
+    public function testAbortsTransactionOnExternalWriteOperations(): void
     {
         $redis1 = $this->getClient();
         $redis2 = $this->getClient();
@@ -92,7 +92,7 @@ class WATCH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testCanWatchNotYetExistingKeys()
+    public function testCanWatchNotYetExistingKeys(): void
     {
         $redis1 = $this->getClient();
         $redis2 = $this->getClient();
@@ -109,7 +109,7 @@ class WATCH_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionWhenCallingInsideTransaction()
+    public function testThrowsExceptionWhenCallingInsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR WATCH inside MULTI is not allowed');

--- a/tests/Predis/Command/Redis/ZADD_Test.php
+++ b/tests/Predis/Command/Redis/ZADD_Test.php
@@ -20,7 +20,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZADD';
     }
@@ -28,7 +28,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZADD';
     }
@@ -36,7 +36,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 1, 'member1', 2, 'member2');
         $expected = array('key', 1, 'member1', 2, 'member2');
@@ -50,7 +50,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsMembersScoresAsSingleArray()
+    public function testFilterArgumentsMembersScoresAsSingleArray(): void
     {
         $arguments = array('key', array('member1' => 1, 'member2' => 2));
         $expected = array('key', 1, 'member1', 2, 'member2');
@@ -64,7 +64,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsMembersScoresAsSingleArrayWithModifiers()
+    public function testFilterArgumentsMembersScoresAsSingleArrayWithModifiers(): void
     {
         $arguments = array('key', 'NX', 'CH', array('member1' => 1, 'member2' => 2));
         $expected = array('key', 'NX', 'CH', 1, 'member1', 2, 'member2');
@@ -78,7 +78,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -86,7 +86,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testAddsOrUpdatesMembersOrderingByScore()
+    public function testAddsOrUpdatesMembersOrderingByScore(): void
     {
         $redis = $this->getClient();
 
@@ -101,7 +101,7 @@ class ZADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.2
      */
-    public function testOnlyAddsNonExistingMembersWithModifierNX()
+    public function testOnlyAddsNonExistingMembersWithModifierNX(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class ZADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.2
      */
-    public function testOnlyUpdatesExistingMembersWithModifierXX()
+    public function testOnlyUpdatesExistingMembersWithModifierXX(): void
     {
         $redis = $this->getClient();
 
@@ -131,7 +131,7 @@ class ZADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.2
      */
-    public function testReturnsNumberOfAddedAndUpdatedElementsWithModifierCH()
+    public function testReturnsNumberOfAddedAndUpdatedElementsWithModifierCH(): void
     {
         $redis = $this->getClient();
 
@@ -149,7 +149,7 @@ class ZADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.2
      */
-    public function testActsLikeZINCRBYWithModifierINCR()
+    public function testActsLikeZINCRBYWithModifierINCR(): void
     {
         $redis = $this->getClient();
 
@@ -163,7 +163,7 @@ class ZADD_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 3.0.2
      */
-    public function testDoesNotAcceptMultipleScoreElementPairsWithModifierINCR()
+    public function testDoesNotAcceptMultipleScoreElementPairsWithModifierINCR(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('INCR option supports a single increment-element pair');
@@ -176,7 +176,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testAcceptsFloatValuesAsScore()
+    public function testAcceptsFloatValuesAsScore(): void
     {
         $redis = $this->getClient();
 
@@ -187,7 +187,7 @@ class ZADD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZCARD_Test.php
+++ b/tests/Predis/Command/Redis/ZCARD_Test.php
@@ -20,7 +20,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZCARD';
     }
@@ -28,7 +28,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZCARD';
     }
@@ -36,7 +36,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key');
         $expected = array('key');
@@ -50,7 +50,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsSizeOfSortedSet()
+    public function testReturnsSizeOfSortedSet(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class ZCARD_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/ZCOUNT_Test.php
@@ -20,7 +20,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZCOUNT';
     }
@@ -28,7 +28,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZCOUNT';
     }
@@ -36,7 +36,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 10);
         $expected = array('key', 0, 10);
@@ -50,7 +50,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsNumberOfElementsInGivenScoreRange()
+    public function testReturnsNumberOfElementsInGivenScoreRange(): void
     {
         $redis = $this->getClient();
 
@@ -78,7 +78,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testInfinityScoreIntervals()
+    public function testInfinityScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -93,7 +93,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testExclusiveScoreIntervals()
+    public function testExclusiveScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -108,7 +108,7 @@ class ZCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/ZINCRBY_Test.php
@@ -20,7 +20,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZINCRBY';
     }
@@ -28,7 +28,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZINCRBY';
     }
@@ -36,7 +36,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 1.0, 'member');
         $expected = array('key', 1.0, 'member');
@@ -50,7 +50,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame('1', $this->getCommand()->parseResponse('1'));
     }
@@ -58,7 +58,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testIncrementsScoreOfMemberByFloat()
+    public function testIncrementsScoreOfMemberByFloat(): void
     {
         $redis = $this->getClient();
 
@@ -71,7 +71,7 @@ class ZINCRBY_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
@@ -20,7 +20,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZINTERSTORE';
     }
@@ -28,7 +28,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZINTERSTORE';
     }
@@ -36,7 +36,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'aggregate' => 'sum',
@@ -57,7 +57,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsSourceKeysAsSingleArray()
+    public function testFilterArgumentsSourceKeysAsSingleArray(): void
     {
         $modifiers = array(
             'aggregate' => 'sum',
@@ -78,7 +78,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -87,7 +87,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresIntersectionInNewSortedSet()
+    public function testStoresIntersectionInNewSortedSet(): void
     {
         $redis = $this->getClient();
 
@@ -106,7 +106,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresIntersectionWithAggregateModifier()
+    public function testStoresIntersectionWithAggregateModifier(): void
     {
         $redis = $this->getClient();
 
@@ -130,7 +130,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresIntersectionWithWeightsModifier()
+    public function testStoresIntersectionWithWeightsModifier(): void
     {
         $redis = $this->getClient();
 
@@ -146,7 +146,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresIntersectionWithCombinedModifiers()
+    public function testStoresIntersectionWithCombinedModifiers(): void
     {
         $redis = $this->getClient();
 
@@ -162,7 +162,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZLEXCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/ZLEXCOUNT_Test.php
@@ -20,7 +20,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZLEXCOUNT';
     }
@@ -28,7 +28,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZLEXCOUNT';
     }
@@ -36,7 +36,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', '+', '-');
         $expected = array('key', '+', '-');
@@ -50,7 +50,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testExclusiveIntervalRange()
+    public function testExclusiveIntervalRange(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testInclusiveIntervalRange()
+    public function testInclusiveIntervalRange(): void
     {
         $redis = $this->getClient();
 
@@ -91,7 +91,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testWholeRangeInterval()
+    public function testWholeRangeInterval(): void
     {
         $redis = $this->getClient();
 
@@ -105,7 +105,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnInvalidRangeFormat()
+    public function testThrowsExceptionOnInvalidRangeFormat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('min or max not valid string range item');
@@ -120,7 +120,7 @@ class ZLEXCOUNT_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZRANGEBYLEX_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGEBYLEX_Test.php
@@ -20,7 +20,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZRANGEBYLEX';
     }
@@ -28,7 +28,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZRANGEBYLEX';
     }
@@ -36,7 +36,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'limit' => array(0, 100),
@@ -54,7 +54,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithNamedLimit()
+    public function testFilterArgumentsWithNamedLimit(): void
     {
         $arguments = array('zset', '[a', '[z', array('limit' => array('offset' => 1, 'count' => 2)));
         $expected = array('zset', '[a', '[z', 'LIMIT', 1, 2);
@@ -68,7 +68,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('a', 'b', 'c');
         $expected = array('a', 'b', 'c');
@@ -82,7 +82,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInWholeRange()
+    public function testReturnsElementsInWholeRange(): void
     {
         $redis = $this->getClient();
 
@@ -98,7 +98,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInInclusiveRange()
+    public function testReturnsElementsInInclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInExclusiveRange()
+    public function testReturnsElementsInExclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -134,7 +134,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInMixedRange()
+    public function testReturnsElementsInMixedRange(): void
     {
         $redis = $this->getClient();
 
@@ -151,7 +151,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRangeWithLimitModifier()
+    public function testRangeWithLimitModifier(): void
     {
         $redis = $this->getClient();
 
@@ -168,7 +168,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnInvalidRangeFormat()
+    public function testThrowsExceptionOnInvalidRangeFormat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('min or max not valid string range item');
@@ -183,7 +183,7 @@ class ZRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZRANGEBYSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGEBYSCORE_Test.php
@@ -20,7 +20,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZRANGEBYSCORE';
     }
@@ -28,7 +28,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZRANGEBYSCORE';
     }
@@ -36,7 +36,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'withscores' => true,
@@ -55,7 +55,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithStringWithscores()
+    public function testFilterArgumentsWithStringWithscores(): void
     {
         $arguments = array('zset', 0, 100, 'withscores');
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -69,7 +69,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithNamedLimit()
+    public function testFilterArgumentsWithNamedLimit(): void
     {
         $arguments = array('zset', 0, 100, array('limit' => array('offset' => 1, 'count' => 2)));
         $expected = array('zset', 0, 100, 'LIMIT', 1, 2);
@@ -83,7 +83,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('element1', 'element2', 'element3');
         $expected = array('element1', 'element2', 'element3');
@@ -96,7 +96,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithScores()
+    public function testParseResponseWithScores(): void
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
         $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
@@ -109,7 +109,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue()
+    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue(): void
     {
         $command = $this->getCommandWithArguments('zset', 0, 100, array('withscores' => true));
         $this->assertSame(array('zset', 0, 100, 'WITHSCORES'), $command->getArguments());
@@ -127,7 +127,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementsInScoreRange()
+    public function testReturnsElementsInScoreRange(): void
     {
         $redis = $this->getClient();
 
@@ -144,7 +144,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testInfinityScoreIntervals()
+    public function testInfinityScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -158,7 +158,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testExclusiveScoreIntervals()
+    public function testExclusiveScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -172,7 +172,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRangeWithWithscoresModifier()
+    public function testRangeWithWithscoresModifier(): void
     {
         $redis = $this->getClient();
 
@@ -186,7 +186,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRangeWithLimitModifier()
+    public function testRangeWithLimitModifier(): void
     {
         $redis = $this->getClient();
 
@@ -200,7 +200,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRangeWithCombinedModifiers()
+    public function testRangeWithCombinedModifiers(): void
     {
         $redis = $this->getClient();
 
@@ -215,7 +215,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZRANGE_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGE_Test.php
@@ -20,7 +20,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZRANGE';
     }
@@ -28,7 +28,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZRANGE';
     }
@@ -36,7 +36,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('zset', 0, 100, array('withscores' => true));
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -50,7 +50,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithStringWithscores()
+    public function testFilterArgumentsWithStringWithscores(): void
     {
         $arguments = array('zset', 0, 100, 'withscores');
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -64,7 +64,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('element1', 'element2', 'element3');
         $expected = array('element1', 'element2', 'element3');
@@ -77,7 +77,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithScores()
+    public function testParseResponseWithScores(): void
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
         $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
@@ -90,7 +90,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue()
+    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue(): void
     {
         $command = $this->getCommandWithArguments('zset', 0, 100, array('withscores' => true));
         $this->assertSame(array('zset', 0, 100, 'WITHSCORES'), $command->getArguments());
@@ -108,7 +108,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementsInRange()
+    public function testReturnsElementsInRange(): void
     {
         $redis = $this->getClient();
 
@@ -129,7 +129,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRangeWithWithscoresModifier()
+    public function testRangeWithWithscoresModifier(): void
     {
         $redis = $this->getClient();
 
@@ -143,7 +143,7 @@ class ZRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZRANK_Test.php
+++ b/tests/Predis/Command/Redis/ZRANK_Test.php
@@ -20,7 +20,7 @@ class ZRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZRANK';
     }
@@ -28,7 +28,7 @@ class ZRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZRANK';
     }
@@ -36,7 +36,7 @@ class ZRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member');
         $expected = array('key', 'member');
@@ -50,7 +50,7 @@ class ZRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsRank()
+    public function testReturnsRank(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class ZRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREMRANGEBYLEX_Test.php
+++ b/tests/Predis/Command/Redis/ZREMRANGEBYLEX_Test.php
@@ -20,7 +20,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREMRANGEBYLEX';
     }
@@ -28,7 +28,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREMRANGEBYLEX';
     }
@@ -36,7 +36,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', '[a', '[b');
         $expected = array('key', '[a', '[b');
@@ -50,7 +50,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRemovesRangeByLexWithWholeRange()
+    public function testRemovesRangeByLexWithWholeRange(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRemovesRangeByLexWithInclusiveRange()
+    public function testRemovesRangeByLexWithInclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRemovesRangeByLexWithExclusiveRange()
+    public function testRemovesRangeByLexWithExclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -103,7 +103,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRemovesRangeByLexWithMixedRange()
+    public function testRemovesRangeByLexWithMixedRange(): void
     {
         $redis = $this->getClient();
 
@@ -117,7 +117,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnInvalidRangeFormat()
+    public function testThrowsExceptionOnInvalidRangeFormat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('min or max not valid string range item');
@@ -132,7 +132,7 @@ class ZREMRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREMRANGEBYRANK_Test.php
+++ b/tests/Predis/Command/Redis/ZREMRANGEBYRANK_Test.php
@@ -20,7 +20,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREMRANGEBYRANK';
     }
@@ -28,7 +28,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREMRANGEBYRANK';
     }
@@ -36,7 +36,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 10);
         $expected = array('key', 0, 10);
@@ -50,7 +50,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testRemovesRangeByRank()
+    public function testRemovesRangeByRank(): void
     {
         $redis = $this->getClient();
 
@@ -75,7 +75,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testRemovesRangeByRankWithNegativeIndex()
+    public function testRemovesRangeByRankWithNegativeIndex(): void
     {
         $redis = $this->getClient();
 
@@ -89,7 +89,7 @@ class ZREMRANGEBYRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREMRANGEBYSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZREMRANGEBYSCORE_Test.php
@@ -20,7 +20,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREMRANGEBYSCORE';
     }
@@ -28,7 +28,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREMRANGEBYSCORE';
     }
@@ -36,7 +36,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 10);
         $expected = array('key', 0, 10);
@@ -50,7 +50,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesRangeByScore()
+    public function testRemovesRangeByScore(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesRangeByExclusiveScore()
+    public function testRemovesRangeByExclusiveScore(): void
     {
         $redis = $this->getClient();
 
@@ -86,7 +86,7 @@ class ZREMRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREM_Test.php
+++ b/tests/Predis/Command/Redis/ZREM_Test.php
@@ -20,7 +20,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREM';
     }
@@ -28,7 +28,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREM';
     }
@@ -36,7 +36,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('zset', 'member1', 'member2', 'member3');
         $expected = array('zset', 'member1', 'member2', 'member3');
@@ -50,7 +50,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRemovesSpecifiedMembers()
+    public function testRemovesSpecifiedMembers(): void
     {
         $redis = $this->getClient();
 
@@ -73,7 +73,7 @@ class ZREM_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREVRANGEBYLEX_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANGEBYLEX_Test.php
@@ -20,7 +20,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREVRANGEBYLEX';
     }
@@ -28,7 +28,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREVRANGEBYLEX';
     }
@@ -36,7 +36,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'limit' => array(0, 100),
@@ -54,7 +54,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithNamedLimit()
+    public function testFilterArgumentsWithNamedLimit(): void
     {
         $arguments = array('zset', '[a', '[z', array('limit' => array('offset' => 1, 'count' => 2)));
         $expected = array('zset', '[a', '[z', 'LIMIT', 1, 2);
@@ -68,7 +68,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('a', 'b', 'c');
         $expected = array('a', 'b', 'c');
@@ -82,7 +82,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInWholeRange()
+    public function testReturnsElementsInWholeRange(): void
     {
         $redis = $this->getClient();
 
@@ -98,7 +98,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInInclusiveRange()
+    public function testReturnsElementsInInclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -116,7 +116,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInExclusiveRange()
+    public function testReturnsElementsInExclusiveRange(): void
     {
         $redis = $this->getClient();
 
@@ -134,7 +134,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testReturnsElementsInMixedRange()
+    public function testReturnsElementsInMixedRange(): void
     {
         $redis = $this->getClient();
 
@@ -151,7 +151,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testRangeWithLimitModifier()
+    public function testRangeWithLimitModifier(): void
     {
         $redis = $this->getClient();
 
@@ -168,7 +168,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnInvalidRangeFormat()
+    public function testThrowsExceptionOnInvalidRangeFormat(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('min or max not valid string range item');
@@ -183,7 +183,7 @@ class ZREVRANGEBYLEX_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.9
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREVRANGEBYSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANGEBYSCORE_Test.php
@@ -20,7 +20,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREVRANGEBYSCORE';
     }
@@ -28,7 +28,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREVRANGEBYSCORE';
     }
@@ -36,7 +36,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'withscores' => true,
@@ -55,7 +55,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithStringWithscores()
+    public function testFilterArgumentsWithStringWithscores(): void
     {
         $arguments = array('zset', 0, 100, 'withscores');
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -69,7 +69,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithNamedLimit()
+    public function testFilterArgumentsWithNamedLimit(): void
     {
         $arguments = array('zset', 0, 100, array('limit' => array('offset' => 1, 'count' => 2)));
         $expected = array('zset', 0, 100, 'LIMIT', 1, 2);
@@ -83,7 +83,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('element1', 'element2', 'element3');
         $expected = array('element1', 'element2', 'element3');
@@ -96,7 +96,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithScores()
+    public function testParseResponseWithScores(): void
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
         $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
@@ -109,7 +109,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue()
+    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue(): void
     {
         $command = $this->getCommandWithArguments('zset', 0, 100, array('withscores' => true));
         $this->assertSame(array('zset', 0, 100, 'WITHSCORES'), $command->getArguments());
@@ -128,7 +128,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testReturnsElementsInScoreRange()
+    public function testReturnsElementsInScoreRange(): void
     {
         $redis = $this->getClient();
 
@@ -146,7 +146,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testInfinityScoreIntervals()
+    public function testInfinityScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -161,7 +161,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testExclusiveScoreIntervals()
+    public function testExclusiveScoreIntervals(): void
     {
         $redis = $this->getClient();
 
@@ -176,7 +176,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testRangeWithWithscoresModifier()
+    public function testRangeWithWithscoresModifier(): void
     {
         $redis = $this->getClient();
 
@@ -191,7 +191,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testRangeWithLimitModifier()
+    public function testRangeWithLimitModifier(): void
     {
         $redis = $this->getClient();
 
@@ -206,7 +206,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testRangeWithCombinedModifiers()
+    public function testRangeWithCombinedModifiers(): void
     {
         $redis = $this->getClient();
 
@@ -222,7 +222,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANGE_Test.php
@@ -20,7 +20,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREVRANGE';
     }
@@ -28,7 +28,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREVRANGE';
     }
@@ -36,7 +36,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('zset', 0, 100, array('withscores' => true));
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -50,7 +50,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithStringWithscores()
+    public function testFilterArgumentsWithStringWithscores(): void
     {
         $arguments = array('zset', 0, 100, 'withscores');
         $expected = array('zset', 0, 100, 'WITHSCORES');
@@ -64,7 +64,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('element1', 'element2', 'element3');
         $expected = array('element1', 'element2', 'element3');
@@ -77,7 +77,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponseWithScores()
+    public function testParseResponseWithScores(): void
     {
         $raw = array('element1', '1', 'element2', '2', 'element3', '3');
         $expected = array('element1' => '1', 'element2' => '2', 'element3' => '3');
@@ -90,7 +90,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue()
+    public function testAddsWithscoresModifiersOnlyWhenOptionIsTrue(): void
     {
         $command = $this->getCommandWithArguments('zset', 0, 100, array('withscores' => true));
         $this->assertSame(array('zset', 0, 100, 'WITHSCORES'), $command->getArguments());
@@ -108,7 +108,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsElementsInRange()
+    public function testReturnsElementsInRange(): void
     {
         $redis = $this->getClient();
 
@@ -129,7 +129,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testRangeWithWithscoresModifier()
+    public function testRangeWithWithscoresModifier(): void
     {
         $redis = $this->getClient();
 
@@ -143,7 +143,7 @@ class ZREVRANGE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANK_Test.php
@@ -20,7 +20,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZREVRANK';
     }
@@ -28,7 +28,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZREVRANK';
     }
@@ -36,7 +36,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member');
         $expected = array('key', 'member');
@@ -50,7 +50,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -59,7 +59,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testReturnsRank()
+    public function testReturnsRank(): void
     {
         $redis = $this->getClient();
 
@@ -76,7 +76,7 @@ class ZREVRANK_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZSCAN_Test.php
+++ b/tests/Predis/Command/Redis/ZSCAN_Test.php
@@ -20,7 +20,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZSCAN';
     }
@@ -28,7 +28,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZSCAN';
     }
@@ -36,7 +36,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
         $expected = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
@@ -50,7 +50,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsBasicUsage()
+    public function testFilterArgumentsBasicUsage(): void
     {
         $arguments = array('key', 0);
         $expected = array('key', 0);
@@ -64,7 +64,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsWithOptionsArray()
+    public function testFilterArgumentsWithOptionsArray(): void
     {
         $arguments = array('key', 0, array('match' => 'member:*', 'count' => 10));
         $expected = array('key', 0, 'MATCH', 'member:*', 'COUNT', 10);
@@ -78,7 +78,7 @@ class ZSCAN_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $raw = array('3', array('member:1', '1', 'member:2', '2', 'member:3', '3'));
         $expected = array('3', array('member:1' => 1.0, 'member:2' => 2.0, 'member:3' => 3.0));
@@ -92,7 +92,7 @@ class ZSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithoutMatch()
+    public function testScanWithoutMatch(): void
     {
         $expectedMembers = array('member:one', 'member:two', 'member:three', 'member:four');
         $expectedScores = array(1.0, 2.0, 3.0, 4.0);
@@ -111,7 +111,7 @@ class ZSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithMatchingMembers()
+    public function testScanWithMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->zadd('key', array('member:one' => 1.0, 'member:two' => 2.0, 'member:three' => 3.0, 'member:four' => 4.0));
@@ -126,7 +126,7 @@ class ZSCAN_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.8.0
      */
-    public function testScanWithNoMatchingMembers()
+    public function testScanWithNoMatchingMembers(): void
     {
         $redis = $this->getClient();
         $redis->zadd('key', $members = array('member:one' => 1.0, 'member:two' => 2.0, 'member:three' => 3.0, 'member:four' => 4.0));

--- a/tests/Predis/Command/Redis/ZSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZSCORE_Test.php
@@ -20,7 +20,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZSCORE';
     }
@@ -28,7 +28,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZSCORE';
     }
@@ -36,7 +36,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $arguments = array('key', 'member');
         $expected = array('key', 'member');
@@ -50,7 +50,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -58,7 +58,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testReturnsRank()
+    public function testReturnsRank(): void
     {
         $redis = $this->getClient();
 
@@ -74,7 +74,7 @@ class ZSCORE_Test extends PredisCommandTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
@@ -20,7 +20,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommand()
+    protected function getExpectedCommand(): string
     {
         return 'Predis\Command\Redis\ZUNIONSTORE';
     }
@@ -28,7 +28,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedId()
+    protected function getExpectedId(): string
     {
         return 'ZUNIONSTORE';
     }
@@ -36,7 +36,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArguments()
+    public function testFilterArguments(): void
     {
         $modifiers = array(
             'aggregate' => 'sum',
@@ -57,7 +57,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testFilterArgumentsSourceKeysAsSingleArray()
+    public function testFilterArgumentsSourceKeysAsSingleArray(): void
     {
         $modifiers = array(
             'aggregate' => 'sum',
@@ -78,7 +78,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
-    public function testParseResponse()
+    public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
     }
@@ -87,7 +87,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresUnionInNewSortedSet()
+    public function testStoresUnionInNewSortedSet(): void
     {
         $redis = $this->getClient();
 
@@ -109,7 +109,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresUnionWithAggregateModifier()
+    public function testStoresUnionWithAggregateModifier(): void
     {
         $redis = $this->getClient();
 
@@ -142,7 +142,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresUnionWithWeightsModifier()
+    public function testStoresUnionWithWeightsModifier(): void
     {
         $redis = $this->getClient();
 
@@ -161,7 +161,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testStoresUnionWithCombinedModifiers()
+    public function testStoresUnionWithCombinedModifiers(): void
     {
         $redis = $this->getClient();
 
@@ -180,7 +180,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testThrowsExceptionOnWrongType()
+    public function testThrowsExceptionOnWrongType(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('Operation against a key holding the wrong kind of value');

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Command;
 
 use Predis\Command\Processor\ProcessorChain;
+use Predis\Command\Processor\ProcessorInterface;
 use PredisTestCase;
 
 /**
@@ -22,7 +23,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportedCommands()
+    public function testSupportedCommands(): void
     {
         $factory = new RedisFactory();
 
@@ -34,7 +35,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportCommand()
+    public function testSupportCommand(): void
     {
         $factory = new RedisFactory();
 
@@ -48,7 +49,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportCommands()
+    public function testSupportCommands(): void
     {
         $factory = new RedisFactory();
 
@@ -63,7 +64,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetCommandClass()
+    public function testGetCommandClass(): void
     {
         $factory = new RedisFactory();
 
@@ -77,7 +78,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineCommand()
+    public function testDefineCommand(): void
     {
         $factory = new RedisFactory();
 
@@ -95,7 +96,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUndefineCommandInClassAutoload()
+    public function testUndefineCommandInClassAutoload(): void
     {
         $factory = new RedisFactory();
 
@@ -111,7 +112,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUndefineCommandInClassMap()
+    public function testUndefineCommandInClassMap(): void
     {
         $factory = new RedisFactory();
 
@@ -130,7 +131,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineInvalidCommand()
+    public function testDefineInvalidCommand(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Class stdClass must implement Predis\Command\CommandInterface");
@@ -143,7 +144,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateCommandWithoutArguments()
+    public function testCreateCommandWithoutArguments(): void
     {
         $factory = new RedisFactory();
 
@@ -157,7 +158,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateCommandWithArguments()
+    public function testCreateCommandWithArguments(): void
     {
         $factory = new RedisFactory();
 
@@ -172,7 +173,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateUndefinedCommand()
+    public function testCreateUndefinedCommand(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage("Command `UNKNOWN` is not a registered Redis command.");
@@ -185,7 +186,7 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetDefaultProcessor()
+    public function testGetDefaultProcessor(): void
     {
         $factory = new RedisFactory();
 
@@ -195,9 +196,11 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetProcessor()
+    public function testSetProcessor(): void
     {
-        $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
+        /** @var ProcessorInterface */
+        $processor = $this
+            ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
         $factory = new RedisFactory();
@@ -209,9 +212,11 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetAndUnsetProcessor()
+    public function testSetAndUnsetProcessor(): void
     {
-        $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
+        /** @var ProcessorInterface */
+        $processor = $this
+            ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
         $factory = new RedisFactory();
@@ -226,13 +231,15 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSingleProcessor()
+    public function testSingleProcessor(): void
     {
         // Could it be that objects passed to the return callback of a mocked
         // method are cloned instead of being passed by reference?
         $argsRef = null;
 
-        $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
+        /** @var ProcessorInterface */
+        $processor = $this
+            ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
         $processor
             ->expects($this->once())
@@ -254,9 +261,11 @@ class RedisFactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testChainOfProcessors()
+    public function testChainOfProcessors(): void
     {
-        $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
+        /** @var ProcessorInterface */
+        $processor = $this
+            ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
         $processor
             ->expects($this->exactly(2))
@@ -281,7 +290,7 @@ class RedisFactoryTest extends PredisTestCase
      *
      * @return array List of supported commands.
      */
-    protected function getExpectedCommands()
+    protected function getExpectedCommands(): array
     {
         return array(
             0 => 'EXISTS',

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -245,11 +245,11 @@ class RedisFactoryTest extends PredisTestCase
             ->expects($this->once())
             ->method('process')
             ->with($this->isInstanceOf('Predis\Command\CommandInterface'))
-            ->will($this->returnCallback(
+            ->willReturnCallback(
                 function (CommandInterface $cmd) use (&$argsRef) {
                     $cmd->setRawArguments($argsRef = array_map('strtoupper', $cmd->getArguments()));
                 }
-            ));
+            );
 
         $factory = new RedisFactory();
         $factory->setProcessor($processor);

--- a/tests/Predis/Command/ScriptCommandTest.php
+++ b/tests/Predis/Command/ScriptCommandTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Command;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group realm-scripting
@@ -24,10 +25,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetId()
+    public function testGetId(): void
     {
+        /** @var CommandInterface */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript'))
+            ->onlyMethods(array('getScript'))
             ->getMock();
 
         $this->assertSame('EVALSHA', $command->getId());
@@ -36,10 +38,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetScriptHash()
+    public function testGetScriptHash(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->exactly(2))
@@ -58,10 +61,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetKeys()
+    public function testGetKeys(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -80,10 +84,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetKeysWithZeroKeysCount()
+    public function testGetKeysWithZeroKeysCount(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript'))
+            ->onlyMethods(array('getScript'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -98,10 +103,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetKeysWithNegativeKeysCount()
+    public function testGetKeysWithNegativeKeysCount(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -120,10 +126,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetArguments()
+    public function testGetArguments(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -142,10 +149,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetArgumentsWithZeroKeysCount()
+    public function testGetArgumentsWithZeroKeysCount(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -160,10 +168,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetArgumentsWithNegativeKeysCount()
+    public function testGetArgumentsWithNegativeKeysCount(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->once())
@@ -182,10 +191,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetEvalArguments()
+    public function testGetEvalArguments(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->exactly(2))
@@ -204,10 +214,11 @@ class ScriptCommandTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetEvalCommand()
+    public function testGetEvalCommand(): void
     {
+        /** @var ScriptCommand|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript', 'getKeysCount'))
+            ->onlyMethods(array('getScript', 'getKeysCount'))
             ->getMock();
         $command
             ->expects($this->exactly(2))

--- a/tests/Predis/Command/ScriptCommandTest.php
+++ b/tests/Predis/Command/ScriptCommandTest.php
@@ -47,11 +47,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->exactly(2))
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->once())
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -70,11 +70,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->exactly(2))
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -93,7 +93,7 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
 
         $command->setArguments($arguments = array('value1', 'value2', 'value3'));
 
@@ -112,11 +112,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->exactly(2))
             ->method('getKeysCount')
-            ->will($this->returnValue(-2));
+            ->willReturn(-2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -135,11 +135,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->once())
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -158,7 +158,7 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -177,11 +177,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->once())
             ->method('getKeysCount')
-            ->will($this->returnValue(-2));
+            ->willReturn(-2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -200,11 +200,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->exactly(2))
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->once())
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 
@@ -223,11 +223,11 @@ class ScriptCommandTest extends PredisTestCase
         $command
             ->expects($this->exactly(2))
             ->method('getScript')
-            ->will($this->returnValue(self::LUA_SCRIPT));
+            ->willReturn(self::LUA_SCRIPT);
         $command
             ->expects($this->once())
             ->method('getKeysCount')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $command->setArguments($arguments = array('key1', 'key2', 'value1', 'value2'));
 

--- a/tests/Predis/CommunicationExceptionTest.php
+++ b/tests/Predis/CommunicationExceptionTest.php
@@ -64,7 +64,7 @@ class CommunicationExceptionTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $connection
             ->expects($this->once())
             ->method('disconnect');
@@ -98,7 +98,7 @@ class CommunicationExceptionTest extends PredisTestCase
         $exception
             ->expects($this->once())
             ->method('shouldResetConnection')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->expectException('Predis\CommunicationException');
         $this->expectExceptionMessage('Communication error message');

--- a/tests/Predis/CommunicationExceptionTest.php
+++ b/tests/Predis/CommunicationExceptionTest.php
@@ -12,6 +12,7 @@
 namespace Predis;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  *
@@ -21,7 +22,7 @@ class CommunicationExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionReturnsInnerConnection()
+    public function testExceptionReturnsInnerConnection(): void
     {
         $connection = $this->getMockConnection();
         $exception = $this->createMockException($connection, 'Communication error message');
@@ -32,7 +33,7 @@ class CommunicationExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionMessage()
+    public function testExceptionMessage(): void
     {
         $connection = $this->getMockConnection();
         $exception = $this->createMockException($connection, $message = 'Connection error message');
@@ -46,7 +47,7 @@ class CommunicationExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testShouldResetConnectionIsTrue()
+    public function testShouldResetConnectionIsTrue(): void
     {
         $connection = $this->getMockConnection();
         $exception = $this->createMockException($connection, 'Communication error message');
@@ -57,7 +58,7 @@ class CommunicationExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCommunicationExceptionHandling()
+    public function testCommunicationExceptionHandling(): void
     {
         $connection = $this->getMockConnection();
         $connection
@@ -79,7 +80,7 @@ class CommunicationExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCommunicationExceptionHandlingWhenShouldResetConnectionIsFalse()
+    public function testCommunicationExceptionHandlingWhenShouldResetConnectionIsFalse(): void
     {
         $connection = $this->getMockConnection();
         $connection
@@ -89,9 +90,10 @@ class CommunicationExceptionTest extends PredisTestCase
             ->expects($this->never())
             ->method('disconnect');
 
+        /** @var CommunicationException|MockObject */
         $exception = $this->getMockBuilder('Predis\CommunicationException')
             ->setConstructorArgs(array($connection, 'Communication error message'))
-            ->setMethods(array('shouldResetConnection'))
+            ->onlyMethods(array('shouldResetConnection'))
             ->getMockForAbstractClass();
         $exception
             ->expects($this->once())
@@ -120,8 +122,8 @@ class CommunicationExceptionTest extends PredisTestCase
      */
     protected function createMockException(
         Connection\NodeConnectionInterface $connection,
-        $message,
-        $code = 0,
+        string $message,
+        int $code = 0,
         \Exception $inner = null
     ) {
         return $this->getMockBuilder('Predis\CommunicationException')

--- a/tests/Predis/Configuration/Option/AggregateTest.php
+++ b/tests/Predis/Configuration/Option/AggregateTest.php
@@ -50,7 +50,7 @@ class AggregateTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
         $this->assertSame($connection, $initializer($parameters = array()));
@@ -77,7 +77,7 @@ class AggregateTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
 

--- a/tests/Predis/Configuration/Option/AggregateTest.php
+++ b/tests/Predis/Configuration/Option/AggregateTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,10 +22,11 @@ class AggregateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Aggregate();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertNull($option->getDefault($options));
@@ -33,15 +35,16 @@ class AggregateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableAsConnectionInitializer()
+    public function testAcceptsCallableAsConnectionInitializer(): void
     {
         $option = new Aggregate();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -56,18 +59,19 @@ class AggregateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer()
+    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Aggregate expects a valid connection type returned by callable initializer');
 
         $option = new Aggregate();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -83,13 +87,14 @@ class AggregateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInstanceOfAggregateConnectionInterface()
+    public function testThrowsExceptionOnInstanceOfAggregateConnectionInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Aggregate expects a valid callable');
 
         $option = new Aggregate();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $cluster = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 

--- a/tests/Predis/Configuration/Option/CRC16Test.php
+++ b/tests/Predis/Configuration/Option/CRC16Test.php
@@ -11,8 +11,8 @@
 
 namespace Predis\Configuration\Option;
 
-use Predis\Cluster\Hash;
 use PredisTestCase;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -22,10 +22,11 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $hashGenerator = $option->getDefault($options);
 
@@ -41,10 +42,11 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsHashGeneratorInstance()
+    public function testAcceptsHashGeneratorInstance(): void
     {
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $hashGenerator = $this->getMockBuilder('Predis\Cluster\Hash\HashGeneratorInterface')->getMock();
 
@@ -54,15 +56,16 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableAsHashGeneratorInitializer()
+    public function testAcceptsCallableAsHashGeneratorInitializer(): void
     {
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $hashGenerator = $this->getMockBuilder('Predis\Cluster\Hash\HashGeneratorInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -76,18 +79,19 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidReturnTypeOfHashGeneratorInitializer()
+    public function testThrowsExceptionOnInvalidReturnTypeOfHashGeneratorInitializer(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\CRC16 expects a valid hash generator');
 
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $wrongValue = $this->getMockBuilder('stdClass')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -101,10 +105,11 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsShortNameStringPredis()
+    public function testAcceptsShortNameStringPredis(): void
     {
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Predis\Cluster\Hash\CRC16', $option->filter($options, 'predis'));
@@ -116,10 +121,11 @@ class CRC16Test extends PredisTestCase
      * @requires extension phpiredis
      * @requires function phpiredis_utils_crc16
      */
-    public function testAcceptsShortNameStringPhpiredis()
+    public function testAcceptsShortNameStringPhpiredis(): void
     {
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Predis\Cluster\Hash\PhpiredisCRC16', $option->filter($options, 'phpiredis'));
@@ -128,13 +134,14 @@ class CRC16Test extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidShortNameString()
+    public function testThrowsExceptionOnInvalidShortNameString(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('String value for the crc16 option must be either `predis` or `phpiredis`');
 
         $option = new CRC16();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, 'unknown');

--- a/tests/Predis/Configuration/Option/CRC16Test.php
+++ b/tests/Predis/Configuration/Option/CRC16Test.php
@@ -71,7 +71,7 @@ class CRC16Test extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($hashGenerator));
+            ->willReturn($hashGenerator);
 
         $this->assertSame($hashGenerator, $option->filter($options, $callable));
     }
@@ -97,7 +97,7 @@ class CRC16Test extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($wrongValue));
+            ->willReturn($wrongValue);
 
         $option->filter($options, $callable);
     }

--- a/tests/Predis/Configuration/Option/ClusterTest.php
+++ b/tests/Predis/Configuration/Option/ClusterTest.php
@@ -113,20 +113,18 @@ class ClusterTest extends PredisTestCase
 
         /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
         $options
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('__get')
-            ->with('connections')
-            ->will($this->returnValue(
-                $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock()
-            ));
-        $options
-            ->expects($this->at(1))
-            ->method('__get')
-            ->with('crc16')
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('connections'),
+                array('crc16')
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock(),
                 $this->getMockBuilder('Predis\Cluster\Hash\HashGeneratorInterface')->getMock()
-            ));
+            );
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, 'redis'));
         $this->assertInstanceOf('Predis\Connection\Cluster\RedisCluster', $initializer($parameters = array()));

--- a/tests/Predis/Configuration/Option/ClusterTest.php
+++ b/tests/Predis/Configuration/Option/ClusterTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,10 +23,11 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Cluster();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Closure', $initializer = $option->getDefault($options));
@@ -34,15 +37,16 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableAsConnectionInitializer()
+    public function testAcceptsCallableAsConnectionInitializer(): void
     {
         $option = new Cluster();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -57,18 +61,19 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer()
+    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Cluster expects a valid connection type returned by callable initializer');
 
         $option = new Cluster();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -84,10 +89,11 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsShortNameStringPredis()
+    public function testAcceptsShortNameStringPredis(): void
     {
         $option = new Cluster();
 
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->never())
@@ -101,10 +107,11 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsShortNameStringRedis()
+    public function testAcceptsShortNameStringRedis(): void
     {
         $option = new Cluster();
 
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->at(0))
@@ -128,13 +135,14 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidShortNameString()
+    public function testThrowsExceptionOnInvalidShortNameString(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('String value for the cluster option must be either `predis` or `redis`');
 
         $option = new Cluster();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, 'unknown');
@@ -143,13 +151,14 @@ class ClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInstanceOfClusterInterface()
+    public function testThrowsExceptionOnInstanceOfClusterInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Cluster expects a valid callable');
 
         $option = new Cluster();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
 

--- a/tests/Predis/Configuration/Option/ClusterTest.php
+++ b/tests/Predis/Configuration/Option/ClusterTest.php
@@ -52,7 +52,7 @@ class ClusterTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
         $this->assertSame($connection, $initializer($parameters = array()));
@@ -79,7 +79,7 @@ class ClusterTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
 

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -11,9 +11,11 @@
 
 namespace Predis\Configuration\Option;
 
+use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Configuration\OptionsInterface;
 use Predis\Command\Processor\KeyPrefixProcessor;
 use Predis\Command\RedisFactory;
-use PredisTestCase;
 
 /**
  *
@@ -23,10 +25,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $commands = $option->getDefault($options);
@@ -38,10 +41,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAppliesPrefixOnDefaultOptionValue()
+    public function testAppliesPrefixOnDefaultOptionValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->once())
@@ -66,10 +70,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCommandFactoryInstanceAsValue()
+    public function testAcceptsCommandFactoryInstanceAsValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $input = new RedisFactory();
@@ -83,10 +88,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsDictionaryOfCommandsAsValue()
+    public function testAcceptsDictionaryOfCommandsAsValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $input = array(
@@ -104,10 +110,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsDictionaryOfCommandsWithNullsToUndefineCommandsAsValue()
+    public function testAcceptsDictionaryOfCommandsWithNullsToUndefineCommandsAsValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $input = array(
@@ -127,15 +134,16 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableReturningCommandFactoryInstance()
+    public function testAcceptsCallableReturningCommandFactoryInstance(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -149,10 +157,11 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableReturningDictionaryOfCommandsAsValue()
+    public function testAcceptsCallableReturningDictionaryOfCommandsAsValue(): void
     {
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $dictionary = array(
@@ -161,7 +170,7 @@ class CommandsTest extends PredisTestCase
         );
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -179,17 +188,18 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidTypeReturnedByCallable()
+    public function testThrowsExceptionOnInvalidTypeReturnedByCallable(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Commands expects a valid command factory');
 
         $option = new Commands();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -205,12 +215,14 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidValue()
+    public function testThrowsExceptionOnInvalidValue(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Commands expects a valid command factory');
 
         $option = new Commands();
+
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, new \stdClass());

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -51,14 +51,14 @@ class CommandsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__isset')
             ->with('prefix')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $options
             ->expects($this->once())
             ->method('__get')
             ->with('prefix')
-            ->will($this->returnValue(
+            ->willReturn(
                 new KeyPrefixProcessor('prefix:')
-            ));
+            );
 
         $commands = $option->getDefault($options);
 
@@ -149,7 +149,7 @@ class CommandsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         $this->assertSame($commands, $option->filter($options, $callable));
     }
@@ -176,7 +176,7 @@ class CommandsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($dictionary));
+            ->willReturn($dictionary);
 
         $commands = $option->filter($options, $callable);
 
@@ -205,9 +205,9 @@ class CommandsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue(
+            ->willReturn(
                 new \stdClass()
-            ));
+            );
 
         $option->filter($options, $callable);
     }

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -58,7 +58,7 @@ class ConnectionsTest extends PredisTestCase
             ->expects($this->once())
             ->method('getDefault')
             ->with($options)
-            ->will($this->returnValue($default));
+            ->willReturn($default);
 
         $this->assertInstanceOf('Predis\Connection\FactoryInterface', $factory = $option->filter($options, $value));
         $this->assertSame($default, $factory);
@@ -147,12 +147,12 @@ class ConnectionsTest extends PredisTestCase
             ->expects($this->once())
             ->method('defined')
             ->with('parameters')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $options
             ->expects($this->once())
             ->method('__get')
             ->with('parameters')
-            ->will($this->returnValue($parameters));
+            ->willReturn($parameters);
 
         $option = new Connections();
         $factory = $option->getDefault($options);
@@ -196,9 +196,9 @@ class ConnectionsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue(
+            ->willReturn(
                 $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock()
-            ));
+            );
 
         $this->assertSame($factory, $option->filter($options, $callable));
     }

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,10 +23,11 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Connections();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Predis\Connection\Factory', $option->getDefault($options));
@@ -33,8 +36,9 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsNamedArrayWithSchemeToConnectionClassMappings()
+    public function testAcceptsNamedArrayWithSchemeToConnectionClassMappings(): void
     {
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $class = get_class($this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock());
@@ -46,8 +50,9 @@ class ConnectionsTest extends PredisTestCase
             ->method('define')
             ->with($this->matchesRegularExpression('/^tcp|redis$/'), $class);
 
+        /** @var OptionInterface */
         $option = $this->getMockBuilder('Predis\Configuration\Option\Connections')
-            ->setMethods(array('getDefault'))
+            ->onlyMethods(array('getDefault'))
             ->getMock();
         $option
             ->expects($this->once())
@@ -132,12 +137,11 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsesParametersOptionToSetDefaultParameters()
+    public function testUsesParametersOptionToSetDefaultParameters(): void
     {
         $parameters = array('database' => 5, 'password' => 'mypassword');
 
-        $default = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
-
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->once())
@@ -159,10 +163,11 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsConnectionFactoryInstance()
+    public function testAcceptsConnectionFactoryInstance(): void
     {
+        /** @var OptionInterface */
         $option = $this->getMockBuilder('Predis\Configuration\Option\Connections')
-            ->setMethods(array('getDefault'))
+            ->onlyMethods(array('getDefault'))
             ->getMock();
         $option
             ->expects($this->never())
@@ -177,14 +182,15 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableReturningConnectionFactoryInstance()
+    public function testAcceptsCallableReturningConnectionFactoryInstance(): void
     {
         $option = new Connections();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -200,12 +206,14 @@ class ConnectionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidArguments()
+    public function testThrowsExceptionOnInvalidArguments(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Connections expects a valid connection factory');
 
         $option = new Connections();
+
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, new \stdClass());

--- a/tests/Predis/Configuration/Option/ExceptionsTest.php
+++ b/tests/Predis/Configuration/Option/ExceptionsTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,9 +22,11 @@ class ExceptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Exceptions();
+
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertTrue($option->getDefault($options));
@@ -32,9 +35,11 @@ class ExceptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsDifferentValuesAndFiltersThemAsBooleans()
+    public function testAcceptsDifferentValuesAndFiltersThemAsBooleans(): void
     {
         $option = new Exceptions();
+
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertFalse($option->filter($options, null));
@@ -55,9 +60,11 @@ class ExceptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsFalesOnValuesNotParsableAsBooleans()
+    public function testReturnsFalesOnValuesNotParsableAsBooleans(): void
     {
         $option = new Exceptions();
+
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertFalse($option->filter($options, new \stdClass()));

--- a/tests/Predis/Configuration/Option/PrefixTest.php
+++ b/tests/Predis/Configuration/Option/PrefixTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,10 +22,11 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertNull($option->getDefault($options));
@@ -33,10 +35,11 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsStringAndReturnsCommandProcessor()
+    public function testAcceptsStringAndReturnsCommandProcessor(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $prefix = $option->filter($options, $value = 'prefix:');
@@ -49,10 +52,11 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCommandProcessorInstance()
+    public function testAcceptsCommandProcessorInstance(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock();
 
@@ -64,14 +68,15 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableReturningProcessorInterface()
+    public function testAcceptsCallableReturningProcessorInterface(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -89,14 +94,15 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableReturningStringPrefix()
+    public function testAcceptsCallableReturningStringPrefix(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -114,14 +120,15 @@ class PrefixTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsObjectAsPrefixAndCastsToString()
+    public function testAcceptsObjectAsPrefixAndCastsToString(): void
     {
         $option = new Prefix();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $input = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__toString'))
+            ->addMethods(array('__toString'))
             ->getMock();
         $input
             ->expects($this->once())

--- a/tests/Predis/Configuration/Option/PrefixTest.php
+++ b/tests/Predis/Configuration/Option/PrefixTest.php
@@ -82,9 +82,9 @@ class PrefixTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue(
+            ->willReturn(
                 $processor = $this->getMockBuilder('Predis\Command\Processor\ProcessorInterface')->getMock()
-            ));
+            );
 
         $prefix = $option->filter($options, $callable);
 
@@ -108,7 +108,7 @@ class PrefixTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue('pfx:'));
+            ->willReturn('pfx:');
 
         $prefix = $option->filter($options, $callable);
 
@@ -133,7 +133,7 @@ class PrefixTest extends PredisTestCase
         $input
             ->expects($this->once())
             ->method('__toString')
-            ->will($this->returnValue('pfx:'));
+            ->willReturn('pfx:');
 
         $prefix = $option->filter($options, $input);
 

--- a/tests/Predis/Configuration/Option/ReplicationTest.php
+++ b/tests/Predis/Configuration/Option/ReplicationTest.php
@@ -49,12 +49,12 @@ class ReplicationTest extends PredisTestCase
             ->expects($this->at(0))
             ->method('__get')
             ->with('autodiscovery')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $options
             ->expects($this->at(1))
             ->method('__get')
             ->with('connections')
-            ->will($this->returnValue($connectionFactory));
+            ->willReturn($connectionFactory);
 
         $this->assertInstanceOf('Closure', $initializer = $option->getDefault($options));
         $this->assertInstanceOf('Predis\Connection\Replication\MasterSlaveReplication', $connection = $initializer($options));
@@ -84,7 +84,7 @@ class ReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
         $this->assertSame($connection, $initializer($parameters = array()));
@@ -111,7 +111,7 @@ class ReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, $callable));
 
@@ -145,7 +145,7 @@ class ReplicationTest extends PredisTestCase
             ->expects($this->at(0))
             ->method('__get')
             ->with('service')
-            ->will($this->returnValue('mymaster'));
+            ->willReturn('mymaster');
         $options
             ->expects($this->at(1))
             ->method('__get')

--- a/tests/Predis/Configuration/Option/ReplicationTest.php
+++ b/tests/Predis/Configuration/Option/ReplicationTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Configuration\Option;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Configuration\OptionsInterface;
 
 /**
  *
@@ -21,10 +23,11 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultOptionValue()
+    public function testDefaultOptionValue(): void
     {
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Closure', $initializer = $option->getDefault($options));
@@ -34,12 +37,13 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConfiguresAutomaticDiscoveryWhenAutodiscoveryOptionIsPresent()
+    public function testConfiguresAutomaticDiscoveryWhenAutodiscoveryOptionIsPresent(): void
     {
         $option = new Replication();
 
         $connectionFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
 
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->at(0))
@@ -65,15 +69,16 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableAsConnectionInitializer()
+    public function testAcceptsCallableAsConnectionInitializer(): void
     {
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -88,18 +93,19 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer()
+    public function testThrowsExceptionOnInvalidReturnTypeOfConnectionInitializer(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Replication expects a valid connection type returned by callable initializer');
 
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -115,10 +121,11 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsShortNameStringPredis()
+    public function testAcceptsShortNameStringPredis(): void
     {
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $this->assertInstanceOf('Closure', $initializer = $option->filter($options, 'predis'));
@@ -128,10 +135,11 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsShortNameStringRedis()
+    public function testAcceptsShortNameStringRedis(): void
     {
         $option = new Replication();
 
+        /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
             ->expects($this->at(0))
@@ -159,13 +167,14 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidShortNameString()
+    public function testThrowsExceptionOnInvalidShortNameString(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('String value for the replication option must be either `predis` or `sentinel`');
 
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, 'unknown');
@@ -174,13 +183,14 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnBooleanValue()
+    public function testThrowsExceptionOnBooleanValue(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Replication expects a valid callable');
 
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, true);
@@ -189,13 +199,14 @@ class ReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInstanceOfReplicationInterface()
+    public function testThrowsExceptionOnInstanceOfReplicationInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Predis\Configuration\Option\Replication expects a valid callable');
 
         $option = new Replication();
 
+        /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $connection = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
 

--- a/tests/Predis/Configuration/Option/ReplicationTest.php
+++ b/tests/Predis/Configuration/Option/ReplicationTest.php
@@ -46,15 +46,16 @@ class ReplicationTest extends PredisTestCase
         /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('__get')
-            ->with('autodiscovery')
-            ->willReturn(true);
-        $options
-            ->expects($this->at(1))
-            ->method('__get')
-            ->with('connections')
-            ->willReturn($connectionFactory);
+            ->withConsecutive(
+                array('autodiscovery'),
+                array('connections')
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                $connectionFactory
+            );
 
         $this->assertInstanceOf('Closure', $initializer = $option->getDefault($options));
         $this->assertInstanceOf('Predis\Connection\Replication\MasterSlaveReplication', $connection = $initializer($options));
@@ -142,17 +143,16 @@ class ReplicationTest extends PredisTestCase
         /** @var OptionsInterface|MockObject */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
         $options
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('__get')
-            ->with('service')
-            ->willReturn('mymaster');
-        $options
-            ->expects($this->at(1))
-            ->method('__get')
-            ->with('connections')
-            ->will($this->returnValue(
+            ->withConsecutive(
+                array('service'),
+                array('connections')
+            )
+            ->willReturnOnConsecutiveCalls(
+                'mymaster',
                 $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock()
-            ));
+            );
 
         $parameters = array(
             $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock(),

--- a/tests/Predis/Configuration/OptionsTest.php
+++ b/tests/Predis/Configuration/OptionsTest.php
@@ -21,7 +21,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithoutArguments()
+    public function testConstructorWithoutArguments(): void
     {
         $options = new Options();
 
@@ -37,12 +37,12 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArrayArgument()
+    public function testConstructorWithArrayArgument(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
 
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->any())
@@ -78,7 +78,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsCustomOptions()
+    public function testSupportsCustomOptions(): void
     {
         $options = new Options(array(
             'custom' => 'foobar',
@@ -90,7 +90,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUndefinedOptionsReturnNull()
+    public function testUndefinedOptionsReturnNull(): void
     {
         $options = new Options();
 
@@ -102,7 +102,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanCheckOptionsIfDefinedByUser()
+    public function testCanCheckOptionsIfDefinedByUser(): void
     {
         $options = new Options(array(
             'prefix' => 'prefix:',
@@ -119,7 +119,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsSetReplicatesPHPBehavior()
+    public function testIsSetReplicatesPHPBehavior(): void
     {
         $options = new Options(array(
             'prefix' => 'prefix:',
@@ -136,7 +136,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsDefaultValueOfSpecifiedOption()
+    public function testReturnsDefaultValueOfSpecifiedOption(): void
     {
         $options = new Options();
 
@@ -146,7 +146,7 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsNullAsDefaultValueForUndefinedOption()
+    public function testReturnsNullAsDefaultValueForUndefinedOption(): void
     {
         $options = new Options();
 
@@ -156,13 +156,13 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testLazilyInitializesOptionValueUsingObjectWithInvokeMagicMethod()
+    public function testLazilyInitializesOptionValueUsingObjectWithInvokeMagicMethod(): void
     {
         $commands = $this->getMockBuilder('Predis\Command\FactoryInterface')->getMock();
 
         // NOTE: closure values are covered by this test since they define __invoke().
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -181,13 +181,13 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testLazilyInitializesCustomOptionValueUsingObjectWithInvokeMagicMethod()
+    public function testLazilyInitializesCustomOptionValueUsingObjectWithInvokeMagicMethod(): void
     {
         $custom = new \stdClass();
 
         // NOTE: closure values are covered by this test since they define __invoke().
         $callable = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callable
             ->expects($this->once())
@@ -206,10 +206,10 @@ class OptionsTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testChecksForInvokeMagicMethodDoesNotTriggerAutoloader()
+    public function testChecksForInvokeMagicMethodDoesNotTriggerAutoloader(): void
     {
         $trigger = $this->getMockBuilder('stdClass')
-            ->setMethods(array('autoload'))
+            ->addMethods(array('autoload'))
             ->getMock();
         $trigger
             ->expects($this->never())

--- a/tests/Predis/Configuration/OptionsTest.php
+++ b/tests/Predis/Configuration/OptionsTest.php
@@ -48,7 +48,7 @@ class OptionsTest extends PredisTestCase
             ->expects($this->any())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $options = new Options(array(
             'exceptions' => false,
@@ -168,7 +168,7 @@ class OptionsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($commands));
+            ->willReturn($commands);
 
         $options = new Options(array(
             'commands' => $callable,
@@ -193,7 +193,7 @@ class OptionsTest extends PredisTestCase
             ->expects($this->once())
             ->method('__invoke')
             ->with($this->isInstanceOf('Predis\Configuration\OptionsInterface'))
-            ->will($this->returnValue($custom));
+            ->willReturn($custom);
 
         $options = new Options(array(
             'custom' => $callable,

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -140,13 +140,13 @@ class PredisClusterTest extends PredisTestCase
         $connection1
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
         $connection2
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $cluster = new PredisCluster();
 
@@ -165,13 +165,13 @@ class PredisClusterTest extends PredisTestCase
         $connection1
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
         $connection2
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $cluster = new PredisCluster();
 

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -21,7 +21,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExposesCommandHashStrategy()
+    public function testExposesCommandHashStrategy(): void
     {
         $cluster = new PredisCluster();
         $this->assertInstanceOf('Predis\Cluster\PredisStrategy', $cluster->getClusterStrategy());
@@ -30,7 +30,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionsToCluster()
+    public function testAddingConnectionsToCluster(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
@@ -48,7 +48,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionsWithAliasParameterToCluster()
+    public function testAddingConnectionsWithAliasParameterToCluster(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001?alias=node01');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002?alias=node02');
@@ -66,7 +66,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemovingConnectionsFromCluster()
+    public function testRemovingConnectionsFromCluster(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001?alias=node01');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
@@ -88,7 +88,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectForcesAllConnectionsToConnect()
+    public function testConnectForcesAllConnectionsToConnect(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -111,7 +111,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDisconnectForcesAllConnectionsToDisconnect()
+    public function testDisconnectForcesAllConnectionsToDisconnect(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -134,7 +134,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen()
+    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -159,7 +159,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed()
+    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection1
@@ -184,7 +184,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanReturnAnIteratorForConnections()
+    public function testCanReturnAnIteratorForConnections(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
@@ -206,7 +206,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsCorrectConnectionUsingSlot()
+    public function testReturnsCorrectConnectionUsingSlot(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
@@ -223,7 +223,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsCorrectConnectionUsingKey()
+    public function testReturnsCorrectConnectionUsingKey(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002');
@@ -242,7 +242,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsCorrectConnectionUsingCommandInstance()
+    public function testReturnsCorrectConnectionUsingCommandInstance(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -278,7 +278,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
     */
-    public function testThrowsExceptionOnNonShardableCommand()
+    public function testThrowsExceptionOnNonShardableCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Cannot use 'PING' over clusters of connections.");
@@ -295,7 +295,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsKeyHashTags()
+    public function testSupportsKeyHashTags(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -321,7 +321,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWritesCommandToCorrectConnection()
+    public function testWritesCommandToCorrectConnection(): void
     {
         $command = $this->getCommandFactory()->create('get', array('node01:5431'));
 
@@ -347,7 +347,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsCommandFromCorrectConnection()
+    public function testReadsCommandFromCorrectConnection(): void
     {
         $command = $this->getCommandFactory()->create('get', array('node02:3212'));
 
@@ -373,7 +373,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecutesCommandOnCorrectConnection()
+    public function testExecutesCommandOnCorrectConnection(): void
     {
         $command = $this->getCommandFactory()->create('get', array('node01:5431'));
 
@@ -399,7 +399,7 @@ class PredisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanBeSerialized()
+    public function testCanBeSerialized(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:7001?alias=first');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:7002?alias=second');

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -11,10 +11,12 @@
 
 namespace Predis\Connection\Cluster;
 
+use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Cluster;
 use Predis\Command;
 use Predis\Connection;
 use Predis\Response;
-use PredisTestCase;
 
 /**
  *
@@ -24,8 +26,9 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCustomConnectionFactory()
+    public function testAcceptsCustomConnectionFactory(): void
     {
+        /** @var Connection\FactoryInterface */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $cluster = new RedisCluster($factory);
 
@@ -35,7 +38,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsesRedisClusterStrategyByDefault()
+    public function testUsesRedisClusterStrategyByDefault(): void
     {
         $cluster = new RedisCluster(new Connection\Factory());
 
@@ -45,8 +48,9 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCustomClusterStrategy()
+    public function testAcceptsCustomClusterStrategy(): void
     {
+        /** @var Cluster\StrategyInterface */
         $strategy = $this->getMockBuilder('Predis\Cluster\StrategyInterface')->getMock();
 
         $cluster = new RedisCluster(new Connection\Factory(), $strategy);
@@ -57,7 +61,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionsToCluster()
+    public function testAddingConnectionsToCluster(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -75,7 +79,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemovingConnectionsFromCluster()
+    public function testRemovingConnectionsFromCluster(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -94,7 +98,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemovingConnectionsFromClusterByAlias()
+    public function testRemovingConnectionsFromClusterByAlias(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -112,7 +116,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCountReturnsNumberOfConnectionsInPool()
+    public function testCountReturnsNumberOfConnectionsInPool(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -134,7 +138,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectPicksRandomConnection()
+    public function testConnectPicksRandomConnection(): void
     {
         $connect1 = false;
         $connect2 = false;
@@ -188,7 +192,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDisconnectForcesAllConnectionsToDisconnect()
+    public function testDisconnectForcesAllConnectionsToDisconnect(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -211,7 +215,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen()
+    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -236,7 +240,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed()
+    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection1
@@ -261,7 +265,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIteratorReturnsConnectionsMappedInSlotsMapWhenUseClusterSlotsIsDisabled()
+    public function testGetIteratorReturnsConnectionsMappedInSlotsMapWhenUseClusterSlotsIsDisabled(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6381?slots=0-5460');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
@@ -288,7 +292,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetIteratorReturnsConnectionsMappedInSlotsMapFetchedFromRedisCluster()
+    public function testGetIteratorReturnsConnectionsMappedInSlotsMapFetchedFromRedisCluster(): void
     {
         $slotsmap = array(
             array(0, 5460, array('127.0.0.1', 6381), array()),
@@ -328,8 +332,9 @@ class RedisClusterTest extends PredisTestCase
             ->will($this->returnValue($connection4));
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
+        /** @var Connection\Cluster\RedisCluster|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\RedisCluster')
-            ->setMethods(array('getRandomConnection'))
+            ->onlyMethods(array('getRandomConnection'))
             ->setConstructorArgs(array($factory))
             ->getMock();
         $cluster
@@ -354,7 +359,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionResetsSlotsMap()
+    public function testAddingConnectionResetsSlotsMap(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -376,7 +381,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemovingConnectionResetsSlotsMap()
+    public function testRemovingConnectionResetsSlotsMap(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -405,7 +410,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanAssignConnectionsToRangeOfSlotsFromParameters()
+    public function testCanAssignConnectionsToRangeOfSlotsFromParameters(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379?slots=0-5460');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380?slots=5461-10922');
@@ -435,7 +440,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanAssignConnectionsToSingleSlotOrRangesOfSlotsFromParameters()
+    public function testCanAssignConnectionsToSingleSlotOrRangesOfSlotsFromParameters(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379?slots=0-5460,5500-5600,11000');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380?slots=5461-5499,5600-10922');
@@ -469,7 +474,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsCorrectConnectionUsingSlotID()
+    public function testReturnsCorrectConnectionUsingSlotID(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -492,7 +497,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsCorrectConnectionUsingCommandInstance()
+    public function testReturnsCorrectConnectionUsingCommandInstance(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -525,7 +530,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWritesCommandToCorrectConnection()
+    public function testWritesCommandToCorrectConnection(): void
     {
         $command = $this->getCommandFactory()->create('get', array('node:1001'));
 
@@ -552,7 +557,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsCommandFromCorrectConnection()
+    public function testReadsCommandFromCorrectConnection(): void
     {
         $command = $this->getCommandFactory()->create('get', array('node:1050'));
 
@@ -579,7 +584,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRetriesExecutingCommandOnConnectionFailureOnlyAfterFetchingNewSlotsMap()
+    public function testRetriesExecutingCommandOnConnectionFailureOnlyAfterFetchingNewSlotsMap(): void
     {
         $slotsmap = array(
             array(0, 5460, array('127.0.0.1', 9381), array()),
@@ -632,6 +637,7 @@ class RedisClusterTest extends PredisTestCase
             ))
             ->will($this->returnValue('value:5001'));
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
@@ -660,7 +666,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRetriesExecutingCommandOnConnectionFailureButDoNotAskSlotMapWhenDisabled()
+    public function testRetriesExecutingCommandOnConnectionFailureButDoNotAskSlotMapWhenDisabled(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6381?slots=0-5500');
         $connection1
@@ -709,8 +715,9 @@ class RedisClusterTest extends PredisTestCase
              ->will($this->returnValue($connection4));
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
+        /** @var Connection\Cluster\RedisCluster|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\RedisCluster')
-            ->setMethods(array('getRandomConnection'))
+            ->onlyMethods(array('getRandomConnection'))
             ->setConstructorArgs(array($factory))
             ->getMock();
         $cluster
@@ -731,11 +738,12 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsClientExceptionWhenExecutingCommandWithEmptyPool()
+    public function testThrowsClientExceptionWhenExecutingCommandWithEmptyPool(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No connections available in the pool');
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->never())
@@ -751,8 +759,9 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskSlotMapReturnEmptyArrayOnEmptyConnectionsPool()
+    public function testAskSlotMapReturnEmptyArrayOnEmptyConnectionsPool(): void
     {
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->never())
@@ -767,7 +776,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskSlotMapRetriesOnDifferentNodeOnConnectionFailure()
+    public function testAskSlotMapRetriesOnDifferentNodeOnConnectionFailure(): void
     {
         $slotsmap = array(
             array(0, 5460, array('127.0.0.1', 9381), array()),
@@ -812,8 +821,9 @@ class RedisClusterTest extends PredisTestCase
             ->method('create');
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
+        /** @var Connection\Cluster\RedisCluster|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\RedisCluster')
-            ->setMethods(array('getRandomConnection'))
+            ->onlyMethods(array('getRandomConnection'))
             ->setConstructorArgs(array($factory))
             ->getMock();
         $cluster
@@ -833,7 +843,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskSlotMapHonorsRetryLimitOnMultipleConnectionFailures()
+    public function testAskSlotMapHonorsRetryLimitOnMultipleConnectionFailures(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("Unknown connection error [127.0.0.1:6382]");
@@ -877,8 +887,9 @@ class RedisClusterTest extends PredisTestCase
             ->method('create');
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
+        /** @var Connection\Cluster\RedisCluster|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\RedisCluster')
-            ->setMethods(array('getRandomConnection'))
+            ->onlyMethods(array('getRandomConnection'))
             ->setConstructorArgs(array($factory))
             ->getMock();
         $cluster
@@ -898,7 +909,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsKeyHashTags()
+    public function testSupportsKeyHashTags(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -924,7 +935,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskResponseWithConnectionInPool()
+    public function testAskResponseWithConnectionInPool(): void
     {
         $askResponse = new Response\Error('ASK 1970 127.0.0.1:6380');
 
@@ -948,7 +959,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($command)
             ->will($this->returnValue('foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->never())
             ->method('create');
@@ -967,7 +979,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskResponseWithConnectionNotInPool()
+    public function testAskResponseWithConnectionNotInPool(): void
     {
         $askResponse = new Response\Error('ASK 1970 127.0.0.1:6381');
 
@@ -998,7 +1010,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($command)
             ->will($this->returnValue('foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
             ->method('create')
@@ -1022,7 +1035,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMovedResponseWithConnectionInPool()
+    public function testMovedResponseWithConnectionInPool(): void
     {
         $movedResponse = new Response\Error('MOVED 1970 127.0.0.1:6380');
 
@@ -1042,7 +1055,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($command)
             ->will($this->onConsecutiveCalls('foobar', 'foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory->expects($this->never())->method('create');
 
         $cluster = new RedisCluster($factory);
@@ -1059,7 +1073,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMovedResponseWithConnectionNotInPool()
+    public function testMovedResponseWithConnectionNotInPool(): void
     {
         $movedResponse = new Response\Error('MOVED 1970 127.0.0.1:6381');
 
@@ -1084,7 +1098,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($command)
             ->will($this->onConsecutiveCalls('foobar', 'foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
             ->method('create')
@@ -1108,7 +1123,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParseIPv6AddresseAndPortPairInRedirectionPayload()
+    public function testParseIPv6AddresseAndPortPairInRedirectionPayload(): void
     {
         $movedResponse = new Response\Error('MOVED 1970 2001:db8:0:f101::2:6379');
 
@@ -1128,7 +1143,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($command)
             ->will($this->returnValue('foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
             ->method('create')
@@ -1149,7 +1165,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFetchSlotsMapFromClusterWithClusterSlotsCommand()
+    public function testFetchSlotsMapFromClusterWithClusterSlotsCommand(): void
     {
         $response = array(
             array(12288, 13311, array('10.1.0.51', 6387), array('10.1.0.52', 6387)),
@@ -1179,7 +1195,8 @@ class RedisClusterTest extends PredisTestCase
             ))
             ->will($this->returnValue($response));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
 
         $cluster = new RedisCluster($factory);
 
@@ -1193,7 +1210,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAskSlotMapToRedisClusterOnMovedResponseByDefault()
+    public function testAskSlotMapToRedisClusterOnMovedResponseByDefault(): void
     {
         $cmdGET = Command\RawCommand::create('GET', 'node:1001');
         $rspMOVED = new Response\Error('MOVED 1970 127.0.0.1:6380');
@@ -1223,7 +1240,8 @@ class RedisClusterTest extends PredisTestCase
             ->with($cmdGET)
             ->will($this->returnValue('foobar'));
 
-        $factory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
             ->method('create')
@@ -1244,7 +1262,7 @@ class RedisClusterTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnNonSupportedCommand()
+    public function testThrowsExceptionOnNonSupportedCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Cannot use 'PING' with redis-cluster");
@@ -1262,7 +1280,7 @@ class RedisClusterTest extends PredisTestCase
      * @medium
      * @group disconnected
      */
-    public function testCanBeSerialized()
+    public function testCanBeSerialized(): void
     {
         $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379?slots=0-5460');
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380?slots=5461-10922');

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -147,29 +147,29 @@ class RedisClusterTest extends PredisTestCase
         $connection1
             ->expects($this->any())
             ->method('connect')
-            ->will($this->returnCallback(function () use (&$connect1) {
+            ->willReturnCallback(function () use (&$connect1) {
                 $connect1 = true;
-            }));
+            });
         $connection1
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnCallback(function () use (&$connect1) {
+            ->willReturnCallback(function () use (&$connect1) {
                 return $connect1;
-            }));
+            });
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
             ->expects($this->any())
             ->method('connect')
-            ->will($this->returnCallback(function () use (&$connect2) {
+            ->willReturnCallback(function () use (&$connect2) {
                 $connect2 = true;
-            }));
+            });
         $connection2
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnCallback(function () use (&$connect2) {
+            ->willReturnCallback(function () use (&$connect2) {
                 return $connect2;
-            }));
+            });
 
         $cluster = new RedisCluster(new Connection\Factory());
 
@@ -221,13 +221,13 @@ class RedisClusterTest extends PredisTestCase
         $connection1
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $cluster = new RedisCluster(new Connection\Factory());
 
@@ -246,13 +246,13 @@ class RedisClusterTest extends PredisTestCase
         $connection1
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $cluster = new RedisCluster(new Connection\Factory());
 
@@ -307,7 +307,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($slotsmap));
+            ->willReturn($slotsmap);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383');
@@ -321,7 +321,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '6383',
             ))
-            ->will($this->returnValue($connection3));
+            ->willReturn($connection3);
         $factory
             ->expects($this->at(1))
             ->method('create')
@@ -329,7 +329,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '6384',
             ))
-            ->will($this->returnValue($connection4));
+            ->willReturn($connection4);
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
         /** @var Connection\Cluster\RedisCluster|MockObject */
@@ -340,7 +340,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster
             ->expects($this->once())
             ->method('getRandomConnection')
-            ->will($this->returnValue($connection1));
+            ->willReturn($connection1);
 
         $cluster->add($connection1);
         $cluster->add($connection2);
@@ -599,9 +599,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'GET', array('node:1001')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection1, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
         $connection2
@@ -610,7 +610,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($slotsmap));
+            ->willReturn($slotsmap);
 
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383?slots=10923-16383');
         $connection3
@@ -619,7 +619,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($slotsmap));
+            ->willReturn($slotsmap);
 
         $connection4 = $this->getMockConnection('tcp://127.0.0.1:9381');
         $connection4
@@ -628,14 +628,14 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'GET', array('node:1001')
             ))
-            ->will($this->returnValue('value:1001'));
+            ->willReturn('value:1001');
         $connection4
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'GET', array('node:5001')
             ))
-            ->will($this->returnValue('value:5001'));
+            ->willReturn('value:5001');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -646,7 +646,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '9381',
             ))
-            ->will($this->returnValue($connection4));
+            ->willReturn($connection4);
 
         $cluster = new RedisCluster($factory);
 
@@ -675,9 +675,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'GET', array('node:1001')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection1, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5501-11000');
         $connection2
@@ -686,9 +686,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'GET', array('node:1001')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 new Response\Error('MOVED 1970 127.0.0.1:9381')
-            ));
+            );
 
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383?slots=11101-16383');
         $connection3
@@ -702,7 +702,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'GET', array('node:1001')
             ))
-            ->will($this->returnValue('value:1001'));
+            ->willReturn('value:1001');
 
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
@@ -712,7 +712,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '9381',
               ))
-             ->will($this->returnValue($connection4));
+             ->willReturn($connection4);
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
         /** @var Connection\Cluster\RedisCluster|MockObject */
@@ -791,9 +791,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection1, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
         $connection2
@@ -802,9 +802,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection2, 'Unknown connection error [127.0.0.1:6383]')
-            ));
+            );
 
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383?slots=10923-16383');
         $connection3
@@ -813,7 +813,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($slotsmap));
+            ->willReturn($slotsmap);
 
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
@@ -829,7 +829,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster
             ->expects($this->exactly(3))
             ->method('getRandomConnection')
-            ->will($this->onConsecutiveCalls($connection1, $connection2, $connection3));
+            ->willReturnOnConsecutiveCalls($connection1, $connection2, $connection3);
 
         $cluster->add($connection1);
         $cluster->add($connection2);
@@ -861,9 +861,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection1, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
         $connection2
@@ -872,9 +872,9 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($connection2, 'Unknown connection error [127.0.0.1:6382]')
-            ));
+            );
 
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383?slots=10923-16383');
         $connection3
@@ -895,7 +895,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster
             ->expects($this->exactly(2))
             ->method('getRandomConnection')
-            ->will($this->onConsecutiveCalls($connection1, $connection2));
+            ->willReturnOnConsecutiveCalls($connection1, $connection2);
 
         $cluster->add($connection1);
         $cluster->add($connection2);
@@ -946,7 +946,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->exactly(2))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->onConsecutiveCalls($askResponse, 'foobar'));
+            ->willReturnOnConsecutiveCalls($askResponse, 'foobar');
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
@@ -957,7 +957,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue('foobar'));
+            ->willReturn('foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -990,7 +990,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->exactly(2))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->onConsecutiveCalls($askResponse, 'foobar'));
+            ->willReturnOnConsecutiveCalls($askResponse, 'foobar');
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
@@ -1008,7 +1008,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue('foobar'));
+            ->willReturn('foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1019,7 +1019,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '6381',
             ))
-            ->will($this->returnValue($connection3));
+            ->willReturn($connection3);
 
         $cluster = new RedisCluster($factory);
         $cluster->useClusterSlots(false);
@@ -1046,14 +1046,14 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->exactly(1))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue($movedResponse));
+            ->willReturn($movedResponse);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
             ->expects($this->exactly(2))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->onConsecutiveCalls('foobar', 'foobar'));
+            ->willReturnOnConsecutiveCalls('foobar', 'foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1084,7 +1084,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue($movedResponse));
+            ->willReturn($movedResponse);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
@@ -1096,7 +1096,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->exactly(2))
             ->method('executeCommand')
             ->with($command)
-            ->will($this->onConsecutiveCalls('foobar', 'foobar'));
+            ->willReturnOnConsecutiveCalls('foobar', 'foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1107,7 +1107,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '6381',
             ))
-            ->will($this->returnValue($connection3));
+            ->willReturn($connection3);
 
         $cluster = new RedisCluster($factory);
         $cluster->useClusterSlots(false);
@@ -1134,14 +1134,14 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue($movedResponse));
+            ->willReturn($movedResponse);
 
         $connection2 = $this->getMockConnection('tcp://[2001:db8:0:f101::2]:6379');
         $connection2
             ->expects($this->once())
             ->method('executeCommand')
             ->with($command)
-            ->will($this->returnValue('foobar'));
+            ->willReturn('foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1152,7 +1152,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '2001:db8:0:f101::2',
                 'port' => '6379',
             ))
-            ->will($this->returnValue($connection2));
+            ->willReturn($connection2);
 
         $cluster = new RedisCluster($factory);
         $cluster->useClusterSlots(false);
@@ -1193,7 +1193,7 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         /** @var Connection\FactoryInterface */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1224,7 +1224,7 @@ class RedisClusterTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdGET)
-            ->will($this->returnValue($rspMOVED));
+            ->willReturn($rspMOVED);
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
@@ -1233,12 +1233,12 @@ class RedisClusterTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'CLUSTER', array('SLOTS')
             ))
-            ->will($this->returnValue($rspSlotsArray));
+            ->willReturn($rspSlotsArray);
         $connection2
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($cmdGET)
-            ->will($this->returnValue('foobar'));
+            ->willReturn('foobar');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1249,7 +1249,7 @@ class RedisClusterTest extends PredisTestCase
                 'host' => '127.0.0.1',
                 'port' => '6380',
             ))
-            ->will($this->returnValue($connection2));
+            ->willReturn($connection2);
 
         $cluster = new RedisCluster($factory);
 

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -315,21 +315,26 @@ class RedisClusterTest extends PredisTestCase
 
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6383',
-            ))
-            ->willReturn($connection3);
-        $factory
-            ->expects($this->at(1))
-            ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6384',
-            ))
-            ->willReturn($connection4);
+            ->withConsecutive(
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6383',
+                    )
+                ),
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6384',
+                    )
+                )
+            )
+            ->willReturnOnConsecutiveCalls(
+                $connection3,
+                $connection4
+            );
 
         // TODO: I'm not sure about mocking a protected method, but it'll do for now
         /** @var Connection\Cluster\RedisCluster|MockObject */
@@ -623,19 +628,16 @@ class RedisClusterTest extends PredisTestCase
 
         $connection4 = $this->getMockConnection('tcp://127.0.0.1:9381');
         $connection4
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'GET', array('node:1001')
-            ))
-            ->willReturn('value:1001');
-        $connection4
-            ->expects($this->at(1))
-            ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'GET', array('node:5001')
-            ))
-            ->willReturn('value:5001');
+            ->withConsecutive(
+                array($this->isRedisCommand('GET', array('node:1001'))),
+                array($this->isRedisCommand('GET', array('node:5001')))
+            )
+            ->willReturnOnConsecutiveCalls(
+                'value:1001',
+                'value:5001'
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -950,14 +952,16 @@ class RedisClusterTest extends PredisTestCase
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
-            ->expects($this->at(2))
+            ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ASKING'));
-        $connection2
-            ->expects($this->at(3))
-            ->method('executeCommand')
-            ->with($command)
-            ->willReturn('foobar');
+            ->withConsecutive(
+                array($this->isRedisCommand('ASKING')),
+                array($this->isRedisCommand($command))
+            )
+            ->willReturnOnConsecutiveCalls(
+                new Response\Status('OK'),
+                'foobar'
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -999,16 +1003,16 @@ class RedisClusterTest extends PredisTestCase
 
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6381');
         $connection3
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'ASKING'
-            ));
-        $connection3
-            ->expects($this->at(1))
-            ->method('executeCommand')
-            ->with($command)
-            ->willReturn('foobar');
+            ->withConsecutive(
+                array($this->isRedisCommand('ASKING')),
+                array($this->isRedisCommand($command))
+            )
+            ->willReturnOnConsecutiveCalls(
+                new Response\Status('OK'),
+                'foobar'
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1228,17 +1232,16 @@ class RedisClusterTest extends PredisTestCase
 
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $connection2
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'CLUSTER', array('SLOTS')
-            ))
-            ->willReturn($rspSlotsArray);
-        $connection2
-            ->expects($this->at(3))
-            ->method('executeCommand')
-            ->with($cmdGET)
-            ->willReturn('foobar');
+            ->withConsecutive(
+                array($this->isRedisCommand('CLUSTER', array('SLOTS'))),
+                array($this->isRedisCommand($cmdGET))
+            )
+            ->willReturnOnConsecutiveCalls(
+                $rspSlotsArray,
+                'foobar'
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();

--- a/tests/Predis/Connection/CompositeStreamConnectionTest.php
+++ b/tests/Predis/Connection/CompositeStreamConnectionTest.php
@@ -47,9 +47,9 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
         $connection
             ->method('executeCommand')
             ->with($cmdSelect)
-            ->will($this->returnValue(
+            ->willReturn(
                 new ErrorResponse('ERR invalid DB index')
-            ));
+            );
 
         $connection->method('createResource');
 

--- a/tests/Predis/Connection/CompositeStreamConnectionTest.php
+++ b/tests/Predis/Connection/CompositeStreamConnectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Predis\Connection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command\RawCommand;
 use Predis\Response\Error as ErrorResponse;
 
@@ -19,21 +20,28 @@ use Predis\Response\Error as ErrorResponse;
  */
 class CompositeStreamConnectionTest extends PredisConnectionTestCase
 {
-    const CONNECTION_CLASS = 'Predis\Connection\CompositeStreamConnection';
+    /**
+     * @inheritDoc
+     */
+    protected function getConnectionClass(): string
+    {
+        return 'Predis\Connection\CompositeStreamConnection';
+    }
 
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInitializationCommandFailure()
+    public function testThrowsExceptionOnInitializationCommandFailure(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("`SELECT` failed: ERR invalid DB index [tcp://127.0.0.1:6379]");
 
         $cmdSelect = RawCommand::create('SELECT', '1000');
 
+        /** @var NodeConnectionInterface|MockObject */
         $connection = $this
-            ->getMockBuilder(static::CONNECTION_CLASS)
-            ->setMethods(array('executeCommand', 'createResource'))
+            ->getMockBuilder($this->getConnectionClass())
+            ->onlyMethods(array('executeCommand', 'createResource'))
             ->setConstructorArgs(array(new Parameters()))
             ->getMock();
         $connection
@@ -56,8 +64,9 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
     /**
      * @group connected
      */
-    public function testReadsMultibulkResponsesAsIterators()
+    public function testReadsMultibulkResponsesAsIterators(): void
     {
+        /** @var CompositeConnectionInterface */
         $connection = $this->createConnection(true);
         $commands = $this->getCommandFactory();
 
@@ -74,7 +83,7 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithFalseLikeValues()
+    public function testPersistentParameterWithFalseLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 0));
         $this->assertNonPersistentConnection($connection1);
@@ -93,7 +102,7 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithTrueLikeValues()
+    public function testPersistentParameterWithTrueLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 1));
         $this->assertPersistentConnection($connection1);
@@ -114,7 +123,7 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeShareResource()
+    public function testPersistentConnectionsToSameNodeShareResource(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => true));
         $connection2 = $this->createConnectionWithParams(array('persistent' => true));
@@ -131,7 +140,7 @@ class CompositeStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID()
+    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 'conn1'));
         $connection2 = $this->createConnectionWithParams(array('persistent' => 'conn2'));

--- a/tests/Predis/Connection/ConnectionExceptionTest.php
+++ b/tests/Predis/Connection/ConnectionExceptionTest.php
@@ -23,8 +23,12 @@ class ConnectionExceptionTest extends CommunicationExceptionTest
     /**
      * {@inheritdoc}
      */
-    protected function getException(NodeConnectionInterface $connection, $message, $code = 0, \Exception $inner = null)
-    {
+    protected function getException(
+        NodeConnectionInterface $connection,
+        string $message,
+        int $code = 0,
+        \Exception $inner = null
+    ) {
         return new ConnectionException($connection, $message, $code, $inner);
     }
 }

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Connection;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Connection\Cluster\ClusterInterface;
 
 /**
  *
@@ -21,7 +23,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testImplementsCorrectInterface()
+    public function testImplementsCorrectInterface(): void
     {
         $factory = new Factory();
 
@@ -31,7 +33,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSettingDefaultParameters()
+    public function testSettingDefaultParameters(): void
     {
         $factory = new Factory();
 
@@ -49,7 +51,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateTcpConnection()
+    public function testCreateTcpConnection(): void
     {
         $factory = new Factory();
 
@@ -69,7 +71,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateSslConnection()
+    public function testCreateSslConnection(): void
     {
         $factory = new Factory();
 
@@ -89,7 +91,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateUnixConnection()
+    public function testCreateUnixConnection(): void
     {
         $factory = new Factory();
 
@@ -103,7 +105,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithParametersInstanceAndDefaultsDoesNotAlterOriginalParameters()
+    public function testCreateConnectionWithParametersInstanceAndDefaultsDoesNotAlterOriginalParameters(): void
     {
         $factory = new Factory();
 
@@ -136,7 +138,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithNullParameters()
+    public function testCreateConnectionWithNullParameters(): void
     {
         $factory = new Factory();
         $connection = $factory->create(null);
@@ -152,7 +154,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithNullParametersAndDefaults()
+    public function testCreateConnectionWithNullParametersAndDefaults(): void
     {
         $factory = new Factory();
 
@@ -177,7 +179,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithArrayParameters()
+    public function testCreateConnectionWithArrayParameters(): void
     {
         $factory = new Factory();
         $connection = $factory->create(array('scheme' => 'tcp', 'custom' => 'foobar'));
@@ -193,7 +195,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithArrayParametersAndDefaults()
+    public function testCreateConnectionWithArrayParametersAndDefaults(): void
     {
         $factory = new Factory();
 
@@ -224,7 +226,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithStringURI()
+    public function testCreateConnectionWithStringURI(): void
     {
         $factory = new Factory();
         $connection = $factory->create('tcp://127.0.0.1?custom=foobar');
@@ -240,7 +242,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithStrinURIAndDefaults()
+    public function testCreateConnectionWithStrinURIAndDefaults(): void
     {
         $factory = new Factory();
 
@@ -266,7 +268,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithoutInitializationCommands()
+    public function testCreateConnectionWithoutInitializationCommands(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -289,7 +291,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateConnectionWithInitializationCommands()
+    public function testCreateConnectionWithInitializationCommands(): void
     {
         $parameters = new Parameters(array(
             'database' => '0',
@@ -426,7 +428,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateUndefinedConnection()
+    public function testCreateUndefinedConnection(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Unknown connection scheme: 'unknown'");
@@ -438,7 +440,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineConnectionWithFQN()
+    public function testDefineConnectionWithFQN(): void
     {
         list(, $connectionClass) = $this->getMockConnectionClass();
 
@@ -454,7 +456,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineConnectionWithCallable()
+    public function testDefineConnectionWithCallable(): void
     {
         list(, $connectionClass) = $this->getMockConnectionClass();
 
@@ -466,7 +468,7 @@ class FactoryTest extends PredisTestCase
         };
 
         $initializerMock = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $initializerMock
             ->expects($this->exactly(2))
@@ -487,7 +489,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineConnectionWithInvalidArgument()
+    public function testDefineConnectionWithInvalidArgument(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -498,7 +500,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUndefineDefinedConnection()
+    public function testUndefineDefinedConnection(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Unknown connection scheme: 'tcp'");
@@ -511,7 +513,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUndefineUndefinedConnection()
+    public function testUndefineUndefinedConnection(): void
     {
         $factory = new Factory();
         $factory->undefine('unknown');
@@ -523,7 +525,7 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefineAndUndefineConnection()
+    public function testDefineAndUndefineConnection(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Unknown connection scheme: 'test'");
@@ -542,18 +544,20 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAggregateConnectionSkipCreationOnConnectionInstance()
+    public function testAggregateConnectionSkipCreationOnConnectionInstance(): void
     {
         list(, $connectionClass) = $this->getMockConnectionClass();
 
+        /** @var ClusterInterface|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
         $cluster
             ->expects($this->exactly(2))
             ->method('add')
             ->with($this->isInstanceOf('Predis\Connection\NodeConnectionInterface'));
 
+        /** @var Factory|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\Factory')
-            ->setMethods(array('create'))
+            ->onlyMethods(array('create'))
             ->getMock();
         $factory
             ->expects($this->never())
@@ -565,18 +569,20 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAggregateConnectionWithMixedParameters()
+    public function testAggregateConnectionWithMixedParameters(): void
     {
         list(, $connectionClass) = $this->getMockConnectionClass();
 
+        /** @var ClusterInterface|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
         $cluster
             ->expects($this->exactly(4))
             ->method('add')
             ->with($this->isInstanceOf('Predis\Connection\NodeConnectionInterface'));
 
+        /** @var Factory|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\Factory')
-            ->setMethods(array('create'))
+            ->onlyMethods(array('create'))
             ->getMock();
         $factory
             ->expects($this->exactly(3))
@@ -591,15 +597,17 @@ class FactoryTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAggregateConnectionWithEmptyListOfParameters()
+    public function testAggregateConnectionWithEmptyListOfParameters(): void
     {
+        /** @var ClusterInterface|MockObject */
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
         $cluster
             ->expects($this->never())
             ->method('add');
 
+        /** @var Factory|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\Factory')
-            ->setMethods(array('create'))
+            ->onlyMethods(array('create'))
             ->getMock();
         $factory
             ->expects($this->never())
@@ -615,7 +623,7 @@ class FactoryTest extends PredisTestCase
     /**
      * Returns a mocked Predis\Connection\NodeConnectionInterface.
      *
-     * @return array Mock instance and class name
+     * @return array Mock instance of a single node connection and its FQCN
      */
     protected function getMockConnectionClass()
     {

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -304,15 +304,14 @@ class FactoryTest extends PredisTestCase
             ->method('getParameters')
             ->willReturn($parameters);
         $connection
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('addConnectCommand')
-            ->with($this->isRedisCommand('AUTH', array('foobar')));
-        $connection
-            ->expects($this->at(2))
-            ->method('addConnectCommand')
-            ->with($this->isRedisCommand('SELECT', array(0)));
+            ->withConsecutive(
+                array($this->isRedisCommand('AUTH', array('foobar'))),
+                array($this->isRedisCommand('SELECT', array('0')))
+            );
 
-            $factory = new Factory();
+        $factory = new Factory();
 
         // TODO: using reflection to make a protected method accessible :facepalm:
         $reflection = new \ReflectionObject($factory);

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -302,7 +302,7 @@ class FactoryTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('getParameters')
-            ->will($this->returnValue($parameters));
+            ->willReturn($parameters);
         $connection
             ->expects($this->at(1))
             ->method('addConnectCommand')
@@ -474,7 +474,7 @@ class FactoryTest extends PredisTestCase
             ->expects($this->exactly(2))
             ->method('__invoke')
             ->with($parameters, $factory)
-            ->will($this->returnCallback($initializer));
+            ->willReturnCallback($initializer);
 
         $factory->define($parameters->scheme, $initializerMock);
 
@@ -587,9 +587,9 @@ class FactoryTest extends PredisTestCase
         $factory
             ->expects($this->exactly(3))
             ->method('create')
-            ->will($this->returnCallback(function () use ($connectionClass) {
+            ->willReturnCallback(function () use ($connectionClass) {
                 return new $connectionClass();
-            }));
+            });
 
         $factory->aggregate($cluster, array(null, 'tcp://127.0.0.1', array('scheme' => 'tcp'), new $connectionClass()));
     }

--- a/tests/Predis/Connection/ParametersTest.php
+++ b/tests/Predis/Connection/ParametersTest.php
@@ -14,15 +14,14 @@ namespace Predis\Connection;
 use PredisTestCase;
 
 /**
- * @todo Parameters::define();
- * @todo Parameters::undefine();
+ *
  */
 class ParametersTest extends PredisTestCase
 {
     /**
      * @group disconnected
      */
-    public function testDefaultValues()
+    public function testDefaultValues(): void
     {
         $defaults = $this->getDefaultParametersArray();
         $parameters = new Parameters();
@@ -35,7 +34,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsSet()
+    public function testIsSet(): void
     {
         $parameters = new Parameters();
 
@@ -43,7 +42,7 @@ class ParametersTest extends PredisTestCase
         $this->assertFalse(isset($parameters->notset), 'Parameter `notset` was expected to be not set');
     }
 
-    public function sharedTestsWithArrayParameters(Parameters $parameters)
+    public function sharedTestsWithArrayParameters(Parameters $parameters): void
     {
         $this->assertTrue(isset($parameters->scheme), 'Parameter `scheme` was expected to be set');
         $this->assertSame('tcp', $parameters->scheme, 'Parameter `scheme` was expected to be set');
@@ -67,7 +66,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructWithArrayParameters()
+    public function testConstructWithArrayParameters(): void
     {
         $parameters = new Parameters(array(
             'port' => 7000,
@@ -82,7 +81,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateWithArrayParameters()
+    public function testCreateWithArrayParameters(): void
     {
         $parameters = new Parameters(array(
             'port' => 7000,
@@ -97,7 +96,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCreateWithUriString()
+    public function testCreateWithUriString(): void
     {
         $overrides = array(
             'port' => 7000,
@@ -117,7 +116,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $additional = array('port' => 7000, 'custom' => 'foobar');
         $parameters = new Parameters($additional);
@@ -128,7 +127,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $parameters = new Parameters(array('port' => 7000, 'custom' => 'foobar'));
         $unserialized = unserialize(serialize($parameters));
@@ -146,7 +145,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURI()
+    public function testParsingURI(): void
     {
         $uri = 'tcp://10.10.10.10:6400?timeout=0.5&persistent=1&database=5&password=secret';
 
@@ -166,7 +165,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithRedisScheme()
+    public function testParsingURIWithRedisScheme(): void
     {
         $uri = 'redis://:secret@10.10.10.10:6400/5?timeout=0.5&persistent=1';
 
@@ -193,7 +192,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithRedisSchemeMustPreserveRemainderOfPath()
+    public function testParsingURIWithRedisSchemeMustPreserveRemainderOfPath(): void
     {
         $uri = 'redis://10.10.10.10/5/rest/of/path';
 
@@ -212,7 +211,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRedisSchemeOverridesPasswordAndDatabaseInQueryString()
+    public function testRedisSchemeOverridesPasswordAndDatabaseInQueryString(): void
     {
         $parameters = Parameters::parse('redis://:secret@10.10.10.10/5?password=ignored&database=4');
 
@@ -223,7 +222,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithUnixDomainSocket()
+    public function testParsingURIWithUnixDomainSocket(): void
     {
         $uri = 'unix:///tmp/redis.sock?timeout=0.5&persistent=1';
 
@@ -240,7 +239,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithUnixDomainSocketOldWay()
+    public function testParsingURIWithUnixDomainSocketOldWay(): void
     {
         $uri = 'unix:/tmp/redis.sock?timeout=0.5&persistent=1';
 
@@ -257,7 +256,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithIncompletePairInQueryString()
+    public function testParsingURIWithIncompletePairInQueryString(): void
     {
         $uri = 'tcp://10.10.10.10?persistent=1&foo=&bar';
 
@@ -275,7 +274,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithMoreThanOneEqualSignInQueryStringPairValue()
+    public function testParsingURIWithMoreThanOneEqualSignInQueryStringPairValue(): void
     {
         $uri = 'tcp://10.10.10.10?foobar=a=b=c&persistent=1';
 
@@ -292,7 +291,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWhenQueryStringHasBracketsInFieldnames()
+    public function testParsingURIWhenQueryStringHasBracketsInFieldnames(): void
     {
         $uri = 'tcp://10.10.10.10?persistent=1&metavars[]=foo&metavars[]=hoge';
 
@@ -309,7 +308,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIWithEmbeddedIPV6AddressShouldStripBracketsFromHost()
+    public function testParsingURIWithEmbeddedIPV6AddressShouldStripBracketsFromHost(): void
     {
         $expected = array('scheme' => 'tcp', 'host' => '::1', 'port' => 7000);
         $this->assertSame($expected, Parameters::parse('tcp://[::1]:7000'));
@@ -321,7 +320,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParsingURIThrowOnInvalidURI()
+    public function testParsingURIThrowOnInvalidURI(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Invalid parameters URI: tcp://invalid:uri");
@@ -332,7 +331,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToStringWithDefaultParameters()
+    public function testToStringWithDefaultParameters(): void
     {
         $parameters = new Parameters();
 
@@ -342,7 +341,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToStringWithUnixScheme()
+    public function testToStringWithUnixScheme(): void
     {
         $uri = 'unix:/path/to/redis.sock';
         $parameters = Parameters::create("$uri?foo=bar");
@@ -353,7 +352,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToStringWithIPv4()
+    public function testToStringWithIPv4(): void
     {
         $uri = 'tcp://127.0.0.1:6379';
         $parameters = Parameters::create("$uri?foo=bar");
@@ -364,7 +363,7 @@ class ParametersTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToStringWithIPv6()
+    public function testToStringWithIPv6(): void
     {
         $uri = 'tcp://[::1]:6379';
         $parameters = Parameters::create("$uri?foo=bar");
@@ -381,7 +380,7 @@ class ParametersTest extends PredisTestCase
      *
      * @return array Default connection parameters.
      */
-    protected function getDefaultParametersArray()
+    protected function getDefaultParametersArray(): array
     {
         return array(
             'scheme' => 'tcp',
@@ -397,7 +396,7 @@ class ParametersTest extends PredisTestCase
      *
      * @return string URI string.
      */
-    protected function getParametersString(array $parameters)
+    protected function getParametersString(array $parameters): string
     {
         $defaults = $this->getDefaultParametersArray();
 

--- a/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
@@ -74,9 +74,9 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
         $connection
             ->method('executeCommand')
             ->with($cmdSelect)
-            ->will($this->returnValue(
+            ->willReturn(
                 new ErrorResponse('ERR invalid DB index')
-            ));
+            );
 
         $connection->method('createResource');
 

--- a/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisSocketConnectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Predis\Connection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command\RawCommand;
 use Predis\Response\Error as ErrorResponse;
 
@@ -20,12 +21,18 @@ use Predis\Response\Error as ErrorResponse;
  */
 class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
 {
-    const CONNECTION_CLASS = 'Predis\Connection\PhpiredisSocketConnection';
+    /**
+     * @inheritDoc
+     */
+    protected function getConnectionClass(): string
+    {
+        return 'Predis\Connection\PhpiredisSocketConnection';
+    }
 
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeTls()
+    public function testSupportsSchemeTls(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Invalid scheme: 'tls'");
@@ -38,7 +45,7 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeRediss()
+    public function testSupportsSchemeRediss(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Invalid scheme: 'rediss'");
@@ -51,16 +58,17 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInitializationCommandFailure()
+    public function testThrowsExceptionOnInitializationCommandFailure(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("`SELECT` failed: ERR invalid DB index [tcp://127.0.0.1:6379]");
 
         $cmdSelect = RawCommand::create('SELECT', '1000');
 
+        /** @var NodeConnectionInterface|MockObject */
         $connection = $this
-            ->getMockBuilder(static::CONNECTION_CLASS)
-            ->setMethods(array('executeCommand', 'createResource'))
+            ->getMockBuilder($this->getConnectionClass())
+            ->onlyMethods(array('executeCommand', 'createResource'))
             ->setConstructorArgs(array(new Parameters()))
             ->getMock();
         $connection
@@ -83,7 +91,7 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
     /**
      * @group connected
      */
-    public function testThrowsExceptionOnUnresolvableHostname()
+    public function testThrowsExceptionOnUnresolvableHostname(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("Cannot resolve the address of 'bogus.tld'");
@@ -96,7 +104,7 @@ class PhpiredisSocketConnectionTest extends PredisConnectionTestCase
      * @medium
      * @group connected
      */
-    public function testThrowsExceptionOnProtocolDesynchronizationErrors()
+    public function testThrowsExceptionOnProtocolDesynchronizationErrors(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
 

--- a/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Predis\Connection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command\RawCommand;
 use Predis\Response\Error as ErrorResponse;
 
@@ -20,12 +21,18 @@ use Predis\Response\Error as ErrorResponse;
  */
 class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
 {
-    const CONNECTION_CLASS = 'Predis\Connection\PhpiredisStreamConnection';
+    /**
+     * @inheritDoc
+     */
+    public function getConnectionClass(): string
+    {
+        return 'Predis\Connection\PhpiredisStreamConnection';
+    }
 
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeTls()
+    public function testSupportsSchemeTls(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('SSL encryption is not supported by this connection backend');
@@ -38,7 +45,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeRediss()
+    public function testSupportsSchemeRediss(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('SSL encryption is not supported by this connection backend');
@@ -51,16 +58,17 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInitializationCommandFailure()
+    public function testThrowsExceptionOnInitializationCommandFailure(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("`SELECT` failed: ERR invalid DB index [tcp://127.0.0.1:6379]");
 
         $cmdSelect = RawCommand::create('SELECT', '1000');
 
+        /** @var NodeConnectionInterface|MockObject */
         $connection = $this
-            ->getMockBuilder(static::CONNECTION_CLASS)
-            ->setMethods(array('executeCommand', 'createResource'))
+            ->getMockBuilder($this->getConnectionClass())
+            ->onlyMethods(array('executeCommand', 'createResource'))
             ->setConstructorArgs(array(new Parameters()))
             ->getMock();
         $connection
@@ -85,7 +93,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @group slow
      * @requires PHP 5.4
      */
-    public function testThrowsExceptionOnReadWriteTimeout()
+    public function testThrowsExceptionOnReadWriteTimeout(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
 
@@ -102,7 +110,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @medium
      * @group connected
      */
-    public function testThrowsExceptionOnProtocolDesynchronizationErrors()
+    public function testThrowsExceptionOnProtocolDesynchronizationErrors(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
 
@@ -119,7 +127,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithFalseLikeValues()
+    public function testPersistentParameterWithFalseLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 0));
         $this->assertNonPersistentConnection($connection1);
@@ -138,7 +146,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithTrueLikeValues()
+    public function testPersistentParameterWithTrueLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 1));
         $this->assertPersistentConnection($connection1);
@@ -159,7 +167,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeShareResource()
+    public function testPersistentConnectionsToSameNodeShareResource(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => true));
         $connection2 = $this->createConnectionWithParams(array('persistent' => true));
@@ -176,7 +184,7 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID()
+    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 'conn1'));
         $connection2 = $this->createConnectionWithParams(array('persistent' => 'conn2'));

--- a/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
+++ b/tests/Predis/Connection/PhpiredisStreamConnectionTest.php
@@ -74,9 +74,9 @@ class PhpiredisStreamConnectionTest extends PredisConnectionTestCase
         $connection
             ->method('executeCommand')
             ->with($cmdSelect)
-            ->will($this->returnValue(
+            ->willReturn(
                 new ErrorResponse('ERR invalid DB index')
-            ));
+            );
 
         $connection->method('createResource');
 

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -1019,8 +1019,9 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $slave1
             ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with(
-                $this->logicalOr($cmdEval, $cmdEvalSha)
+            ->withConsecutive(
+                array($this->isRedisCommand($cmdEval)),
+                array($this->isRedisCommand($cmdEvalSha))
             );
 
         $replication = new MasterSlaveReplication();
@@ -1063,8 +1064,10 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $master
             ->expects($this->once())
             ->method('executeCommand')
-            ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->with(
+                $this->isRedisCommand($cmdInfo)
+            )
+            ->willReturn('
 # Replication
 role:master
 connected_slaves:2
@@ -1076,7 +1079,7 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:2
 repl_backlog_histlen:12978
 '
-            ));
+            );
 
         $replication = new MasterSlaveReplication();
         $replication->setConnectionFactory($connFactory);
@@ -1107,32 +1110,41 @@ repl_backlog_histlen:12978
         /** @var Connection\FactoryInterface|MockObject */
         $connFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connFactory
-            ->expects($this->at(0))
+            ->expects($this->exactly(3))
             ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6381',
-                'role' => 'master',
-            ))
-            ->willReturn($master);
-        $connFactory
-            ->expects($this->at(1))
-            ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6382',
-                'role' => 'slave',
-            ))
-            ->willReturn($slave1);
-        $connFactory
-            ->expects($this->at(2))
-            ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6383',
-                'role' => 'slave',
-            ))
-            ->willReturn($slave2);
+            ->withConsecutive(
+                # Connection to master node
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6381',
+                        'role' => 'master',
+                    )
+                ),
+
+                # Connection to first slave
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6382',
+                        'role' => 'slave',
+                    )
+                ),
+
+                # Connection to second slave
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6383',
+                        'role' => 'slave',
+                    )
+                )
+            )
+            ->willReturnOnConsecutiveCalls(
+                $master,
+                $slave1,
+                $slave2
+            );
 
         $slave1
             ->expects($this->once())
@@ -1206,37 +1218,48 @@ repl_backlog_histlen:12978
         /** @var Connection\FactoryInterface|MockObject */
         $connFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connFactory
-            ->expects($this->at(0))
+            ->expects($this->exactly(3))
             ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6381',
-                'role' => 'master',
-            ))
-            ->willReturn($master);
-        $connFactory
-            ->expects($this->at(1))
-            ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6382',
-                'role' => 'slave',
-            ))
-            ->willReturn($slave1);
-        $connFactory
-            ->expects($this->at(2))
-            ->method('create')
-            ->with(array(
-                'host' => '127.0.0.1',
-                'port' => '6383',
-                'role' => 'slave',
-            ))
-            ->willReturn($slave2);
+            ->withConsecutive(
+                # Connection to master node
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6381',
+                        'role' => 'master',
+                    )
+                ),
+
+                # Connection to first slave
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6382',
+                        'role' => 'slave',
+                    )
+                ),
+
+                # Connection to second slave
+                array(
+                    array(
+                        'host' => '127.0.0.1',
+                        'port' => '6383',
+                        'role' => 'slave',
+                    )
+                )
+            )
+            ->willReturnOnConsecutiveCalls(
+                $master,
+                $slave1,
+                $slave2
+            );
 
         $masterKO
             ->expects($this->once())
             ->method('executeCommand')
-            ->with($cmdInfo)
+            ->with(
+                $this->isRedisCommand($cmdInfo)
+            )
             ->willThrowException(
                 new Connection\ConnectionException($masterKO)
             );
@@ -1268,8 +1291,10 @@ repl_backlog_histlen:0
         $master
             ->expects($this->once())
             ->method('executeCommand')
-            ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->with(
+                $this->isRedisCommand($cmdInfo)
+            )
+            ->willReturn('
 # Replication
 role:master
 connected_slaves:2
@@ -1281,7 +1306,7 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:2
 repl_backlog_histlen:12978
 '
-            ));
+            );
 
         $replication = new MasterSlaveReplication();
         $replication->setConnectionFactory($connFactory);

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -11,11 +11,12 @@
 
 namespace Predis\Connection\Replication;
 
+use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command;
 use Predis\Connection;
 use Predis\Replication\ReplicationStrategy;
 use Predis\Response;
-use PredisTestCase;
 
 /**
  *
@@ -25,7 +26,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionsToReplication()
+    public function testAddingConnectionsToReplication(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -47,7 +48,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectionsWithoutRoleParameterDefaultsToSlaveRole()
+    public function testAddingConnectionsWithoutRoleParameterDefaultsToSlaveRole(): void
     {
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380');
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6381');
@@ -62,7 +63,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRemovingConnectionsFromReplication()
+    public function testRemovingConnectionsFromReplication(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -82,7 +83,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByIdOnEmptyReplication()
+    public function testGetConnectionByIdOnEmptyReplication(): void
     {
         $replication = new MasterSlaveReplication();
 
@@ -92,7 +93,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByAlias()
+    public function testGetConnectionByAlias(): void
     {
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6379?alias=aliased');
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6380');
@@ -109,7 +110,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByAliasOnEmptyReplication()
+    public function testGetConnectionByAliasOnEmptyReplication(): void
     {
         $replication = new MasterSlaveReplication();
 
@@ -119,7 +120,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByRole()
+    public function testGetConnectionByRole(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -135,7 +136,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByRoleOnEmptyReplication()
+    public function testGetConnectionByRoleOnEmptyReplication(): void
     {
         $replication = new MasterSlaveReplication();
 
@@ -146,7 +147,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByRoleUnknown()
+    public function testGetConnectionByRoleUnknown(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -161,7 +162,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnEmptyReplication()
+    public function testThrowsExceptionOnEmptyReplication(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No available connection for replication');
@@ -173,7 +174,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectsToOneOfSlaves()
+    public function testConnectsToOneOfSlaves(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -195,7 +196,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectsToMasterOnMissingSlaves()
+    public function testConnectsToMasterOnMissingSlaves(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
 
@@ -209,7 +210,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen()
+    public function testIsConnectedReturnsTrueIfAtLeastOneConnectionIsOpen(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -234,7 +235,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed()
+    public function testIsConnectedReturnsFalseIfAllConnectionsAreClosed(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -263,7 +264,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDisconnectForcesCurrentConnectionToDisconnect()
+    public function testDisconnectForcesCurrentConnectionToDisconnect(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master
@@ -285,7 +286,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSwitchConnection()
+    public function testCanSwitchConnection(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -306,7 +307,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsErrorWhenSwitchingToConnectionNotInPool()
+    public function testThrowsErrorWhenSwitchingToConnectionNotInPool(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid connection or connection not found.');
@@ -324,7 +325,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSwitchConnectionByInstance()
+    public function testCanSwitchConnectionByInstance(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -345,7 +346,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsErrorWhenSwitchingToUnknownConnectionByInstance()
+    public function testThrowsErrorWhenSwitchingToUnknownConnectionByInstance(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid connection or connection not found.');
@@ -363,7 +364,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSwitchToMaster()
+    public function testCanSwitchToMaster(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -384,7 +385,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsErrorOnSwitchToMasterWithNoMasterDefined()
+    public function testThrowsErrorOnSwitchToMasterWithNoMasterDefined(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid connection or connection not found.');
@@ -403,7 +404,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
      *
      * @todo We should find a way to test that the slave is indeed randomly selected.
      */
-    public function testCanSwitchToRandomSlave()
+    public function testCanSwitchToRandomSlave(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
@@ -422,7 +423,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsErrorOnSwitchToRandomSlaveWithNoSlavesDefined()
+    public function testThrowsErrorOnSwitchToRandomSlaveWithNoSlavesDefined(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid connection or connection not found.');
@@ -439,7 +440,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsesSlavesOnReadOnlyCommands()
+    public function testUsesSlavesOnReadOnlyCommands(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -461,7 +462,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsesMasterOnWriteRequests()
+    public function testUsesMasterOnWriteRequests(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -483,7 +484,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsesMasterOnReadRequestsWhenNoSlavesAvailable()
+    public function testUsesMasterOnReadRequestsWhenNoSlavesAvailable(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -503,7 +504,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSwitchesFromSlaveToMasterOnWriteRequests()
+    public function testSwitchesFromSlaveToMasterOnWriteRequests(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -528,7 +529,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWritesCommandToCorrectConnection()
+    public function testWritesCommandToCorrectConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('foo'));
@@ -557,7 +558,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsCommandFromCorrectConnection()
+    public function testReadsCommandFromCorrectConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('foo'));
@@ -587,7 +588,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecutesCommandOnCorrectConnection()
+    public function testExecutesCommandOnCorrectConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('foo'));
@@ -617,7 +618,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWatchTriggersSwitchToMasterConnection()
+    public function testWatchTriggersSwitchToMasterConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdWatch = $commands->create('watch', array('foo'));
@@ -644,7 +645,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMultiTriggersSwitchToMasterConnection()
+    public function testMultiTriggersSwitchToMasterConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdMulti = $commands->create('multi');
@@ -671,7 +672,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testEvalTriggersSwitchToMasterConnection()
+    public function testEvalTriggersSwitchToMasterConnection(): void
     {
         $commands = $this->getCommandFactory();
         $cmdEval = $commands->create('eval', array("return redis.call('info')"));
@@ -698,7 +699,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDiscardsUnreachableSlaveAndExecutesReadOnlyCommandOnNextSlave()
+    public function testDiscardsUnreachableSlaveAndExecutesReadOnlyCommandOnNextSlave(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('key'));
@@ -742,7 +743,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDiscardsUnreachableSlavesAndExecutesReadOnlyCommandOnMaster()
+    public function testDiscardsUnreachableSlavesAndExecutesReadOnlyCommandOnMaster(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('key'));
@@ -788,7 +789,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSucceedOnReadOnlyCommandAndNoConnectionSetAsMaster()
+    public function testSucceedOnReadOnlyCommandAndNoConnectionSetAsMaster(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExists = $commands->create('exists', array('key'));
@@ -812,7 +813,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFailsOnWriteCommandAndNoConnectionSetAsMaster()
+    public function testFailsOnWriteCommandAndNoConnectionSetAsMaster(): void
     {
         $this->expectException('Predis\Replication\MissingMasterException');
         $this->expectExceptionMessage('No master server available for replication');
@@ -835,7 +836,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDiscardsSlaveWhenRespondsLOADINGAndExecutesReadOnlyCommandOnNextSlave()
+    public function testDiscardsSlaveWhenRespondsLOADINGAndExecutesReadOnlyCommandOnNextSlave(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $master->expects($this->never())
@@ -881,7 +882,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFailsOnUnreachableMaster()
+    public function testFailsOnUnreachableMaster(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
 
@@ -913,7 +914,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnNonSupportedCommand()
+    public function testThrowsExceptionOnNonSupportedCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The command 'INFO' is not allowed in replication mode.");
@@ -931,7 +932,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanOverrideReadOnlyFlagForCommands()
+    public function testCanOverrideReadOnlyFlagForCommands(): void
     {
         $commands = $this->getCommandFactory();
         $cmdSet = $commands->create('set', array('foo', 'bar'));
@@ -964,7 +965,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAcceptsCallableToOverrideReadOnlyFlagForCommands()
+    public function testAcceptsCallableToOverrideReadOnlyFlagForCommands(): void
     {
         $commands = $this->getCommandFactory();
         $cmdExistsFoo = $commands->create('exists', array('foo'));
@@ -1002,7 +1003,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSetReadOnlyFlagForEvalScripts()
+    public function testCanSetReadOnlyFlagForEvalScripts(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -1038,7 +1039,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDiscoveryRequiresConnectionFactory()
+    public function testDiscoveryRequiresConnectionFactory(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('Discovery requires a connection factory');
@@ -1053,7 +1054,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDiscoversReplicationConfigurationFromMaster()
+    public function testDiscoversReplicationConfigurationFromMaster(): void
     {
         $connFactory = new Connection\Factory();
         $cmdInfo = Command\RawCommand::create('INFO', 'REPLICATION');
@@ -1095,7 +1096,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testDiscoversReplicationConfigurationFromSlave()
+    public function testDiscoversReplicationConfigurationFromSlave(): void
     {
         $cmdInfo = $command = Command\RawCommand::create('INFO', 'REPLICATION');
 
@@ -1103,7 +1104,8 @@ repl_backlog_histlen:12978
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6383?role=slave');
 
-        $connFactory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $connFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connFactory
             ->expects($this->at(0))
             ->method('create')
@@ -1192,7 +1194,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testDiscoversReplicationConfigurationFromSlaveIfMasterFails()
+    public function testDiscoversReplicationConfigurationFromSlaveIfMasterFails(): void
     {
         $cmdInfo = $command = Command\RawCommand::create('INFO', 'REPLICATION');
 
@@ -1201,7 +1203,8 @@ repl_backlog_histlen:12978
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6383?role=slave');
 
-        $connFactory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $connFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connFactory
             ->expects($this->at(0))
             ->method('create')
@@ -1299,7 +1302,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testAutomaticDiscoveryRequiresConnectionFactory()
+    public function testAutomaticDiscoveryRequiresConnectionFactory(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('Automatic discovery requires a connection factory');
@@ -1316,7 +1319,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testAutomaticDiscoveryOnUnreachableServer()
+    public function testAutomaticDiscoveryOnUnreachableServer(): void
     {
         $cmdInfo = $command = Command\RawCommand::create('INFO', 'REPLICATION');
         $cmdExists = $command = Command\RawCommand::create('EXISTS', 'key');
@@ -1325,7 +1328,8 @@ repl_backlog_histlen:12978
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
 
-        $connFactory = $this->getMockBuilder('Predis\Connection\Factory')->getMock();
+        /** @var Connection\FactoryInterface|MockObject */
+        $connFactory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $connFactory
             ->expects($this->once())
             ->method('create')
@@ -1380,7 +1384,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testExposesReplicationStrategy()
+    public function testExposesReplicationStrategy(): void
     {
         $replication = new MasterSlaveReplication();
         $this->assertInstanceOf('Predis\Replication\ReplicationStrategy', $replication->getReplicationStrategy());
@@ -1394,7 +1398,7 @@ repl_backlog_histlen:12978
     /**
      * @group disconnected
      */
-    public function testCanBeSerialized()
+    public function testCanBeSerialized(): void
     {
         $master = $this->getMockConnection('tcp://127.0.0.1:6379?role=master');
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');

--- a/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
+++ b/tests/Predis/Connection/Replication/MasterSlaveReplicationTest.php
@@ -216,13 +216,13 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $master
             ->expects($this->never())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $slave = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
         $slave
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $replication = new MasterSlaveReplication();
         $replication->add($master);
@@ -241,13 +241,13 @@ class MasterSlaveReplicationTest extends PredisTestCase
         $master
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $slave = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
         $slave
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $replication = new MasterSlaveReplication();
         $replication->add($master);
@@ -714,16 +714,16 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($slave1)
-            ));
+            );
 
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6381?role=slave&alias=slave2');
         $slave2
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $replication = new MasterSlaveReplication();
 
@@ -753,23 +753,23 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
         $slave1
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->throwException(new Connection\ConnectionException($slave1)));
+            ->willThrowException(new Connection\ConnectionException($slave1));
 
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6381?role=slave');
         $slave2
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($slave2)
-            ));
+            );
 
         $replication = new MasterSlaveReplication();
 
@@ -799,7 +799,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $replication = new MasterSlaveReplication();
 
@@ -849,9 +849,9 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'EXISTS', array('key')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 new Response\Error('LOADING')
-            ));
+            );
 
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6381?role=slave');
         $slave2
@@ -860,7 +860,7 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'EXISTS', array('key')
             ))
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $replication = new MasterSlaveReplication();
 
@@ -894,9 +894,9 @@ class MasterSlaveReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdSet)
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($master)
-            ));
+            );
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6380?role=slave');
         $slave1
@@ -1114,7 +1114,7 @@ repl_backlog_histlen:12978
                 'port' => '6381',
                 'role' => 'master',
             ))
-            ->will($this->returnValue($master));
+            ->willReturn($master);
         $connFactory
             ->expects($this->at(1))
             ->method('create')
@@ -1123,7 +1123,7 @@ repl_backlog_histlen:12978
                 'port' => '6382',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave1));
+            ->willReturn($slave1);
         $connFactory
             ->expects($this->at(2))
             ->method('create')
@@ -1132,13 +1132,13 @@ repl_backlog_histlen:12978
                 'port' => '6383',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave2));
+            ->willReturn($slave2);
 
         $slave1
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->willReturn('
 # Replication
 role:slave
 master_host:127.0.0.1
@@ -1156,13 +1156,13 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:0
 repl_backlog_histlen:0
 '
-            ));
+            );
 
         $master
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->willReturn('
 # Replication
 role:master
 connected_slaves:2
@@ -1174,7 +1174,7 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:2
 repl_backlog_histlen:12978
 '
-            ));
+            );
 
         $replication = new MasterSlaveReplication();
         $replication->setConnectionFactory($connFactory);
@@ -1213,7 +1213,7 @@ repl_backlog_histlen:12978
                 'port' => '6381',
                 'role' => 'master',
             ))
-            ->will($this->returnValue($master));
+            ->willReturn($master);
         $connFactory
             ->expects($this->at(1))
             ->method('create')
@@ -1222,7 +1222,7 @@ repl_backlog_histlen:12978
                 'port' => '6382',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave1));
+            ->willReturn($slave1);
         $connFactory
             ->expects($this->at(2))
             ->method('create')
@@ -1231,21 +1231,21 @@ repl_backlog_histlen:12978
                 'port' => '6383',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave2));
+            ->willReturn($slave2);
 
         $masterKO
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdInfo)
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($masterKO)
-            ));
+            );
 
         $slave1
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->willReturn('
 # Replication
 role:slave
 master_host:127.0.0.1
@@ -1263,7 +1263,7 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:0
 repl_backlog_histlen:0
 '
-            ));
+            );
 
         $master
             ->expects($this->once())
@@ -1338,27 +1338,27 @@ repl_backlog_histlen:12978
                 'port' => '6382',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave1));
+            ->willReturn($slave1);
 
         $slaveKO
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($slaveKO)
-            ));
+            );
 
         $slave1
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdExists)
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $master
             ->expects($this->once())
             ->method('executeCommand')
             ->with($cmdInfo)
-            ->will($this->returnValue('
+            ->willReturn('
 # Replication
 role:master
 connected_slaves:2
@@ -1369,7 +1369,7 @@ repl_backlog_size:1048576
 repl_backlog_first_byte_offset:2
 repl_backlog_histlen:12978
 '
-            ));
+            );
 
         $replication = new MasterSlaveReplication();
         $replication->setConnectionFactory($connFactory);

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -466,12 +466,12 @@ class SentinelReplicationTest extends PredisTestCase
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SENTINEL', array('get-master-addr-by-name', 'svc')
-            ))
-            ->willReturn(
+            ->withConsecutive(
+                array($this->isRedisCommand('SENTINEL', array('get-master-addr-by-name', 'svc')))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array('127.0.0.1', '6381')
             );
 
@@ -511,12 +511,12 @@ class SentinelReplicationTest extends PredisTestCase
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SENTINEL', array('slaves', 'svc')
-            ))
-            ->willReturn(
+            ->withConsecutive(
+                array($this->isRedisCommand('SENTINEL', array('slaves', 'svc')))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(
                     array(
                         'name', '127.0.0.1:6382',
@@ -670,21 +670,14 @@ class SentinelReplicationTest extends PredisTestCase
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SENTINEL', array('slaves', 'svc')
-            ))
-            ->willReturn(
-                array()
-            );
-        $sentinel1
-            ->expects($this->at(1))
-            ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SENTINEL', array('get-master-addr-by-name', 'svc')
-            ))
-            ->willReturn(
+            ->withConsecutive(
+                array($this->isRedisCommand('SENTINEL', array('slaves', 'svc'))),
+                array($this->isRedisCommand('SENTINEL', array('get-master-addr-by-name', 'svc')))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array(),
                 array('127.0.0.1', '6381')
             );
 
@@ -912,12 +905,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'master', 3129659, array(array('127.0.0.1', 6382, 3129242)),
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('master', 3129659, array(array('127.0.0.1', 6382, 3129242)))
+            );
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
 
@@ -950,12 +945,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true);
         $slave1
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('slave', '127.0.0.1', 9000, 'connected', 3167038)
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -984,25 +981,29 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false, true);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'master', 3129659, array(array('127.0.0.1', 6382, 3129242)),
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('master', 3129659, array(array('127.0.0.1', 6382, 3129242)))
+            );
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave1
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('isConnected')
             ->willReturnOnConsecutiveCalls(false);
         $slave1
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('slave', '127.0.0.1', 9000, 'connected', 3167038)
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1038,12 +1039,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(false);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('slave', '127.0.0.1', 9000, 'connected', 3167038)
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1061,10 +1064,10 @@ class SentinelReplicationTest extends PredisTestCase
         $sentinel1
             ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SENTINEL', array('slaves', 'svc')
-            ))
-            ->willReturn(
+            ->withConsecutive(
+                array($this->isRedisCommand('SENTINEL', array('slaves', 'svc')))
+            )
+            ->willReturnOnConsecutiveCalls(
                 array(
                     array(
                         'name', '127.0.0.1:6382',
@@ -1084,12 +1087,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(false);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand('ROLE'))
-            ->willReturn(array(
-                'master', '0', array(),
-            ));
+            ->withConsecutive(
+                array($this->isRedisCommand('ROLE'))
+            )
+            ->willReturnOnConsecutiveCalls(
+                array('master', '0', array())
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1117,12 +1122,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'SET', array('key', $cmdGetResponse)
-            ))
-           ->willReturn($cmdSetResponse);
+            ->withConsecutive(
+                array($this->isRedisCommand('SET', array('key', $cmdGetResponse)))
+            )
+           ->willReturnOnConsecutiveCalls(
+               $cmdSetResponse
+            );
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave1
@@ -1130,12 +1137,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $slave1
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'GET', array('key')
-            ))
-            ->willReturn($cmdGetResponse);
+            ->withConsecutive(
+                array($this->isRedisCommand('GET', array('key')))
+            )
+           ->willReturnOnConsecutiveCalls(
+                $cmdGetResponse
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1184,11 +1193,11 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $slave1
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'GET', array('key')
-            ))
+            ->with(
+                $this->isRedisCommand('GET', array('key'))
+            )
             ->willThrowException(
                 new Connection\ConnectionException($slave1, 'Unknown connection error [127.0.0.1:6382]')
             );
@@ -1199,12 +1208,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $slave2
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'GET', array('key')
-            ))
-            ->willReturn('value');
+            ->withConsecutive(
+                array($this->isRedisCommand('GET', array('key')))
+            )
+            ->willReturnOnConsecutiveCalls(
+                'value'
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1250,11 +1261,11 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $masterOld
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'DEL', array('key')
-            ))
+            ->with(
+                $this->isRedisCommand('DEL', array('key'))
+            )
             ->willThrowException(
                 new Connection\ConnectionException($masterOld, 'Unknown connection error [127.0.0.1:6381]')
             );
@@ -1265,12 +1276,14 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $masterNew
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'DEL', array('key')
-            ))
-            ->willReturn(1);
+            ->withConsecutive(
+                array($this->isRedisCommand('DEL', array('key')))
+            )
+            ->willReturnOnConsecutiveCalls(
+                1
+            );
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1316,11 +1329,11 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $masterOld
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'DEL', array('key')
-            ))
+            ->with(
+                $this->isRedisCommand('DEL', array('key'))
+            )
             ->willThrowException(
                 new Connection\ConnectionException($masterOld, 'Unknown connection error [127.0.0.1:6381]')
             );
@@ -1359,11 +1372,11 @@ class SentinelReplicationTest extends PredisTestCase
             ->method('isConnected')
             ->willReturn(true);
         $master
-            ->expects($this->at(3))
+            ->expects($this->once())
             ->method('executeCommand')
-            ->with($this->isRedisCommand(
-                'DEL', array('key')
-            ))
+            ->with(
+                $this->isRedisCommand('DEL', array('key'))
+            )
             ->willThrowException(
                 new Connection\ConnectionException($master, 'Unknown connection error [127.0.0.1:6381]')
             );

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -11,11 +11,12 @@
 
 namespace Predis\Connection\Replication;
 
+use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command;
 use Predis\Connection;
 use Predis\Replication;
 use Predis\Response;
-use PredisTestCase;
 
 /**
  *
@@ -25,7 +26,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetSentinelConnectionThrowsExceptionOnEmptySentinelsPool()
+    public function testMethodGetSentinelConnectionThrowsExceptionOnEmptySentinelsPool(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -37,7 +38,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParametersForSentinelConnectionShouldIgnoreDatabaseAndPassword()
+    public function testParametersForSentinelConnectionShouldIgnoreDatabaseAndPassword(): void
     {
         $replication = $this->getReplicationConnection('svc', array(
             'tcp://127.0.0.1:5381?role=sentinel&database=1&password=secret',
@@ -52,7 +53,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParametersForSentinelConnectionHaveDefaultTimeout()
+    public function testParametersForSentinelConnectionHaveDefaultTimeout(): void
     {
         $replication = $this->getReplicationConnection('svc', array(
             'tcp://127.0.0.1:5381?role=sentinel',
@@ -67,7 +68,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParametersForSentinelConnectionCanOverrideDefaultTimeout()
+    public function testParametersForSentinelConnectionCanOverrideDefaultTimeout(): void
     {
         $replication = $this->getReplicationConnection('svc', array(
             'tcp://127.0.0.1:5381?role=sentinel&timeout=1',
@@ -85,7 +86,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectionParametersInstanceForSentinelConnectionIsNotModified()
+    public function testConnectionParametersInstanceForSentinelConnectionIsNotModified(): void
     {
         $originalParameters = Connection\Parameters::create(
             'tcp://127.0.0.1:5381?role=sentinel&database=1&password=secret'
@@ -105,7 +106,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetSentinelConnectionReturnsFirstAvailableSentinel()
+    public function testMethodGetSentinelConnectionReturnsFirstAvailableSentinel(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel&alias=sentinel1');
         $sentinel2 = $this->getMockSentinelConnection('tcp://127.0.0.1:5382?role=sentinel&alias=sentinel2');
@@ -119,7 +120,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodAddAttachesMasterOrSlaveNodesToReplication()
+    public function testMethodAddAttachesMasterOrSlaveNodesToReplication(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -145,7 +146,7 @@ class SentinelReplicationTest extends PredisTestCase
      * @group disconnected
      * @FIXME
      */
-    public function testMethodRemoveDismissesMasterOrSlaveNodesFromReplication()
+    public function testMethodRemoveDismissesMasterOrSlaveNodesFromReplication(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -170,7 +171,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetConnectionByIdOnEmptyReplication()
+    public function testMethodGetConnectionByIdOnEmptyReplication(): void
     {
         $replication = $this->getReplicationConnection('svc', array());
 
@@ -180,7 +181,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetConnectionByRole()
+    public function testMethodGetConnectionByRole(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
@@ -200,7 +201,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetConnectionByRoleOnEmptyReplicationForcesSentinelQueries()
+    public function testMethodGetConnectionByRoleOnEmptyReplicationForcesSentinelQueries(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -238,7 +239,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetConnectionByRoleUnknown()
+    public function testMethodGetConnectionByRoleUnknown(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
@@ -256,7 +257,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodUpdateSentinelsFetchesSentinelNodes()
+    public function testMethodUpdateSentinelsFetchesSentinelNodes(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -304,7 +305,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodUpdateSentinelsRemovesCurrentSentinelAndRetriesNextOneOnFailure()
+    public function testMethodUpdateSentinelsRemovesCurrentSentinelAndRetriesNextOneOnFailure(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel&alias=sentinel1');
         $sentinel1
@@ -355,7 +356,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodUpdateSentinelsThrowsExceptionOnNoAvailableSentinel()
+    public function testMethodUpdateSentinelsThrowsExceptionOnNoAvailableSentinel(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -378,7 +379,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodQuerySentinelFetchesMasterNodeSlaveNodesAndSentinelNodes()
+    public function testMethodQuerySentinelFetchesMasterNodeSlaveNodesAndSentinelNodes(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel&alias=sentinel1');
         $sentinel1
@@ -461,7 +462,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetMasterAsksSentinelForMasterOnMasterNotSet()
+    public function testMethodGetMasterAsksSentinelForMasterOnMasterNotSet(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -482,7 +483,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetMasterThrowsExceptionOnNoAvailableSentinels()
+    public function testMethodGetMasterThrowsExceptionOnNoAvailableSentinels(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -506,7 +507,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetSlavesOnEmptySlavePoolAsksSentinelForSlaves()
+    public function testMethodGetSlavesOnEmptySlavePoolAsksSentinelForSlaves(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -549,7 +550,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetSlavesThrowsExceptionOnNoAvailableSentinels()
+    public function testMethodGetSlavesThrowsExceptionOnNoAvailableSentinels(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -573,7 +574,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodConnectThrowsExceptionOnConnectWithEmptySentinelsPool()
+    public function testMethodConnectThrowsExceptionOnConnectWithEmptySentinelsPool(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -585,7 +586,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodConnectForcesConnectionToSlave()
+    public function testMethodConnectForcesConnectionToSlave(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -610,7 +611,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodConnectOnEmptySlavePoolAsksSentinelForSlavesAndForcesConnectionToSlave()
+    public function testMethodConnectOnEmptySlavePoolAsksSentinelForSlavesAndForcesConnectionToSlave(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -643,6 +644,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('connect');
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
@@ -664,7 +666,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodConnectOnEmptySlavePoolAsksSentinelForSlavesAndForcesConnectionToMasterIfStillEmpty()
+    public function testMethodConnectOnEmptySlavePoolAsksSentinelForSlavesAndForcesConnectionToMasterIfStillEmpty(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -691,6 +693,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->expects($this->once())
             ->method('connect');
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
@@ -710,7 +713,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodDisconnectForcesDisconnectionOnAllConnectionsInPool()
+    public function testMethodDisconnectForcesDisconnectionOnAllConnectionsInPool(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -744,7 +747,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodIsConnectedReturnConnectionStatusOfCurrentConnection()
+    public function testMethodIsConnectedReturnConnectionStatusOfCurrentConnection(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -768,7 +771,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetConnectionByIdReturnsConnectionWhenFound()
+    public function testMethodGetConnectionByIdReturnsConnectionWhenFound(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -788,7 +791,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodSwitchToSelectsCurrentConnection()
+    public function testMethodSwitchToSelectsCurrentConnection(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -823,7 +826,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodSwitchToThrowsExceptionOnConnectionNotFound()
+    public function testMethodSwitchToThrowsExceptionOnConnectionNotFound(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid connection or connection not found.');
@@ -845,7 +848,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodSwitchToMasterSelectsCurrentConnectionToMaster()
+    public function testMethodSwitchToMasterSelectsCurrentConnectionToMaster(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -872,7 +875,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodSwitchToSlaveSelectsCurrentConnectionToRandomSlave()
+    public function testMethodSwitchToSlaveSelectsCurrentConnectionToRandomSlave(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -899,7 +902,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByCommandReturnsMasterForWriteCommands()
+    public function testGetConnectionByCommandReturnsMasterForWriteCommands(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -935,7 +938,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByCommandReturnsSlaveForReadOnlyCommands()
+    public function testGetConnectionByCommandReturnsSlaveForReadOnlyCommands(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -971,7 +974,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByCommandSwitchesToMasterAfterWriteCommand()
+    public function testGetConnectionByCommandSwitchesToMasterAfterWriteCommand(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -1022,7 +1025,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByCommandThrowsExceptionOnNodeRoleMismatch()
+    public function testGetConnectionByCommandThrowsExceptionOnNodeRoleMismatch(): void
     {
         $this->expectException('Predis\Replication\RoleException');
         $this->expectExceptionMessage('Expected master but got slave [127.0.0.1:6381]');
@@ -1052,7 +1055,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetConnectionByCommandReturnsMasterForReadOnlyOperationsOnUnavailableSlaves()
+    public function testGetConnectionByCommandReturnsMasterForReadOnlyOperationsOnUnavailableSlaves(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -1098,7 +1101,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodExecuteCommandSendsCommandToNodeAndReturnsResponse()
+    public function testMethodExecuteCommandSendsCommandToNodeAndReturnsResponse(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -1146,7 +1149,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodExecuteCommandRetriesReadOnlyCommandOnNextSlaveOnFailure()
+    public function testMethodExecuteCommandRetriesReadOnlyCommandOnNextSlaveOnFailure(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -1203,6 +1206,7 @@ class SentinelReplicationTest extends PredisTestCase
             ))
             ->will($this->returnValue('value'));
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
@@ -1227,7 +1231,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodExecuteCommandRetriesWriteCommandOnNewMasterOnFailure()
+    public function testMethodExecuteCommandRetriesWriteCommandOnNewMasterOnFailure(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
         $sentinel1
@@ -1268,6 +1272,7 @@ class SentinelReplicationTest extends PredisTestCase
             ))
             ->will($this->returnValue(1));
 
+        /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
         $factory
             ->expects($this->once())
@@ -1291,7 +1296,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodExecuteCommandThrowsExceptionOnUnknownServiceName()
+    public function testMethodExecuteCommandThrowsExceptionOnUnknownServiceName(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR No such master with that name');
@@ -1332,7 +1337,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodExecuteCommandThrowsExceptionOnConnectionFailureAndNoAvailableSentinels()
+    public function testMethodExecuteCommandThrowsExceptionOnConnectionFailureAndNoAvailableSentinels(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('No sentinel server available for autodiscovery.');
@@ -1375,7 +1380,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodGetReplicationStrategyReturnsInstance()
+    public function testMethodGetReplicationStrategyReturnsInstance(): void
     {
         $strategy = new Replication\ReplicationStrategy();
         $factory = new Connection\Factory();
@@ -1390,7 +1395,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMethodSerializeCanSerializeWholeObject()
+    public function testMethodSerializeCanSerializeWholeObject(): void
     {
         $sentinel1 = $this->getMockSentinelConnection('tcp://127.0.0.1:5381?role=sentinel');
 
@@ -1424,11 +1429,11 @@ class SentinelReplicationTest extends PredisTestCase
      *
      * @param string                          $service   Name of the service
      * @param array                           $sentinels Array of sentinels
-     * @param ConnectionFactoryInterface|null $factory   Optional connection factory instance.
+     * @param ConnectionFactoryInterface|null $factory   Optional connection factory instance
      *
      * @return SentinelReplication
      */
-    protected function getReplicationConnection($service, $sentinels, Connection\FactoryInterface $factory = null)
+    protected function getReplicationConnection(string $service, array $sentinels, Connection\FactoryInterface $factory = null): SentinelReplication
     {
         $factory = $factory ?: new Connection\Factory();
 
@@ -1441,7 +1446,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * Returns a base mocked connection from Predis\Connection\NodeConnectionInterface.
      *
-     * @param mixed $parameters Optional parameters.
+     * @param array|string $parameters Optional parameters
      *
      * @return mixed
      */

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -211,7 +211,7 @@ class SentinelReplicationTest extends PredisTestCase
                 array($this->isRedisCommand('SENTINEL', array('get-master-addr-by-name', 'svc'))),
                 array($this->isRedisCommand('SENTINEL', array('slaves', 'svc')))
             )
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 // SENTINEL get-master-addr-by-name svc
                 array('127.0.0.1', '6381'),
 
@@ -227,7 +227,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -266,7 +266,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('sentinels', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:5382',
@@ -283,7 +283,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'flags', 'sentinel',
                     ),
                 )
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
         $replication->updateSentinels();
@@ -314,9 +314,9 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('sentinels', 'svc')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($sentinel1, 'Unknown connection error [127.0.0.1:5381]')
-            ));
+            );
 
         $sentinel2 = $this->getMockSentinelConnection('tcp://127.0.0.1:5382?role=sentinel&alias=sentinel2');
         $sentinel2
@@ -325,7 +325,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('sentinels', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:5383',
@@ -335,7 +335,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'flags', 'sentinel',
                     ),
                 )
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1, $sentinel2));
         $replication->updateSentinels();
@@ -368,9 +368,9 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('sentinels', 'svc')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($sentinel1, 'Unknown connection error [127.0.0.1:5381]')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
         $replication->updateSentinels();
@@ -390,7 +390,7 @@ class SentinelReplicationTest extends PredisTestCase
                 array($this->isRedisCommand('SENTINEL', array('get-master-addr-by-name', 'svc'))),
                 array($this->isRedisCommand('SENTINEL', array('slaves', 'svc')))
             )
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 // SENTINEL sentinels svc
                 array(
                     array(
@@ -426,7 +426,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $sentinel2 = $this->getMockSentinelConnection('tcp://127.0.0.1:5382?role=sentinel&alias=sentinel2');
 
@@ -471,9 +471,9 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array('127.0.0.1', '6381')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -495,9 +495,9 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($sentinel1, 'Unknown connection error [127.0.0.1:5381]')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -516,7 +516,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:6382',
@@ -537,7 +537,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -562,9 +562,9 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($sentinel1, 'Unknown connection error [127.0.0.1:5381]')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -620,7 +620,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:6382',
@@ -632,7 +632,7 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $master
@@ -654,7 +654,7 @@ class SentinelReplicationTest extends PredisTestCase
                 'port' => '6382',
                 'role' => 'slave',
             ))
-           ->will($this->returnValue($slave1));
+           ->willReturn($slave1);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1), $factory);
 
@@ -675,18 +675,18 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array()
-            ));
+            );
         $sentinel1
             ->expects($this->at(1))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array('127.0.0.1', '6381')
-            ));
+            );
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $master
@@ -703,7 +703,7 @@ class SentinelReplicationTest extends PredisTestCase
                 'port' => '6381',
                 'role' => 'master',
             ))
-            ->will($this->returnValue($master));
+            ->willReturn($master);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1), $factory);
 
@@ -755,7 +755,7 @@ class SentinelReplicationTest extends PredisTestCase
         $slave1
             ->expects($this->exactly(2))
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(true, false));
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -910,14 +910,14 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->exactly(2))
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->willReturnOnConsecutiveCalls(false, true);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'master', 3129659, array(array('127.0.0.1', 6382, 3129242)),
-            )));
+            ));
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
 
@@ -948,14 +948,14 @@ class SentinelReplicationTest extends PredisTestCase
         $slave1
             ->expects($this->exactly(2))
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->willReturnOnConsecutiveCalls(false, true);
         $slave1
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            )));
+            ));
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -982,27 +982,27 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->exactly(2))
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(false, true));
+            ->willReturnOnConsecutiveCalls(false, true);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'master', 3129659, array(array('127.0.0.1', 6382, 3129242)),
-            )));
+            ));
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave1
             ->expects($this->exactly(1))
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(false));
+            ->willReturnOnConsecutiveCalls(false);
         $slave1
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            )));
+            ));
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1036,14 +1036,14 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'slave', '127.0.0.1', 9000, 'connected', 3167038,
-            )));
+            ));
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1064,7 +1064,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:6382',
@@ -1076,20 +1076,20 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $master
             ->expects($this->once())
             ->method('isConnected')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand('ROLE'))
-            ->will($this->returnValue(array(
+            ->willReturn(array(
                 'master', '0', array(),
-            )));
+            ));
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1115,27 +1115,27 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'SET', array('key', $cmdGetResponse)
             ))
-           ->will($this->returnValue($cmdSetResponse));
+           ->willReturn($cmdSetResponse);
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave1
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $slave1
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'GET', array('key')
             ))
-            ->will($this->returnValue($cmdGetResponse));
+            ->willReturn($cmdGetResponse);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1158,7 +1158,7 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('slaves', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array(
                     array(
                         'name', '127.0.0.1:6383',
@@ -1170,41 +1170,41 @@ class SentinelReplicationTest extends PredisTestCase
                         'master-port', '6381',
                     ),
                 )
-            ));
+            );
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $master
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $slave1 = $this->getMockConnection('tcp://127.0.0.1:6382?role=slave');
         $slave1
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $slave1
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'GET', array('key')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($slave1, 'Unknown connection error [127.0.0.1:6382]')
-            ));
+            );
 
         $slave2 = $this->getMockConnection('tcp://127.0.0.1:6383?role=slave');
         $slave2
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $slave2
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'GET', array('key')
             ))
-            ->will($this->returnValue('value'));
+            ->willReturn('value');
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1216,7 +1216,7 @@ class SentinelReplicationTest extends PredisTestCase
                 'port' => '6383',
                 'role' => 'slave',
             ))
-            ->will($this->returnValue($slave2));
+            ->willReturn($slave2);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1), $factory);
 
@@ -1240,37 +1240,37 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->returnValue(
+            ->willReturn(
                 array('127.0.0.1', '6391')
-            ));
+            );
 
         $masterOld = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $masterOld
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $masterOld
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'DEL', array('key')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($masterOld, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $masterNew = $this->getMockConnection('tcp://127.0.0.1:6391?role=master');
         $masterNew
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $masterNew
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'DEL', array('key')
             ))
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         /** @var Connection\FactoryInterface|MockObject */
         $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
@@ -1282,7 +1282,7 @@ class SentinelReplicationTest extends PredisTestCase
                 'port' => '6391',
                 'role' => 'master',
             ))
-            ->will($this->returnValue($masterNew));
+            ->willReturn($masterNew);
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1), $factory);
 
@@ -1308,22 +1308,22 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $masterOld = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $masterOld
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $masterOld
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'DEL', array('key')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($masterOld, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 
@@ -1349,24 +1349,24 @@ class SentinelReplicationTest extends PredisTestCase
             ->with($this->isRedisCommand(
                 'SENTINEL', array('get-master-addr-by-name', 'svc')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($sentinel1, 'Unknown connection error [127.0.0.1:5381]')
-            ));
+            );
 
         $master = $this->getMockConnection('tcp://127.0.0.1:6381?role=master');
         $master
             ->expects($this->any())
             ->method('isConnected')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $master
             ->expects($this->at(3))
             ->method('executeCommand')
             ->with($this->isRedisCommand(
                 'DEL', array('key')
             ))
-            ->will($this->throwException(
+            ->willThrowException(
                 new Connection\ConnectionException($master, 'Unknown connection error [127.0.0.1:6381]')
-            ));
+            );
 
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
 

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Predis\Connection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Command\RawCommand;
 use Predis\Response\Error as ErrorResponse;
 
@@ -19,21 +20,28 @@ use Predis\Response\Error as ErrorResponse;
  */
 class StreamConnectionTest extends PredisConnectionTestCase
 {
-    const CONNECTION_CLASS = 'Predis\Connection\StreamConnection';
+    /**
+     * @inheritDoc
+     */
+    public function getConnectionClass(): string
+    {
+        return 'Predis\Connection\StreamConnection';
+    }
 
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInitializationCommandFailure()
+    public function testThrowsExceptionOnInitializationCommandFailure(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
         $this->expectExceptionMessage("`SELECT` failed: ERR invalid DB index [tcp://127.0.0.1:6379]");
 
         $cmdSelect = RawCommand::create('SELECT', '1000');
 
+        /** @var NodeConnectionInterface|MockObject */
         $connection = $this
-            ->getMockBuilder(static::CONNECTION_CLASS)
-            ->setMethods(array('executeCommand', 'createResource'))
+            ->getMockBuilder($this->getConnectionClass())
+            ->onlyMethods(array('executeCommand', 'createResource'))
             ->setConstructorArgs(array(new Parameters()))
             ->getMock();
         $connection
@@ -57,7 +65,7 @@ class StreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithFalseLikeValues()
+    public function testPersistentParameterWithFalseLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 0));
         $this->assertNonPersistentConnection($connection1);
@@ -76,7 +84,7 @@ class StreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentParameterWithTrueLikeValues()
+    public function testPersistentParameterWithTrueLikeValues(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 1));
         $this->assertPersistentConnection($connection1);
@@ -97,7 +105,7 @@ class StreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeShareResource()
+    public function testPersistentConnectionsToSameNodeShareResource(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => true));
         $connection2 = $this->createConnectionWithParams(array('persistent' => true));
@@ -114,7 +122,7 @@ class StreamConnectionTest extends PredisConnectionTestCase
      * @group connected
      * @requires PHP 5.4
      */
-    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID()
+    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID(): void
     {
         $connection1 = $this->createConnectionWithParams(array('persistent' => 'conn1'));
         $connection2 = $this->createConnectionWithParams(array('persistent' => 'conn2'));

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -47,9 +47,9 @@ class StreamConnectionTest extends PredisConnectionTestCase
         $connection
             ->method('executeCommand')
             ->with($cmdSelect)
-            ->will($this->returnValue(
+            ->willReturn(
                 new ErrorResponse('ERR invalid DB index')
-            ));
+            );
 
         $connection->method('createResource');
 

--- a/tests/Predis/Connection/WebdisConnectionTest.php
+++ b/tests/Predis/Connection/WebdisConnectionTest.php
@@ -26,7 +26,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsConnectedAlwaysReturnsTrue()
+    public function testIsConnectedAlwaysReturnsTrue(): void
     {
         $connection = $this->createConnection();
 
@@ -36,7 +36,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSupportsSchemeUnix()
+    public function testSupportsSchemeUnix(): void
     {
         $connection = $this->createConnectionWithParams(array('scheme' => 'http'));
 
@@ -46,7 +46,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnInvalidScheme()
+    public function testThrowsExceptionOnInvalidScheme(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Invalid scheme: 'tcp'");
@@ -57,7 +57,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWritingCommandsIsNotSupported()
+    public function testWritingCommandsIsNotSupported(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::writeRequest() is not supported");
@@ -69,7 +69,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadingResponsesIsNotSupported()
+    public function testReadingResponsesIsNotSupported(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::readResponse() is not supported");
@@ -81,7 +81,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadingFromConnectionIsNotSupported()
+    public function testReadingFromConnectionIsNotSupported(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::read() is not supported");
@@ -93,7 +93,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAddingConnectCommandsIsNotSupported()
+    public function testAddingConnectCommandsIsNotSupported(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The method Predis\Connection\WebdisConnection::addConnectCommand() is not supported");
@@ -105,7 +105,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRejectCommandSelect()
+    public function testRejectCommandSelect(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Command 'SELECT' is not allowed by Webdis");
@@ -117,7 +117,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testRejectCommandAuth()
+    public function testRejectCommandAuth(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("Command 'AUTH' is not allowed by Webdis");
@@ -129,7 +129,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanBeSerialized()
+    public function testCanBeSerialized(): void
     {
         $parameters = $this->getParameters(array(
             'alias' => 'redis',
@@ -151,7 +151,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testExecutesMultipleCommandsOnServer()
+    public function testExecutesMultipleCommandsOnServer(): void
     {
         $commands = $this->getCommandFactory();
 
@@ -175,7 +175,7 @@ class WebdisConnectionTest extends PredisTestCase
      * @group disconnected
      * @group slow
      */
-    public function testThrowExceptionWhenUnableToConnect()
+    public function testThrowExceptionWhenUnableToConnect(): void
     {
         $this->expectException('Predis\Connection\ConnectionException');
 
@@ -190,21 +190,21 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * Returns a named array with the default connection parameters and their values.
      *
-     * @return array Default connection parameters.
+     * @return array Default connection parameters
      */
-    protected function getDefaultParametersArray()
+    protected function getDefaultParametersArray(): array
     {
         return array(
             'scheme' => 'http',
-            'host' => WEBDIS_SERVER_HOST,
-            'port' => WEBDIS_SERVER_PORT,
+            'host' => constant('WEBDIS_SERVER_HOST'),
+            'port' => constant('WEBDIS_SERVER_PORT'),
         );
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function createConnection()
+    protected function createConnection(): NodeConnectionInterface
     {
         return $this->createConnectionWithParams(array());
     }
@@ -212,7 +212,7 @@ class WebdisConnectionTest extends PredisTestCase
     /**
      * {@inheritdoc}
      */
-    protected function createConnectionWithParams($parameters)
+    protected function createConnectionWithParams($parameters): NodeConnectionInterface
     {
         if (!$parameters instanceof ParametersInterface) {
             $parameters = $this->getParameters($parameters);

--- a/tests/Predis/Monitor/ConsumerTest.php
+++ b/tests/Predis/Monitor/ConsumerTest.php
@@ -11,9 +11,9 @@
 
 namespace Predis\Monitor;
 
+use PredisTestCase;
 use Predis\Client;
 use Predis\Monitor\Consumer as MonitorConsumer;
-use PredisTestCase;
 
 /**
  * @group realm-monitor
@@ -23,7 +23,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMonitorConsumerRequireMonitorCommand()
+    public function testMonitorConsumerRequireMonitorCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("'MONITOR' is not supported by the current command factory.");
@@ -43,7 +43,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMonitorConsumerDoesNotWorkOnClusters()
+    public function testMonitorConsumerDoesNotWorkOnClusters(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('Cannot initialize a monitor consumer over aggregate connections');
@@ -57,13 +57,14 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorStartsConsumer()
+    public function testConstructorStartsConsumer(): void
     {
         $cmdMonitor = $this->getCommandFactory()->create('monitor');
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('createCommand', 'executeCommand'))
+            ->onlyMethods(array('createCommand', 'executeCommand'))
             ->setConstructorArgs(array($connection))
             ->getMock();
         $client
@@ -86,12 +87,13 @@ class ConsumerTest extends PredisTestCase
      *       the reason is probably that the GC invokes __destruct() on monitor
      *       thus calling disconnect() a second time at the end of the test.
      */
-    public function testStoppingConsumerClosesConnection()
+    public function testStoppingConsumerClosesConnection(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('disconnect'))
+            ->onlyMethods(array('disconnect'))
             ->setConstructorArgs(array($connection))
             ->getMock();
         $client
@@ -106,12 +108,13 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGarbageCollectorRunStopsConsumer()
+    public function testGarbageCollectorRunStopsConsumer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var \Predis\ClientInterface */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('disconnect'))
+            ->onlyMethods(array('disconnect'))
             ->setConstructorArgs(array($connection))
             ->getMock();
         $client
@@ -126,7 +129,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsMessageFromConnectionToRedis24()
+    public function testReadsMessageFromConnectionToRedis24(): void
     {
         $message = '1323367530.939137 (db 15) "MONITOR"';
 
@@ -151,7 +154,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsMessageFromConnectionToRedis26()
+    public function testReadsMessageFromConnectionToRedis26(): void
     {
         $message = '1323367530.939137 [15 127.0.0.1:37265] "MONITOR"';
 
@@ -180,12 +183,12 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testMonitorAgainstRedisServer()
+    public function testMonitorAgainstRedisServer(): void
     {
         $parameters = array(
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             // Prevents suite from handing on broken test
             'read_write_timeout' => 2,
         );

--- a/tests/Predis/Monitor/ConsumerTest.php
+++ b/tests/Predis/Monitor/ConsumerTest.php
@@ -33,7 +33,7 @@ class ConsumerTest extends PredisTestCase
             ->expects($this->once())
             ->method('supports')
             ->with('MONITOR')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $client = new Client(null, array('commands' => $commands));
 
@@ -71,7 +71,7 @@ class ConsumerTest extends PredisTestCase
             ->expects($this->once())
             ->method('createCommand')
             ->with('MONITOR', array())
-            ->will($this->returnValue($cmdMonitor));
+            ->willReturn($cmdMonitor);
         $client
             ->expects($this->once())
             ->method('executeCommand')
@@ -137,7 +137,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
 
         $client = new Client($connection);
 
@@ -162,7 +162,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
 
         $client = new Client($connection);
 

--- a/tests/Predis/Pipeline/AtomicTest.php
+++ b/tests/Predis/Pipeline/AtomicTest.php
@@ -23,7 +23,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithSingleConnection()
+    public function testPipelineWithSingleConnection(): void
     {
         $pong = new Response\Status('PONG');
         $queued = new Response\Status('QUEUED');
@@ -53,7 +53,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnAbortedTransaction()
+    public function testThrowsExceptionOnAbortedTransaction(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('The underlying transaction has been aborted by the server');
@@ -76,7 +76,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithErrorInTransaction()
+    public function testPipelineWithErrorInTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR Test error');
@@ -110,7 +110,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsServerExceptionOnResponseErrorByDefault()
+    public function testThrowsServerExceptionOnResponseErrorByDefault(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR Test error');
@@ -134,7 +134,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsResponseErrorWithClientExceptionsSetToFalse()
+    public function testReturnsResponseErrorWithClientExceptionsSetToFalse(): void
     {
         $pong = new Response\Status('PONG');
         $queued = new Response\Status('QUEUED');
@@ -162,7 +162,7 @@ class AtomicTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecutorWithAggregateConnection()
+    public function testExecutorWithAggregateConnection(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage("The class 'Predis\Pipeline\Atomic' does not support aggregate connections");

--- a/tests/Predis/Pipeline/AtomicTest.php
+++ b/tests/Predis/Pipeline/AtomicTest.php
@@ -32,14 +32,14 @@ class AtomicTest extends PredisTestCase
         $connection
             ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->will($this->onConsecutiveCalls(true, array($pong, $pong, $pong)));
+            ->willReturnOnConsecutiveCalls(true, array($pong, $pong, $pong));
         $connection
             ->expects($this->exactly(3))
             ->method('writeRequest');
         $connection
             ->expects($this->at(3))
             ->method('readResponse')
-            ->will($this->onConsecutiveCalls($queued, $queued, $queued));
+            ->willReturnOnConsecutiveCalls($queued, $queued, $queued);
 
         $pipeline = new Atomic(new Client($connection));
 
@@ -62,7 +62,7 @@ class AtomicTest extends PredisTestCase
         $connection
             ->expects($this->exactly(2))
             ->method('executeCommand')
-            ->will($this->onConsecutiveCalls(true, null));
+            ->willReturnOnConsecutiveCalls(true, null);
 
         $pipeline = new Atomic(new Client($connection));
 
@@ -88,11 +88,11 @@ class AtomicTest extends PredisTestCase
         $connection
             ->expects($this->at(0))
             ->method('executeCommand')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $connection
             ->expects($this->exactly(3))
             ->method('readResponse')
-            ->will($this->onConsecutiveCalls($queued, $queued, $error));
+            ->willReturnOnConsecutiveCalls($queued, $queued, $error);
         $connection
             ->expects($this->at(7))
             ->method('executeCommand')
@@ -121,7 +121,7 @@ class AtomicTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readResponse')
-            ->will($this->returnValue($error));
+            ->willReturn($error);
 
         $pipeline = new Atomic(new Client($connection));
 
@@ -144,11 +144,11 @@ class AtomicTest extends PredisTestCase
         $connection
             ->expects($this->exactly(3))
             ->method('readResponse')
-            ->will($this->onConsecutiveCalls($queued, $queued, $queued));
+            ->willReturnOnConsecutiveCalls($queued, $queued, $queued);
         $connection
             ->expects($this->at(7))
             ->method('executeCommand')
-            ->will($this->returnValue(array($pong, $pong, $error)));
+            ->willReturn(array($pong, $pong, $error));
 
         $pipeline = new Atomic(new Client($connection, array('exceptions' => false)));
 

--- a/tests/Predis/Pipeline/FireAndForgetTest.php
+++ b/tests/Predis/Pipeline/FireAndForgetTest.php
@@ -22,7 +22,7 @@ class FireAndForgetTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPipelineWithSingleConnection()
+    public function testPipelineWithSingleConnection(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -44,7 +44,7 @@ class FireAndForgetTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSwitchesToMasterWithReplicationConnection()
+    public function testSwitchesToMasterWithReplicationConnection(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\Replication\ReplicationInterface')
             ->getMock();

--- a/tests/Predis/Pipeline/PipelineTest.php
+++ b/tests/Predis/Pipeline/PipelineTest.php
@@ -13,6 +13,8 @@ namespace Predis\Pipeline;
 
 use Predis\Client;
 use Predis\ClientException;
+use Predis\ClientInterface;
+use Predis\Command\CommandInterface;
 use Predis\Response;
 use PredisTestCase;
 
@@ -24,7 +26,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $client = new Client();
         $pipeline = new Pipeline($client);
@@ -35,7 +37,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCallDoesNotSendCommandsWithoutExecute()
+    public function testCallDoesNotSendCommandsWithoutExecute(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -55,7 +57,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCallReturnsPipelineForFluentInterface()
+    public function testCallReturnsPipelineForFluentInterface(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -74,7 +76,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDoesNotParseComplexResponseObjects()
+    public function testDoesNotParseComplexResponseObjects(): void
     {
         $object = $this->getMockBuilder('Predis\Response\ResponseInterface')->getMock();
 
@@ -94,7 +96,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsServerExceptionOnResponseErrorByDefault()
+    public function testThrowsServerExceptionOnResponseErrorByDefault(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR Test error');
@@ -118,7 +120,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReturnsResponseErrorWithClientExceptionsSetToFalse()
+    public function testReturnsResponseErrorWithClientExceptionsSetToFalse(): void
     {
         $error = $this->getMockBuilder('Predis\Response\ErrorInterface')->getMock();
 
@@ -141,7 +143,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteReturnsPipelineForFluentInterface()
+    public function testExecuteReturnsPipelineForFluentInterface(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $command = $this->getCommandFactory()->create('echo', array('one'));
@@ -154,7 +156,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteCommandDoesNotSendCommandsWithoutExecute()
+    public function testExecuteCommandDoesNotSendCommandsWithoutExecute(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -176,7 +178,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteWithEmptyBuffer()
+    public function testExecuteWithEmptyBuffer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -194,7 +196,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteWithFilledBuffer()
+    public function testExecuteWithFilledBuffer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -219,7 +221,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFlushWithFalseArgumentDiscardsBuffer()
+    public function testFlushWithFalseArgumentDiscardsBuffer(): void
     {
         $pipeline = new Pipeline(new Client());
 
@@ -235,7 +237,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFlushHandlesPartialBuffers()
+    public function testFlushHandlesPartialBuffers(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -260,7 +262,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSwitchesToMasterWithReplicationConnection()
+    public function testSwitchesToMasterWithReplicationConnection(): void
     {
         $pong = new Response\Status('PONG');
 
@@ -288,12 +290,12 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteAcceptsCallableArgument()
+    public function testExecuteAcceptsCallableArgument(): void
     {
         $test = $this;
         $pipeline = new Pipeline(new Client());
 
-        $callable = function ($pipe) use ($test, $pipeline) {
+        $callable = function (Pipeline $pipe) use ($test, $pipeline) {
             $test->assertSame($pipeline, $pipe);
             $pipe->flushPipeline(false);
         };
@@ -304,7 +306,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteDoesNotAcceptNonCallableArgument()
+    public function testExecuteDoesNotAcceptNonCallableArgument(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -317,13 +319,13 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteInsideCallableArgumentThrowsException()
+    public function testExecuteInsideCallableArgumentThrowsException(): void
     {
         $this->expectException('Predis\ClientException');
 
         $pipeline = new Pipeline(new Client());
 
-        $pipeline->execute(function ($pipe) {
+        $pipeline->execute(function (Pipeline $pipe) {
             $pipe->execute();
         });
     }
@@ -331,7 +333,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteWithCallableArgumentRunsPipelineInCallable()
+    public function testExecuteWithCallableArgumentRunsPipelineInCallable(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -344,7 +346,7 @@ class PipelineTest extends PredisTestCase
 
         $pipeline = new Pipeline(new Client($connection));
 
-        $responses = $pipeline->execute(function ($pipe) {
+        $responses = $pipeline->execute(function (Pipeline $pipe) {
             $pipe->echo('one');
             $pipe->echo('two');
             $pipe->echo('three');
@@ -357,7 +359,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecuteWithCallableArgumentHandlesExceptions()
+    public function testExecuteWithCallableArgumentHandlesExceptions(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -373,7 +375,7 @@ class PipelineTest extends PredisTestCase
         $pipeline = new Pipeline(new Client($connection));
 
         try {
-            $responses = $pipeline->execute(function ($pipe) {
+            $responses = $pipeline->execute(function (Pipeline $pipe) {
                 $pipe->echo('one');
                 $pipe->echo('two');
                 throw new ClientException('TEST');
@@ -394,7 +396,7 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationWithFluentInterface()
+    public function testIntegrationWithFluentInterface(): void
     {
         $pipeline = $this->getClient()->pipeline();
 
@@ -410,11 +412,11 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationWithCallableBlock()
+    public function testIntegrationWithCallableBlock(): void
     {
         $client = $this->getClient();
 
-        $results = $client->pipeline(function ($pipe) {
+        $results = $client->pipeline(function (Pipeline $pipe) {
             $pipe->set('foo', 'bar');
             $pipe->get('foo');
         });
@@ -426,12 +428,12 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testOutOfBandMessagesInsidePipeline()
+    public function testOutOfBandMessagesInsidePipeline(): void
     {
         $oob = null;
         $client = $this->getClient();
 
-        $results = $client->pipeline(function ($pipe) use (&$oob) {
+        $results = $client->pipeline(function (Pipeline $pipe) use (&$oob) {
             $pipe->set('foo', 'bar');
             $oob = $pipe->getClient()->echo('oob message');
             $pipe->get('foo');
@@ -445,14 +447,14 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationWithClientExceptionInCallableBlock()
+    public function testIntegrationWithClientExceptionInCallableBlock(): void
     {
         $exception = null;
 
         $client = $this->getClient();
 
         try {
-            $client->pipeline(function ($pipe) {
+            $client->pipeline(function (Pipeline $pipe) {
                 $pipe->set('foo', 'bar');
                 throw new ClientException('TEST');
             });
@@ -468,14 +470,14 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationWithServerExceptionInCallableBlock()
+    public function testIntegrationWithServerExceptionInCallableBlock(): void
     {
         $exception = null;
 
         $client = $this->getClient();
 
         try {
-            $client->pipeline(function ($pipe) {
+            $client->pipeline(function (Pipeline $pipe) {
                 $pipe->set('foo', 'bar');
                 // LPUSH on a string key fails, but won't stop
                 // the pipeline to send the commands.
@@ -494,11 +496,11 @@ class PipelineTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationWithServerErrorInCallableBlock()
+    public function testIntegrationWithServerErrorInCallableBlock(): void
     {
         $client = $this->getClient(array(), array('exceptions' => false));
 
-        $results = $client->pipeline(function ($pipe) {
+        $results = $client->pipeline(function (Pipeline $pipe) {
             $pipe->set('foo', 'bar');
             $pipe->lpush('foo', 'bar'); // LPUSH on a string key fails.
             $pipe->get('foo');
@@ -514,28 +516,26 @@ class PipelineTest extends PredisTestCase
     // ******************************************************************** //
 
     /**
-     * Returns a client instance connected to the specified Redis
-     * server instance to perform integration tests.
+     * Returns a client instance connected to the specified Redis server.
      *
-     * @param array $parameters Additional connection parameters.
-     * @param array $options    Additional client options.
+     * @param array $parameters Additional connection parameters
+     * @param array $options    Additional client options
      *
-     * @return Client
+     * @return ClientInterface
      */
-    protected function getClient(array $parameters = array(), array $options = array())
+    protected function getClient(array $parameters = array(), array $options = array()): ClientInterface
     {
         return $this->createClient($parameters, $options);
     }
 
     /**
-     * Helper method that returns a callback used to emulate the response to an
-     * ECHO command.
+     * Helper method returning a callback used to responses to ECHO command.
      *
-     * @return \Closure
+     * @return callable
      */
-    protected function getReadCallback()
+    protected function getReadCallback(): callable
     {
-        return function ($command) {
+        return function (CommandInterface $command) {
             if (($id = $command->getId()) !== 'ECHO') {
                 throw new \InvalidArgumentException("Expected ECHO, got {$id}");
             }

--- a/tests/Predis/Pipeline/PipelineTest.php
+++ b/tests/Predis/Pipeline/PipelineTest.php
@@ -84,7 +84,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readResponse')
-            ->will($this->returnValue($object));
+            ->willReturn($object);
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -107,7 +107,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readResponse')
-            ->will($this->returnValue($error));
+            ->willReturn($error);
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -128,7 +128,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->exactly(2))
             ->method('readResponse')
-            ->will($this->returnValue($error));
+            ->willReturn($error);
 
         $client = new Client($connection, array('exceptions' => false));
 
@@ -205,7 +205,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->exactly(3))
             ->method('readResponse')
-            ->will($this->returnCallback($this->getReadCallback()));
+            ->willReturnCallback($this->getReadCallback());
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -246,7 +246,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->exactly(4))
             ->method('readResponse')
-            ->will($this->returnCallback($this->getReadCallback()));
+            ->willReturnCallback($this->getReadCallback());
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -276,7 +276,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->exactly(3))
             ->method('readResponse')
-            ->will($this->returnValue($pong));
+            ->willReturn($pong);
 
         $pipeline = new Pipeline(new Client($connection));
 
@@ -342,7 +342,7 @@ class PipelineTest extends PredisTestCase
         $connection
             ->expects($this->exactly(4))
             ->method('readResponse')
-            ->will($this->returnCallback($this->getReadCallback()));
+            ->willReturnCallback($this->getReadCallback());
 
         $pipeline = new Pipeline(new Client($connection));
 

--- a/tests/Predis/PredisExceptionTest.php
+++ b/tests/Predis/PredisExceptionTest.php
@@ -21,7 +21,7 @@ class PredisExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionMessage()
+    public function testExceptionMessage(): void
     {
         $message = 'Predis exception message';
         $exception = $this->getMockForAbstractClass('Predis\PredisException', array($message));

--- a/tests/Predis/Protocol/ProtocolExceptionTest.php
+++ b/tests/Predis/Protocol/ProtocolExceptionTest.php
@@ -13,6 +13,7 @@ namespace Predis\Protocol;
 
 require_once __DIR__.'/../CommunicationExceptionTest.php';
 
+use Predis\CommunicationException;
 use Predis\CommunicationExceptionTest;
 use Predis\Connection\NodeConnectionInterface;
 
@@ -24,8 +25,12 @@ class ProtocolExceptionTest extends CommunicationExceptionTest
     /**
      * {@inheritdoc}
      */
-    protected function getException(NodeConnectionInterface $connection, $message, $code = 0, \Exception $inner = null)
-    {
+    protected function getException(
+        NodeConnectionInterface $connection,
+        string $message,
+        int $code = 0,
+        \Exception $inner = null
+    ): CommunicationException {
         return new ProtocolException($connection, $message, $code, $inner);
     }
 }

--- a/tests/Predis/Protocol/Text/CompositeProtocolProcessorTest.php
+++ b/tests/Predis/Protocol/Text/CompositeProtocolProcessorTest.php
@@ -103,7 +103,7 @@ class CompositeProtocolProcessorTest extends PredisTestCase
             ->expects($this->once())
             ->method('serialize')
             ->with($command)
-            ->will($this->returnValue($serialized));
+            ->willReturn($serialized);
 
         $protocol->write($connection, $command);
     }
@@ -124,7 +124,7 @@ class CompositeProtocolProcessorTest extends PredisTestCase
             ->expects($this->once())
             ->method('read')
             ->with($connection)
-            ->will($this->returnValue('bulk'));
+            ->willReturn('bulk');
 
         $this->assertSame('bulk', $protocol->read($connection));
     }

--- a/tests/Predis/Protocol/Text/CompositeProtocolProcessorTest.php
+++ b/tests/Predis/Protocol/Text/CompositeProtocolProcessorTest.php
@@ -12,6 +12,11 @@
 namespace Predis\Protocol\Text;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\CommandInterface;
+use Predis\Connection\CompositeConnectionInterface;
+use Predis\Protocol\RequestSerializerInterface;
+use Predis\Protocol\ResponseReaderInterface;
 
 /**
  *
@@ -21,7 +26,7 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $protocol = new CompositeProtocolProcessor();
 
@@ -32,9 +37,11 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithArguments()
+    public function testConstructorWithArguments(): void
     {
+        /** @var RequestSerializerInterface */
         $serializer = $this->getMockBuilder('Predis\Protocol\RequestSerializerInterface')->getMock();
+        /** @var ResponseReaderInterface */
         $reader = $this->getMockBuilder('Predis\Protocol\ResponseReaderInterface')->getMock();
 
         $protocol = new CompositeProtocolProcessor($serializer, $reader);
@@ -46,8 +53,9 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCustomRequestSerializer()
+    public function testCustomRequestSerializer(): void
     {
+        /** @var RequestSerializerInterface */
         $serializer = $this->getMockBuilder('Predis\Protocol\RequestSerializerInterface')->getMock();
 
         $protocol = new CompositeProtocolProcessor();
@@ -59,8 +67,9 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCustomResponseReader()
+    public function testCustomResponseReader(): void
     {
+        /** @var ResponseReaderInterface */
         $reader = $this->getMockBuilder('Predis\Protocol\ResponseReaderInterface')->getMock();
 
         $protocol = new CompositeProtocolProcessor();
@@ -72,12 +81,15 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectionWrite()
+    public function testConnectionWrite(): void
     {
         $serialized = "*1\r\n$4\r\nPING\r\n";
 
+        /** @var CommandInterface */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
+        /** @var CompositeConnectionInterface|MockObject */
         $connection = $this->getMockBuilder('Predis\Connection\CompositeConnectionInterface')->getMock();
+        /** @var RequestSerializerInterface|MockObject */
         $serializer = $this->getMockBuilder('Predis\Protocol\RequestSerializerInterface')->getMock();
 
         $protocol = new CompositeProtocolProcessor($serializer);
@@ -99,9 +111,11 @@ class CompositeProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectionRead()
+    public function testConnectionRead(): void
     {
+        /** @var CompositeConnectionInterface */
         $connection = $this->getMockBuilder('Predis\Connection\CompositeConnectionInterface')->getMock();
+        /** @var ResponseReaderInterface|MockObject */
         $reader = $this->getMockBuilder('Predis\Protocol\ResponseReaderInterface')->getMock();
 
         $protocol = new CompositeProtocolProcessor(null, $reader);

--- a/tests/Predis/Protocol/Text/Handler/BulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/BulkResponseTest.php
@@ -21,7 +21,7 @@ class BulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testZeroLengthBulk()
+    public function testZeroLengthBulk(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -41,7 +41,7 @@ class BulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testBulk()
+    public function testBulk(): void
     {
         $bulk = 'This is a bulk string.';
         $bulkLengh = strlen($bulk);
@@ -64,7 +64,7 @@ class BulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNull()
+    public function testNull(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -82,7 +82,7 @@ class BulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInvalidLengthString()
+    public function testInvalidLengthString(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Cannot parse 'invalid' as a valid length for a bulk response [tcp://127.0.0.1:6379]");
@@ -103,7 +103,7 @@ class BulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInvalidLengthInteger()
+    public function testInvalidLengthInteger(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Value '-5' is not a valid length for a bulk response [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/Handler/BulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/BulkResponseTest.php
@@ -31,7 +31,7 @@ class BulkResponseTest extends PredisTestCase
             ->expects($this->once())
             ->method('readBuffer')
             ->with($this->equalTo(2))
-            ->will($this->returnValue("\r\n"));
+            ->willReturn("\r\n");
 
         $handler = new Handler\BulkResponse();
 
@@ -54,7 +54,7 @@ class BulkResponseTest extends PredisTestCase
             ->expects($this->once())
             ->method('readBuffer')
             ->with($this->equalTo($bulkLengh + 2))
-            ->will($this->returnValue("$bulk\r\n"));
+            ->willReturn("$bulk\r\n");
 
         $handler = new Handler\BulkResponse();
 

--- a/tests/Predis/Protocol/Text/Handler/ErrorResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/ErrorResponseTest.php
@@ -21,7 +21,7 @@ class ErrorResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOk()
+    public function testOk(): void
     {
         $message = 'ERR Operation against a key holding the wrong kind of value';
 

--- a/tests/Predis/Protocol/Text/Handler/IntegerResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/IntegerResponseTest.php
@@ -21,7 +21,7 @@ class IntegerResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInteger()
+    public function testInteger(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -42,7 +42,7 @@ class IntegerResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNull()
+    public function testNull(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -60,7 +60,7 @@ class IntegerResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Cannot parse 'invalid' as a valid numeric response [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
@@ -27,23 +27,23 @@ class MultiBulkResponseTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('getProtocol')
-            ->will($this->returnValue(new CompositeProtocolProcessor()));
+            ->willReturn(new CompositeProtocolProcessor());
         $connection
             ->expects($this->at(1))
             ->method('readLine')
-            ->will($this->returnValue('$3'));
+            ->willReturn('$3');
         $connection
             ->expects($this->at(2))
             ->method('readBuffer')
-            ->will($this->returnValue("foo\r\n"));
+            ->willReturn("foo\r\n");
         $connection
             ->expects($this->at(3))
             ->method('readLine')
-            ->will($this->returnValue('$3'));
+            ->willReturn('$3');
         $connection
             ->expects($this->at(4))
             ->method('readBuffer')
-            ->will($this->returnValue("bar\r\n"));
+            ->willReturn("bar\r\n");
 
         $handler = new Handler\MultiBulkResponse();
 

--- a/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
@@ -27,23 +27,23 @@ class MultiBulkResponseTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('getProtocol')
-            ->willReturn(new CompositeProtocolProcessor());
+            ->willReturn(
+                new CompositeProtocolProcessor()
+            );
         $connection
-            ->expects($this->at(1))
+            ->expects($this->exactly(2))
             ->method('readLine')
-            ->willReturn('$3');
+            ->willReturnOnConsecutiveCalls(
+                '$3',
+                '$3'
+            );
         $connection
-            ->expects($this->at(2))
+            ->expects($this->exactly(2))
             ->method('readBuffer')
-            ->willReturn("foo\r\n");
-        $connection
-            ->expects($this->at(3))
-            ->method('readLine')
-            ->willReturn('$3');
-        $connection
-            ->expects($this->at(4))
-            ->method('readBuffer')
-            ->willReturn("bar\r\n");
+            ->willReturnOnConsecutiveCalls(
+                "foo\r\n",
+                "bar\r\n"
+            );
 
         $handler = new Handler\MultiBulkResponse();
 

--- a/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/MultiBulkResponseTest.php
@@ -21,7 +21,7 @@ class MultiBulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testMultiBulk()
+    public function testMultiBulk(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -53,7 +53,7 @@ class MultiBulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testNull()
+    public function testNull(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -71,7 +71,7 @@ class MultiBulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Cannot parse 'invalid' as a valid length of a multi-bulk response [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/Handler/StatusResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/StatusResponseTest.php
@@ -21,7 +21,7 @@ class StatusResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOk()
+    public function testOk(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -41,7 +41,7 @@ class StatusResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testQueued()
+    public function testQueued(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -61,7 +61,7 @@ class StatusResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPlainString()
+    public function testPlainString(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection

--- a/tests/Predis/Protocol/Text/Handler/StreamableMultiBulkResponseTest.php
+++ b/tests/Predis/Protocol/Text/Handler/StreamableMultiBulkResponseTest.php
@@ -21,9 +21,9 @@ class StreamableMultiBulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testOk()
+    public function testOk(): void
     {
-        $connection = $this->getMockBuilder('Predis\Connection\CompositeConnectionInterface')->getMock();
+        $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
             ->expects($this->never())
             ->method('readLine');
@@ -39,7 +39,7 @@ class StreamableMultiBulkResponseTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Cannot parse 'invalid' as a valid length for a multi-bulk response [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
+++ b/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
@@ -57,25 +57,15 @@ class ProtocolProcessorTest extends PredisTestCase
 
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
-            ->expects($this->at(0))
+            ->expects($this->exactly(5))
             ->method('readLine')
-            ->willReturn('+OK');
-        $connection
-            ->expects($this->at(1))
-            ->method('readLine')
-            ->willReturn('-ERR error message');
-        $connection
-            ->expects($this->at(2))
-            ->method('readLine')
-            ->willReturn(':2');
-        $connection
-            ->expects($this->at(3))
-            ->method('readLine')
-            ->willReturn('$-1');
-        $connection
-            ->expects($this->at(4))
-            ->method('readLine')
-            ->willReturn('*-1');
+            ->willReturnOnConsecutiveCalls(
+                '+OK',
+                '-ERR error message',
+                ':2',
+                '$-1',
+                '*-1'
+            );
 
         $this->assertEquals('OK', $protocol->read($connection));
         $this->assertEquals('ERR error message', $protocol->read($connection));

--- a/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
+++ b/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
@@ -33,11 +33,11 @@ class ProtocolProcessorTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getId')
-            ->will($this->returnValue('PING'));
+            ->willReturn('PING');
         $command
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -59,23 +59,23 @@ class ProtocolProcessorTest extends PredisTestCase
         $connection
             ->expects($this->at(0))
             ->method('readLine')
-            ->will($this->returnValue('+OK'));
+            ->willReturn('+OK');
         $connection
             ->expects($this->at(1))
             ->method('readLine')
-            ->will($this->returnValue('-ERR error message'));
+            ->willReturn('-ERR error message');
         $connection
             ->expects($this->at(2))
             ->method('readLine')
-            ->will($this->returnValue(':2'));
+            ->willReturn(':2');
         $connection
             ->expects($this->at(3))
             ->method('readLine')
-            ->will($this->returnValue('$-1'));
+            ->willReturn('$-1');
         $connection
             ->expects($this->at(4))
             ->method('readLine')
-            ->will($this->returnValue('*-1'));
+            ->willReturn('*-1');
 
         $this->assertEquals('OK', $protocol->read($connection));
         $this->assertEquals('ERR error message', $protocol->read($connection));
@@ -96,7 +96,7 @@ class ProtocolProcessorTest extends PredisTestCase
         $connection
             ->expects($this->once(4))
             ->method('readLine')
-            ->will($this->returnValue('*1'));
+            ->willReturn('*1');
 
         $this->assertInstanceOf('Predis\Response\Iterator\MultiBulk', $protocol->read($connection));
     }
@@ -115,7 +115,7 @@ class ProtocolProcessorTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readLine')
-            ->will($this->returnValue('!'));
+            ->willReturn('!');
 
         $protocol->read($connection);
     }

--- a/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
+++ b/tests/Predis/Protocol/Text/ProtocolProcessorTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Protocol\Text;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\CommandInterface;
 
 /**
  *
@@ -21,11 +23,12 @@ class ProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectionWrite()
+    public function testConnectionWrite(): void
     {
         $serialized = "*1\r\n$4\r\nPING\r\n";
         $protocol = new ProtocolProcessor();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->once())
@@ -48,7 +51,7 @@ class ProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConnectionRead()
+    public function testConnectionRead(): void
     {
         $protocol = new ProtocolProcessor();
 
@@ -84,7 +87,7 @@ class ProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIterableMultibulkSupport()
+    public function testIterableMultibulkSupport(): void
     {
         $protocol = new ProtocolProcessor();
         $protocol->useIterableMultibulk(true);
@@ -101,7 +104,7 @@ class ProtocolProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnknownResponsePrefix()
+    public function testUnknownResponsePrefix(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Unknown response prefix: '!' [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/RequestSerializerTest.php
+++ b/tests/Predis/Protocol/Text/RequestSerializerTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Protocol\Text;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\CommandInterface;
 
 /**
  *
@@ -21,10 +23,11 @@ class RequestSerializerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSerializerIdWithNoArguments()
+    public function testSerializerIdWithNoArguments(): void
     {
         $serializer = new RequestSerializer();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->once())
@@ -43,10 +46,11 @@ class RequestSerializerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSerializerIdWithArguments()
+    public function testSerializerIdWithArguments(): void
     {
         $serializer = new RequestSerializer();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->once())
@@ -65,10 +69,11 @@ class RequestSerializerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSerializerDoesNotBreakOnArgumentsWithHoles()
+    public function testSerializerDoesNotBreakOnArgumentsWithHoles(): void
     {
         $serializer = new RequestSerializer();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->once())

--- a/tests/Predis/Protocol/Text/RequestSerializerTest.php
+++ b/tests/Predis/Protocol/Text/RequestSerializerTest.php
@@ -32,11 +32,11 @@ class RequestSerializerTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getId')
-            ->will($this->returnValue('PING'));
+            ->willReturn('PING');
         $command
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array()));
+            ->willReturn(array());
 
         $result = $serializer->serialize($command);
 
@@ -55,11 +55,11 @@ class RequestSerializerTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getId')
-            ->will($this->returnValue('SET'));
+            ->willReturn('SET');
         $command
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array('key', 'value')));
+            ->willReturn(array('key', 'value'));
 
         $result = $serializer->serialize($command);
 
@@ -78,11 +78,11 @@ class RequestSerializerTest extends PredisTestCase
         $command
             ->expects($this->once())
             ->method('getId')
-            ->will($this->returnValue('DEL'));
+            ->willReturn('DEL');
         $command
             ->expects($this->once())
             ->method('getArguments')
-            ->will($this->returnValue(array(0 => 'key:1', 2 => 'key:2')));
+            ->willReturn(array(0 => 'key:1', 2 => 'key:2'));
 
         $result = $serializer->serialize($command);
 

--- a/tests/Predis/Protocol/Text/ResponseReaderTest.php
+++ b/tests/Predis/Protocol/Text/ResponseReaderTest.php
@@ -56,25 +56,15 @@ class ResponseReaderTest extends PredisTestCase
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
-            ->expects($this->at(0))
+            ->expects($this->exactly(5))
             ->method('readLine')
-            ->willReturn('+OK');
-        $connection
-            ->expects($this->at(1))
-            ->method('readLine')
-            ->willReturn('-ERR error message');
-        $connection
-            ->expects($this->at(2))
-            ->method('readLine')
-            ->willReturn(':2');
-        $connection
-            ->expects($this->at(3))
-            ->method('readLine')
-            ->willReturn('$-1');
-        $connection
-            ->expects($this->at(4))
-            ->method('readLine')
-            ->willReturn('*-1');
+            ->willReturnOnConsecutiveCalls(
+                '+OK',
+                '-ERR error message',
+                ':2',
+                '$-1',
+                '*-1'
+            );
 
         $reader = new ResponseReader();
 

--- a/tests/Predis/Protocol/Text/ResponseReaderTest.php
+++ b/tests/Predis/Protocol/Text/ResponseReaderTest.php
@@ -12,6 +12,7 @@
 namespace Predis\Protocol\Text;
 
 use PredisTestCase;
+use Predis\Protocol\Text\Handler\ResponseHandlerInterface;
 
 /**
  *
@@ -21,7 +22,7 @@ class ResponseReaderTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultHandlers()
+    public function testDefaultHandlers(): void
     {
         $reader = new ResponseReader();
 
@@ -37,8 +38,9 @@ class ResponseReaderTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReplaceHandler()
+    public function testReplaceHandler(): void
     {
+        /** @var ResponseHandlerInterface */
         $handler = $this->getMockBuilder('Predis\Protocol\Text\Handler\ResponseHandlerInterface')->getMock();
 
         $reader = new ResponseReader();
@@ -50,7 +52,7 @@ class ResponseReaderTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadResponse()
+    public function testReadResponse(): void
     {
         $connection = $this->getMockConnectionOfType('Predis\Connection\CompositeConnectionInterface');
         $connection
@@ -86,7 +88,7 @@ class ResponseReaderTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testEmptyResponseHeader()
+    public function testEmptyResponseHeader(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage('Unexpected empty reponse header [tcp://127.0.0.1:6379]');
@@ -104,7 +106,7 @@ class ResponseReaderTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnknownResponsePrefix()
+    public function testUnknownResponsePrefix(): void
     {
         $this->expectException('Predis\Protocol\ProtocolException');
         $this->expectExceptionMessage("Unknown response prefix: '!' [tcp://127.0.0.1:6379]");

--- a/tests/Predis/Protocol/Text/ResponseReaderTest.php
+++ b/tests/Predis/Protocol/Text/ResponseReaderTest.php
@@ -58,23 +58,23 @@ class ResponseReaderTest extends PredisTestCase
         $connection
             ->expects($this->at(0))
             ->method('readLine')
-            ->will($this->returnValue('+OK'));
+            ->willReturn('+OK');
         $connection
             ->expects($this->at(1))
             ->method('readLine')
-            ->will($this->returnValue('-ERR error message'));
+            ->willReturn('-ERR error message');
         $connection
             ->expects($this->at(2))
             ->method('readLine')
-            ->will($this->returnValue(':2'));
+            ->willReturn(':2');
         $connection
             ->expects($this->at(3))
             ->method('readLine')
-            ->will($this->returnValue('$-1'));
+            ->willReturn('$-1');
         $connection
             ->expects($this->at(4))
             ->method('readLine')
-            ->will($this->returnValue('*-1'));
+            ->willReturn('*-1');
 
         $reader = new ResponseReader();
 
@@ -97,7 +97,7 @@ class ResponseReaderTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readLine')
-            ->will($this->returnValue(''));
+            ->willReturn('');
 
         $reader = new ResponseReader();
         $reader->read($connection);
@@ -115,7 +115,7 @@ class ResponseReaderTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('readLine')
-            ->will($this->returnValue('!'));
+            ->willReturn('!');
 
         $reader = new ResponseReader();
         $reader->read($connection);

--- a/tests/Predis/PubSub/ConsumerTest.php
+++ b/tests/Predis/PubSub/ConsumerTest.php
@@ -11,9 +11,9 @@
 
 namespace Predis\PubSub;
 
+use PredisTestCase;
 use Predis\Client;
 use Predis\PubSub\Consumer as PubSubConsumer;
-use PredisTestCase;
 
 /**
  * @group realm-pubsub
@@ -23,7 +23,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubConsumerRequirePubSubRelatedCommand()
+    public function testPubSubConsumerRequirePubSubRelatedCommand(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('PUB/SUB commands are not supported by the current command factory.');
@@ -42,7 +42,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testPubSubConsumerDoesNotWorkOnClusters()
+    public function testPubSubConsumerDoesNotWorkOnClusters(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('Cannot initialize a PUB/SUB consumer over aggregate connections');
@@ -56,12 +56,13 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithoutSubscriptionsDoesNotStartConsumer()
+    public function testConstructorWithoutSubscriptionsDoesNotStartConsumer(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('executeCommand'))
+            ->onlyMethods(array('executeCommand'))
             ->setConstructorArgs(array($connection))
             ->getMock();
 
@@ -74,15 +75,17 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testConstructorWithSubscriptionsStartsConsumer()
+    public function testConstructorWithSubscriptionsStartsConsumer(): void
     {
         $commands = $this->getCommandFactory();
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection->expects($this->exactly(2))->method('writeRequest');
 
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('createCommand', 'writeRequest'))
+            ->onlyMethods(array('createCommand'))
+            ->addMethods(array('writeRequest'))
             ->setConstructorArgs(array($connection))
             ->getMock();
         $client
@@ -101,12 +104,13 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStoppingConsumerWithTrueClosesConnection()
+    public function testStoppingConsumerWithTrueClosesConnection(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('disconnect'))
+            ->onlyMethods(array('disconnect'))
             ->setConstructorArgs(array($connection))
             ->getMock();
         $client
@@ -123,7 +127,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStoppingConsumerWithFalseSendsUnsubscriptions()
+    public function testStoppingConsumerWithFalseSendsUnsubscriptions(): void
     {
         $commands = $this->getCommandFactory();
         $classUnsubscribe = $commands->getCommandClass('unsubscribe');
@@ -131,8 +135,9 @@ class ConsumerTest extends PredisTestCase
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('disconnect'))
+            ->onlyMethods(array('disconnect'))
             ->setConstructorArgs(array($connection))
             ->getMock();
 
@@ -153,11 +158,13 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsNotValidWhenNotSubscribed()
+    public function testIsNotValidWhenNotSubscribed(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
+
+        /** @var Client */
         $client = $this->getMockBuilder('Predis\Client')
-            ->setMethods(array('disconnect'))
+            ->onlyMethods(array('disconnect'))
             ->setConstructorArgs(array($connection))
             ->getMock();
 
@@ -170,7 +177,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHandlesPongMessages()
+    public function testHandlesPongMessages(): void
     {
         $rawmessage = array('pong', '');
 
@@ -191,7 +198,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHandlesPongMessagesWithPayload()
+    public function testHandlesPongMessagesWithPayload(): void
     {
         $rawmessage = array('pong', 'foobar');
 
@@ -212,7 +219,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsMessageFromConnection()
+    public function testReadsMessageFromConnection(): void
     {
         $rawmessage = array('message', 'channel:foo', 'message from channel');
 
@@ -234,7 +241,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsPmessageFromConnection()
+    public function testReadsPmessageFromConnection(): void
     {
         $rawmessage = array('pmessage', 'channel:*', 'channel:foo', 'message from channel');
 
@@ -257,7 +264,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsSubscriptionMessageFromConnection()
+    public function testReadsSubscriptionMessageFromConnection(): void
     {
         $rawmessage = array('subscribe', 'channel:foo', 1);
 
@@ -279,7 +286,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadsUnsubscriptionMessageFromConnection()
+    public function testReadsUnsubscriptionMessageFromConnection(): void
     {
         $rawmessage = array('unsubscribe', 'channel:foo', 1);
 
@@ -301,7 +308,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnsubscriptionMessageWithZeroChannelCountInvalidatesConsumer()
+    public function testUnsubscriptionMessageWithZeroChannelCountInvalidatesConsumer(): void
     {
         $rawmessage = array('unsubscribe', 'channel:foo', 0);
 
@@ -327,7 +334,7 @@ class ConsumerTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGetUnderlyingClientInstance()
+    public function testGetUnderlyingClientInstance(): void
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
 
@@ -355,7 +362,7 @@ class ConsumerTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testPubSubAgainstRedisServer()
+    public function testPubSubAgainstRedisServer(): void
     {
         if (getenv('GITHUB_ACTIONS') || getenv('TRAVIS')) {
             $this->markTestSkipped(
@@ -364,9 +371,9 @@ class ConsumerTest extends PredisTestCase
         }
 
         $parameters = array(
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             // Prevents suite from handing on broken test
             'read_write_timeout' => 2,
         );
@@ -406,7 +413,7 @@ class ConsumerTest extends PredisTestCase
      * @requiresRedisVersion >= 2.0.0
      * @requires extension pcntl
      */
-    public function testPubSubAgainstRedisServerBlocking()
+    public function testPubSubAgainstRedisServerBlocking(): void
     {
         if (getenv('GITHUB_ACTIONS') || getenv('TRAVIS')) {
             $this->markTestSkipped(
@@ -415,9 +422,9 @@ class ConsumerTest extends PredisTestCase
         }
 
         $parameters = array(
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             'read_write_timeout' => -1, // -1 to set blocking reads
         );
 

--- a/tests/Predis/PubSub/ConsumerTest.php
+++ b/tests/Predis/PubSub/ConsumerTest.php
@@ -32,7 +32,7 @@ class ConsumerTest extends PredisTestCase
         $commands
             ->expects($this->any())
             ->method('supports')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $client = new Client(null, array('commands' => $commands));
 
@@ -92,9 +92,9 @@ class ConsumerTest extends PredisTestCase
             ->expects($this->exactly(2))
             ->method('createCommand')
             ->with($this->logicalOr($this->equalTo('subscribe'), $this->equalTo('psubscribe')))
-            ->will($this->returnCallback(function ($id, $args) use ($commands) {
+            ->willReturnCallback(function ($id, $args) use ($commands) {
                 return $commands->create($id, $args);
-            }));
+            });
 
         $options = array('subscribe' => 'channel:foo', 'psubscribe' => 'channels:*');
 
@@ -185,7 +185,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));
@@ -206,7 +206,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));
@@ -227,7 +227,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));
@@ -249,7 +249,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('psubscribe' => 'channel:*'));
@@ -272,7 +272,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));
@@ -294,7 +294,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));
@@ -316,7 +316,7 @@ class ConsumerTest extends PredisTestCase
         $connection
             ->expects($this->once())
             ->method('read')
-            ->will($this->returnValue($rawmessage));
+            ->willReturn($rawmessage);
 
         $client = new Client($connection);
         $pubsub = new PubSubConsumer($client, array('subscribe' => 'channel:foo'));

--- a/tests/Predis/PubSub/DispatcherLoopTest.php
+++ b/tests/Predis/PubSub/DispatcherLoopTest.php
@@ -11,8 +11,8 @@
 
 namespace Predis\PubSub;
 
-use Predis\Client;
 use PredisTestCase;
+use Predis\Client;
 
 /**
  * @group realm-pubsub
@@ -27,12 +27,12 @@ class DispatcherLoopTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDispatcherLoopAgainstRedisServer()
+    public function testDispatcherLoopAgainstRedisServer(): void
     {
         $parameters = array(
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             // Prevents suite from hanging on broken test
             'read_write_timeout' => 2,
         );
@@ -47,7 +47,7 @@ class DispatcherLoopTest extends PredisTestCase
         $dispatcher = new DispatcherLoop($pubsub);
 
         $function01 = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $function01
             ->expects($this->exactly(2))
@@ -63,7 +63,7 @@ class DispatcherLoopTest extends PredisTestCase
             }));
 
         $function02 = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $function02
             ->expects($this->once())
@@ -71,7 +71,7 @@ class DispatcherLoopTest extends PredisTestCase
             ->with('02:argument');
 
         $function03 = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $function03
             ->expects($this->never())
@@ -94,12 +94,12 @@ class DispatcherLoopTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testDispatcherLoopAgainstRedisServerWithPrefix()
+    public function testDispatcherLoopAgainstRedisServerWithPrefix(): void
     {
         $parameters = array(
-            'host' => REDIS_SERVER_HOST,
-            'port' => REDIS_SERVER_PORT,
-            'database' => REDIS_SERVER_DBNUM,
+            'host' => constant('REDIS_SERVER_HOST'),
+            'port' => constant('REDIS_SERVER_PORT'),
+            'database' => constant('REDIS_SERVER_DBNUM'),
             // Prevents suite from handing on broken test
             'read_write_timeout' => 2,
         );
@@ -116,7 +116,7 @@ class DispatcherLoopTest extends PredisTestCase
         $dispatcher = new DispatcherLoop($pubsub);
 
         $callback = $this->getMockBuilder('stdClass')
-            ->setMethods(array('__invoke'))
+            ->addMethods(array('__invoke'))
             ->getMock();
         $callback
             ->expects($this->exactly(1))

--- a/tests/Predis/PubSub/DispatcherLoopTest.php
+++ b/tests/Predis/PubSub/DispatcherLoopTest.php
@@ -56,11 +56,11 @@ class DispatcherLoopTest extends PredisTestCase
                 $this->equalTo('01:argument'),
                 $this->equalTo('01:quit')
             ), $dispatcher)
-            ->will($this->returnCallback(function ($arg, $dispatcher) {
+            ->willReturnCallback(function ($arg, $dispatcher) {
                 if ($arg === '01:quit') {
                     $dispatcher->stop();
                 }
-            }));
+            });
 
         $function02 = $this->getMockBuilder('stdClass')
             ->addMethods(array('__invoke'))
@@ -122,9 +122,9 @@ class DispatcherLoopTest extends PredisTestCase
             ->expects($this->exactly(1))
             ->method('__invoke')
             ->with($this->equalTo('arg:prefixed'), $dispatcher)
-            ->will($this->returnCallback(function ($arg, $dispatcher) {
+            ->willReturnCallback(function ($arg, $dispatcher) {
                 $dispatcher->stop();
-            }));
+            });
 
         $dispatcher->attachCallback('callback', $callback);
 

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -12,6 +12,8 @@
 namespace Predis\Replication;
 
 use PredisTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\CommandInterface;
 
 /**
  *
@@ -21,7 +23,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testReadCommands()
+    public function testReadCommands(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -39,7 +41,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testWriteRequests()
+    public function testWriteRequests(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -57,7 +59,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDisallowedCommands()
+    public function testDisallowedCommands(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -75,7 +77,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSortCommand()
+    public function testSortCommand(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -96,7 +98,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testBitFieldCommand()
+    public function testBitFieldCommand(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -141,7 +143,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGeoradiusCommand()
+    public function testGeoradiusCommand(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -168,7 +170,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testGeoradiusByMemberCommand()
+    public function testGeoradiusByMemberCommand(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -195,7 +197,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUsingDisallowedCommandThrowsException()
+    public function testUsingDisallowedCommandThrowsException(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage("The command 'INFO' is not allowed in replication mode");
@@ -210,10 +212,11 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testDefaultIsWriteOperation()
+    public function testDefaultIsWriteOperation(): void
     {
         $strategy = new ReplicationStrategy();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->any())
@@ -226,10 +229,11 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSetCommandAsReadOperation()
+    public function testCanSetCommandAsReadOperation(): void
     {
         $strategy = new ReplicationStrategy();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->any())
@@ -243,10 +247,11 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanSetCommandAsWriteOperation()
+    public function testCanSetCommandAsWriteOperation(): void
     {
         $strategy = new ReplicationStrategy();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')->getMock();
         $command
             ->expects($this->any())
@@ -263,12 +268,12 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanUseCallableToCheckCommand()
+    public function testCanUseCallableToCheckCommand(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
 
-        $strategy->setCommandReadOnly('SET', function ($command) {
+        $strategy->setCommandReadOnly('SET', function (CommandInterface $command) {
             return $command->getArgument(1) === true;
         });
 
@@ -282,7 +287,7 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetLuaScriptAsReadOperation()
+    public function testSetLuaScriptAsReadOperation(): void
     {
         $commands = $this->getCommandFactory();
         $strategy = new ReplicationStrategy();
@@ -306,19 +311,20 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetLuaScriptAsReadOperationWorksWithScriptCommand()
+    public function testSetLuaScriptAsReadOperationWorksWithScriptCommand(): void
     {
         $strategy = new ReplicationStrategy();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript'))
+            ->onlyMethods(array('getScript'))
             ->getMock();
         $command
             ->expects($this->any())
             ->method('getScript')
             ->will($this->returnValue($script = 'return true'));
 
-        $strategy->setScriptReadOnly($script, function ($command) {
+        $strategy->setScriptReadOnly($script, function (CommandInterface $command) {
             return $command->getArgument(2) === true;
         });
 
@@ -332,12 +338,13 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSetLuaScriptAsReadOperationWorksWithScriptCommandAndCallableCheck()
+    public function testSetLuaScriptAsReadOperationWorksWithScriptCommandAndCallableCheck(): void
     {
         $strategy = new ReplicationStrategy();
 
+        /** @var CommandInterface|MockObject */
         $command = $this->getMockBuilder('Predis\Command\ScriptCommand')
-            ->setMethods(array('getScript'))
+            ->onlyMethods(array('getScript'))
             ->getMock(array('getScript'));
         $command
             ->expects($this->any())
@@ -358,11 +365,11 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * Returns the list of expected supported commands.
      *
-     * @param string $type Optional type of command (based on its keys)
+     * @param ?string $type Optional type of command (based on its keys)
      *
      * @return array
      */
-    protected function getExpectedCommands($type = null)
+    protected function getExpectedCommands(?string $type = null): array
     {
         $commands = array(
             /* commands operating on the connection */
@@ -512,7 +519,7 @@ class ReplicationStrategyTest extends PredisTestCase
         );
 
         if (isset($type)) {
-            $commands = array_filter($commands, function ($expectedType) use ($type) {
+            $commands = array_filter($commands, function (string $expectedType) use ($type) {
                 return $expectedType === $type;
             });
         }

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -221,7 +221,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $command
             ->expects($this->any())
             ->method('getId')
-            ->will($this->returnValue('CMDTEST'));
+            ->willReturn('CMDTEST');
 
         $this->assertFalse($strategy->isReadOperation($command));
     }
@@ -238,7 +238,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $command
             ->expects($this->any())
             ->method('getId')
-            ->will($this->returnValue('CMDTEST'));
+            ->willReturn('CMDTEST');
 
         $strategy->setCommandReadOnly('CMDTEST', true);
         $this->assertTrue($strategy->isReadOperation($command));
@@ -256,7 +256,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $command
             ->expects($this->any())
             ->method('getId')
-            ->will($this->returnValue('CMDTEST'));
+            ->willReturn('CMDTEST');
 
         $strategy->setCommandReadOnly('CMDTEST', false);
         $this->assertFalse($strategy->isReadOperation($command));
@@ -322,7 +322,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $command
             ->expects($this->any())
             ->method('getScript')
-            ->will($this->returnValue($script = 'return true'));
+            ->willReturn($script = 'return true');
 
         $strategy->setScriptReadOnly($script, function (CommandInterface $command) {
             return $command->getArgument(2) === true;
@@ -349,7 +349,7 @@ class ReplicationStrategyTest extends PredisTestCase
         $command
             ->expects($this->any())
             ->method('getScript')
-            ->will($this->returnValue($script = 'return true'));
+            ->willReturn($script = 'return true');
 
         $command->setArguments(array('trigger', false));
 

--- a/tests/Predis/Response/ErrorTest.php
+++ b/tests/Predis/Response/ErrorTest.php
@@ -23,7 +23,7 @@ class ErrorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testResponseErrorClass()
+    public function testResponseErrorClass(): void
     {
         $error = new Error(self::ERR_WRONG_KEY_TYPE);
 
@@ -34,7 +34,7 @@ class ErrorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testErrorMessage()
+    public function testErrorMessage(): void
     {
         $error = new Error(self::ERR_WRONG_KEY_TYPE);
 
@@ -44,7 +44,7 @@ class ErrorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testErrorType()
+    public function testErrorType(): void
     {
         $exception = new Error(self::ERR_WRONG_KEY_TYPE);
 
@@ -54,7 +54,7 @@ class ErrorTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToString()
+    public function testToString(): void
     {
         $error = new Error(self::ERR_WRONG_KEY_TYPE);
 

--- a/tests/Predis/Response/Iterator/MultiBulkTest.php
+++ b/tests/Predis/Response/Iterator/MultiBulkTest.php
@@ -11,10 +11,11 @@
 
 namespace Predis\Response\Iterator;
 
+use PredisTestCase;
 use Predis\Client;
+use Predis\ClientInterface;
 use Predis\Connection\CompositeStreamConnection;
 use Predis\Protocol\Text\ProtocolProcessor as TextProtocolProcessor;
-use PredisTestCase;
 
 /**
  * @group realm-iterators
@@ -24,13 +25,15 @@ class MultiBulkTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIterableMultibulk()
+    public function testIterableMultibulk(): void
     {
         $client = $this->getClient();
         $client->rpush('metavars', 'foo', 'hoge', 'lol');
 
+        /** @var MultiBulkIterator */
         $this->assertInstanceOf('Iterator', $iterator = $client->lrange('metavars', 0, -1));
         $this->assertInstanceOf('Predis\Response\Iterator\MultiBulk', $iterator);
+
         $iterator->valid();
         $this->assertSame(3, $iterator->count());
 
@@ -52,11 +55,12 @@ class MultiBulkTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testDropWithFalseConsumesResponseFromUnderlyingConnection()
+    public function testDropWithFalseConsumesResponseFromUnderlyingConnection(): void
     {
         $client = $this->getClient();
         $client->rpush('metavars', 'foo', 'hoge', 'lol');
 
+        /** @var MultiBulkIterMultiBulkator */
         $iterator = $client->lrange('metavars', 0, -1);
         $iterator->drop(false);
 
@@ -67,11 +71,12 @@ class MultiBulkTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testDropWithTrueDropsUnderlyingConnection()
+    public function testDropWithTrueDropsUnderlyingConnection(): void
     {
         $client = $this->getClient();
         $client->rpush('metavars', 'foo', 'hoge', 'lol');
 
+        /** @var MultiBulk */
         $iterator = $client->lrange('metavars', 0, -1);
         $iterator->drop(true);
 
@@ -82,11 +87,12 @@ class MultiBulkTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testGarbageCollectorDropsUnderlyingConnection()
+    public function testGarbageCollectorDropsUnderlyingConnection(): void
     {
         $client = $this->getClient();
         $client->rpush('metavars', 'foo', 'hoge', 'lol');
 
+        /** @var MultiBulkIterator */
         $iterator = $client->lrange('metavars', 0, -1);
 
         unset($iterator);
@@ -102,9 +108,9 @@ class MultiBulkTest extends PredisTestCase
     /**
      * Returns a new client instance.
      *
-     * @return Client
+     * @return ClientInterface
      */
-    protected function getClient()
+    protected function getClient(): ClientInterface
     {
         $parameters = $this->getParameters(array('read_write_timeout' => 2));
 

--- a/tests/Predis/Response/ServerExceptionTest.php
+++ b/tests/Predis/Response/ServerExceptionTest.php
@@ -23,7 +23,7 @@ class ServerExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionMessage()
+    public function testExceptionMessage(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage(self::ERR_WRONG_KEY_TYPE);
@@ -34,7 +34,7 @@ class ServerExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionClass()
+    public function testExceptionClass(): void
     {
         $exception = new ServerException(self::ERR_WRONG_KEY_TYPE);
 
@@ -47,7 +47,7 @@ class ServerExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testErrorType()
+    public function testErrorType(): void
     {
         $exception = new ServerException(self::ERR_WRONG_KEY_TYPE);
 
@@ -57,7 +57,7 @@ class ServerExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testToErrorResponse()
+    public function testToErrorResponse(): void
     {
         $exception = new ServerException(self::ERR_WRONG_KEY_TYPE);
         $error = $exception->toErrorResponse();

--- a/tests/Predis/Response/StatusTest.php
+++ b/tests/Predis/Response/StatusTest.php
@@ -21,7 +21,7 @@ class StatusTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStatusResponse()
+    public function testStatusResponse(): void
     {
         $status = new Status('OK');
 
@@ -32,7 +32,7 @@ class StatusTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStatusToString()
+    public function testStatusToString(): void
     {
         $queued = new Status('OK');
 
@@ -43,7 +43,7 @@ class StatusTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStaticGetMethod()
+    public function testStaticGetMethod(): void
     {
         $this->assertInstanceOf('Predis\Response\Status', $response = Status::get('OK'));
         $this->assertEquals('OK', $response);
@@ -58,7 +58,7 @@ class StatusTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStaticGetMethodCachesOnlyCommonStatuses()
+    public function testStaticGetMethodCachesOnlyCommonStatuses(): void
     {
         $response = Status::get('OK');
         $this->assertSame($response, Status::get('OK'));

--- a/tests/Predis/Transaction/AbortedMultiExecExceptionTest.php
+++ b/tests/Predis/Transaction/AbortedMultiExecExceptionTest.php
@@ -11,8 +11,8 @@
 
 namespace Predis\Transaction;
 
-use Predis\Client;
 use PredisTestCase;
+use Predis\Client;
 
 /**
  *
@@ -22,7 +22,7 @@ class AbortedMultiExecExceptionTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionClass()
+    public function testExceptionClass(): void
     {
         $client = new Client();
         $transaction = new MultiExec($client);

--- a/tests/Predis/Transaction/MultiExecStateTest.php
+++ b/tests/Predis/Transaction/MultiExecStateTest.php
@@ -21,7 +21,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testFlagsValues()
+    public function testFlagsValues(): void
     {
         $this->assertSame(1,  MultiExecState::INITIALIZED);
         $this->assertSame(2,  MultiExecState::INSIDEBLOCK);
@@ -33,7 +33,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testStateConstructorStartsWithResetState()
+    public function testStateConstructorStartsWithResetState(): void
     {
         $state = new MultiExecState();
 
@@ -44,7 +44,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanCheckOneOrMoreStateFlags()
+    public function testCanCheckOneOrMoreStateFlags(): void
     {
         $flags = MultiExecState::INITIALIZED | MultiExecState::CAS;
         $state = new MultiExecState();
@@ -63,7 +63,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSettingAndGettingWholeFlags()
+    public function testSettingAndGettingWholeFlags(): void
     {
         $flags = MultiExecState::INITIALIZED | MultiExecState::CAS;
         $state = new MultiExecState();
@@ -78,7 +78,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanFlagSingleStates()
+    public function testCanFlagSingleStates(): void
     {
         $flags = MultiExecState::INITIALIZED | MultiExecState::CAS;
         $state = new MultiExecState();
@@ -97,7 +97,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCanUnflagSingleStates()
+    public function testCanUnflagSingleStates(): void
     {
         $state = new MultiExecState();
         $state->set(MultiExecState::INITIALIZED | MultiExecState::CAS);
@@ -119,7 +119,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsInitializedMethod()
+    public function testIsInitializedMethod(): void
     {
         $state = new MultiExecState();
 
@@ -132,7 +132,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsExecuting()
+    public function testIsExecuting(): void
     {
         $state = new MultiExecState();
 
@@ -145,7 +145,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsCAS()
+    public function testIsCAS(): void
     {
         $state = new MultiExecState();
 
@@ -158,7 +158,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsWatchAllowed()
+    public function testIsWatchAllowed(): void
     {
         $state = new MultiExecState();
 
@@ -177,7 +177,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsWatching()
+    public function testIsWatching(): void
     {
         $state = new MultiExecState();
 
@@ -190,7 +190,7 @@ class MultiExecStateTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testIsDiscarded()
+    public function testIsDiscarded(): void
     {
         $state = new MultiExecState();
 

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -37,7 +37,7 @@ class MultiExecTest extends PredisTestCase
             ->expects($this->once())
             ->method('supports')
             ->with('MULTI', 'EXEC', 'DISCARD')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $client = new Client($connection, array('commands' => $commands));
@@ -844,7 +844,7 @@ class MultiExecTest extends PredisTestCase
         $connection
             ->expects($this->any())
             ->method('executeCommand')
-            ->will($this->returnCallback($executeCallback));
+            ->willReturnCallback($executeCallback);
 
         return $connection;
     }

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -11,10 +11,13 @@
 
 namespace Predis\Transaction;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Client;
-use Predis\Command\CommandInterface;
-use Predis\Response;
+use Predis\ClientInterface;
 use PredisTestCase;
+use Predis\Response;
+use Predis\Command\CommandInterface;
+use Predis\Connection\NodeConnectionInterface;
 
 /**
  * @group realm-transaction
@@ -24,7 +27,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnUnsupportedMultiExecInCommandFactory()
+    public function testThrowsExceptionOnUnsupportedMultiExecInCommandFactory(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('MULTI, EXEC and DISCARD are not supported by the current command factory.');
@@ -45,7 +48,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnUnsupportedWatchInCommandFactory()
+    public function testThrowsExceptionOnUnsupportedWatchInCommandFactory(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('WATCH is not supported by the current command factory.');
@@ -73,7 +76,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnUnsupportedUnwatchInCommandFactory()
+    public function testThrowsExceptionOnUnsupportedUnwatchInCommandFactory(): void
     {
         $this->expectException('Predis\NotSupportedException');
         $this->expectExceptionMessage('UNWATCH is not supported by the current command factory.');
@@ -104,7 +107,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecutionWithFluentInterface()
+    public function testExecutionWithFluentInterface(): void
     {
         $commands = array();
         $expected = array('one', 'two', 'three');
@@ -119,7 +122,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExecutionWithCallable()
+    public function testExecutionWithCallable(): void
     {
         $commands = array();
         $expected = array('one', 'two', 'three');
@@ -140,7 +143,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCannotMixExecutionWithFluentInterfaceAndCallable()
+    public function testCannotMixExecutionWithFluentInterfaceAndCallable(): void
     {
         $commands = array();
 
@@ -164,7 +167,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testEmptyTransactionDoesNotSendMultiExecCommands()
+    public function testEmptyTransactionDoesNotSendMultiExecCommands(): void
     {
         $commands = array();
 
@@ -182,7 +185,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnExecInsideTransactionBlock()
+    public function testThrowsExceptionOnExecInsideTransactionBlock(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('Cannot invoke "execute" or "exec" inside an active transaction context');
@@ -203,7 +206,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testEmptyTransactionIgnoresDiscard()
+    public function testEmptyTransactionIgnoresDiscard(): void
     {
         $commands = array();
 
@@ -221,7 +224,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testTransactionWithCommandsSendsDiscard()
+    public function testTransactionWithCommandsSendsDiscard(): void
     {
         $commands = array();
 
@@ -241,7 +244,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testSendMultiOnCommandsFollowingDiscard()
+    public function testSendMultiOnCommandsFollowingDiscard(): void
     {
         $commands = array();
         $expected = array('after DISCARD');
@@ -261,7 +264,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnWatchInsideMulti()
+    public function testThrowsExceptionOnWatchInsideMulti(): void
     {
         $this->expectException('Predis\ClientException');
 
@@ -274,7 +277,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testUnwatchInsideMulti()
+    public function testUnwatchInsideMulti(): void
     {
         $commands = array();
         $expected = array('foobar', true);
@@ -291,7 +294,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAutomaticWatchInOptions()
+    public function testAutomaticWatchInOptions(): void
     {
         $txCommands = $casCommands = array();
         $expected = array('bar', 'piyo');
@@ -313,7 +316,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCheckAndSetWithFluentInterface()
+    public function testCheckAndSetWithFluentInterface(): void
     {
         $txCommands = $casCommands = array();
         $expected = array('bar', 'piyo');
@@ -340,7 +343,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCheckAndSetWithBlock()
+    public function testCheckAndSetWithBlock(): void
     {
         $txCommands = $casCommands = array();
         $expected = array('bar', 'piyo');
@@ -373,7 +376,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCheckAndSetWithEmptyBlock()
+    public function testCheckAndSetWithEmptyBlock(): void
     {
         $txCommands = $casCommands = array();
         $options = array('cas' => true);
@@ -392,7 +395,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testCheckAndSetWithoutExec()
+    public function testCheckAndSetWithoutExec(): void
     {
         $txCommands = $casCommands = array();
         $options = array('cas' => true);
@@ -412,7 +415,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnAutomaticRetriesWithFluentInterface()
+    public function testThrowsExceptionOnAutomaticRetriesWithFluentInterface(): void
     {
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage('Automatic retries are supported only when a callable block is provided');
@@ -429,26 +432,28 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testAutomaticRetryOnServerSideTransactionAbort()
+    public function testAutomaticRetryOnServerSideTransactionAbort(): void
     {
         $casCommands = $txCommands = array();
         $expected = array('bar');
         $options = array('watch' => array('foo', 'bar'), 'retry' => ($attempts = 2) + 1);
 
-        $sentinel = $this->getMockBuilder('stdClass')
-            ->setMethods(array('signal'))
+        $signal = $this->getMockBuilder('stdClass')
+            ->addMethods(array('__invoke'))
             ->getMock();
-        $sentinel->expects($this->exactly($attempts))->method('signal');
+        $signal
+            ->expects($this->exactly($attempts))
+            ->method('__invoke');
 
         $callback = $this->getExecuteCallback($expected, $txCommands, $casCommands);
         $tx = $this->getMockedTransaction($callback, $options);
 
-        $responses = $tx->execute(function ($tx) use ($sentinel, &$attempts) {
+        $responses = $tx->execute(function (MultiExec $tx) use ($signal, &$attempts) {
             $tx->get('foo');
 
             if ($attempts > 0) {
                 $attempts -= 1;
-                $sentinel->signal();
+                $signal();
 
                 $tx->echo('!!ABORT!!');
             }
@@ -463,7 +468,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testThrowsExceptionOnServerSideTransactionAbort()
+    public function testThrowsExceptionOnServerSideTransactionAbort(): void
     {
         $this->expectException('Predis\Transaction\AbortedMultiExecException');
 
@@ -478,7 +483,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHandlesStandardExceptionsInBlock()
+    public function testHandlesStandardExceptionsInBlock(): void
     {
         $commands = array();
         $expected = array('foobar', true);
@@ -489,7 +494,7 @@ class MultiExecTest extends PredisTestCase
         $responses = null;
 
         try {
-            $responses = $tx->execute(function ($tx) {
+            $responses = $tx->execute(function (MultiExec $tx) {
                 $tx->set('foo', 'bar');
                 $tx->get('foo');
 
@@ -507,7 +512,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testHandlesServerExceptionsInBlock()
+    public function testHandlesServerExceptionsInBlock(): void
     {
         $commands = array();
         $expected = array('foobar', true);
@@ -518,7 +523,7 @@ class MultiExecTest extends PredisTestCase
         $responses = null;
 
         try {
-            $responses = $tx->execute(function ($tx) {
+            $responses = $tx->execute(function (MultiExec $tx) {
                 $tx->set('foo', 'bar');
                 $tx->echo('ERR Invalid operation');
                 $tx->get('foo');
@@ -534,7 +539,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testProperlyDiscardsTransactionAfterServerExceptionInBlock()
+    public function testProperlyDiscardsTransactionAfterServerExceptionInBlock(): void
     {
         $connection = $this->getMockedConnection(function (CommandInterface $command) {
             switch ($command->getId()) {
@@ -578,7 +583,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionsOptionTakesPrecedenceOverClientOptionsWhenFalse()
+    public function testExceptionsOptionTakesPrecedenceOverClientOptionsWhenFalse(): void
     {
         $expected = array('before', new Response\Error('ERR simulated error'), 'after');
 
@@ -611,7 +616,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionsOptionTakesPrecedenceOverClientOptionsWhenTrue()
+    public function testExceptionsOptionTakesPrecedenceOverClientOptionsWhenTrue(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR simulated error');
@@ -640,7 +645,7 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testExceptionsOptionDoesNotAffectTransactionControlCommands()
+    public function testExceptionsOptionDoesNotAffectTransactionControlCommands(): void
     {
         $this->expectException('Predis\Response\ServerException');
         $this->expectExceptionMessage('ERR simulated failure on EXEC');
@@ -671,13 +676,13 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationHandlesStandardExceptionsInBlock()
+    public function testIntegrationHandlesStandardExceptionsInBlock(): void
     {
         $client = $this->getClient();
         $exception = null;
 
         try {
-            $client->transaction(function ($tx) {
+            $client->transaction(function (MultiExec $tx) {
                 $tx->set('foo', 'bar');
                 throw new \RuntimeException('TEST');
             });
@@ -692,14 +697,14 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationThrowsExceptionOnRedisErrorInBlock()
+    public function testIntegrationThrowsExceptionOnRedisErrorInBlock(): void
     {
         $client = $this->getClient();
         $exception = null;
         $value = (string) rand();
 
         try {
-            $client->transaction(function ($tx) use ($value) {
+            $client->transaction(function (MultiExec $tx) use ($value) {
                 $tx->set('foo', 'bar');
                 $tx->lpush('foo', 'bar');
                 $tx->set('foo', $value);
@@ -715,11 +720,11 @@ class MultiExecTest extends PredisTestCase
     /**
      * @group connected
      */
-    public function testIntegrationReturnsErrorObjectOnRedisErrorInBlock()
+    public function testIntegrationReturnsErrorObjectOnRedisErrorInBlock(): void
     {
         $client = $this->getClient(array(), array('exceptions' => false));
 
-        $responses = $client->transaction(function ($tx) {
+        $responses = $client->transaction(function (MultiExec $tx) {
             $tx->set('foo', 'bar');
             $tx->lpush('foo', 'bar');
             $tx->echo('foobar');
@@ -734,11 +739,11 @@ class MultiExecTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
-    public function testIntegrationSendMultiOnCommandsAfterDiscard()
+    public function testIntegrationSendMultiOnCommandsAfterDiscard(): void
     {
         $client = $this->getClient();
 
-        $responses = $client->transaction(function ($tx) {
+        $responses = $client->transaction(function (MultiExec $tx) {
             $tx->set('foo', 'bar');
             $tx->discard();
             $tx->set('hoge', 'piyo');
@@ -753,7 +758,7 @@ class MultiExecTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testIntegrationWritesOnWatchedKeysAbortTransaction()
+    public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void
     {
         $exception = null;
         $client1 = $this->getClient();
@@ -777,7 +782,7 @@ class MultiExecTest extends PredisTestCase
      * @group connected
      * @requiresRedisVersion >= 2.2.0
      */
-    public function testIntegrationCheckAndSetWithDiscardAndRetry()
+    public function testIntegrationCheckAndSetWithDiscardAndRetry(): void
     {
         $client = $this->getClient();
 
@@ -829,11 +834,11 @@ class MultiExecTest extends PredisTestCase
      * Returns a mocked instance of Predis\Connection\NodeConnectionInterface
      * using the specified callback to return values from executeCommand().
      *
-     * @param \Closure $executeCallback
+     * @param callable $executeCallback
      *
-     * @return \Predis\Connection\NodeConnectionInterface
+     * @return NodeConnectionInterface|MockObject
      */
-    protected function getMockedConnection($executeCallback)
+    protected function getMockedConnection(callable $executeCallback)
     {
         $connection = $this->getMockBuilder('Predis\Connection\NodeConnectionInterface')->getMock();
         $connection
@@ -849,13 +854,13 @@ class MultiExecTest extends PredisTestCase
      * the specified callback to return values from the executeCommand method
      * of the underlying connection.
      *
-     * @param \Closure $executeCallback
+     * @param callable $executeCallback
      * @param array    $txOpts
      * @param array    $clientOpts
      *
      * @return MultiExec
      */
-    protected function getMockedTransaction($executeCallback, $txOpts = null, $clientOpts = null)
+    protected function getMockedTransaction($executeCallback, $txOpts = null, $clientOpts = null): MultiExec
     {
         $connection = $this->getMockedConnection($executeCallback);
         $client = new Client($connection, $clientOpts ?: array());
@@ -865,16 +870,19 @@ class MultiExecTest extends PredisTestCase
     }
 
     /**
-     * Returns a callback that emulates a server-side MULTI/EXEC transaction context.
+     * Returns a callback emulating a server-side MULTI/EXEC context.
      *
-     * @param array $expected Expected responses.
-     * @param array $commands Reference to an array storing the whole flow of commands.
-     * @param array $cas      Check and set operations performed by the transaction.
+     * @param ?array $expected List of expected responses
+     * @param ?array $commands Reference to an array storing the whole flow of commands
+     * @param ?array $cas      Reference to an array storing CAS operations performed by the transaction
      *
-     * @return \Closure
+     * @return callable
      */
-    protected function getExecuteCallback($expected = array(), &$commands = array(), &$cas = array())
-    {
+    protected function getExecuteCallback(
+        ?array $expected = array(),
+        ?array &$commands = array(),
+        ?array &$cas = array()
+    ): callable {
         $multi = $watch = $abort = false;
 
         return function (CommandInterface $command) use (&$expected, &$commands, &$cas, &$multi, &$watch, &$abort) {
@@ -949,14 +957,13 @@ class MultiExecTest extends PredisTestCase
     }
 
     /**
-     * Converts an array of instances of Predis\Command\CommandInterface and
-     * returns an array containing their IDs.
+     * Converts an array of command instances to an array of command IDs.
      *
-     * @param array $commands List of commands instances.
+     * @param CommandInterface[] $commands List of commands instances
      *
      * @return array
      */
-    protected static function commandsToIDs($commands)
+    protected static function commandsToIDs(array $commands): array
     {
         return array_map(function ($cmd) { return $cmd->getId(); }, $commands);
     }
@@ -965,12 +972,12 @@ class MultiExecTest extends PredisTestCase
      * Returns a client instance connected to the specified Redis
      * server instance to perform integration tests.
      *
-     * @param array $parameters Additional connection parameters.
-     * @param array $options    Additional client options.
+     * @param array $parameters Additional connection parameters
+     * @param array $options    Additional client options
      *
-     * @return Client
+     * @return ClientInterface
      */
-    protected function getClient(array $parameters = array(), array $options = array())
+    protected function getClient(array $parameters = array(), array $options = array()): ClientInterface
     {
         return $this->createClient($parameters, $options);
     }


### PR DESCRIPTION
Another humongous set of changes, luckily vscode and a few regexp-based search & replace helped a lot.

- Added typehints for function parameters and return values everywhere.
- Added `@var` where needed to give proper hints to IDEs and avoid annoying warnings.
- Replaced the hard deprecated `TestCase::at()`, this gets rid of 99% of the warnings on PHPUnit 9 and it's better anyway.
- Replaced `MockObject::setMethods()` (soft deprecated in PHPUnit since last year) with `addMethods()` and `onlyMethods()`.
- Replaced generic `MockObject::will()` with specialized methods like `willReturn()`, `willReturnCallback()`, etc...
- Rewording of some phpdocs descriptions and annotations.
- Took the opportunity to improve some tests while converting them.

There is still one hard deprecation warning on PHPUnit 9 about `assertRegExp()`, they say to replace it with `assertMatchesRegularExpression()` but then it gave me an error on PHPUnit 8. It's just three warnings being emitted in the output of a test run so we can leave it for now, I'll look into it later.