### PR TITLE
Implement Predis\Command\RawFactory

### DIFF
--- a/src/Command/RawFactory.php
+++ b/src/Command/RawFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) Daniele Alessandri <suppakilla@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command;
+
+/**
+ * Command factory creating raw command instances out of command IDs.
+ *
+ * Any command ID will produce a command instance even for unknown commands that
+ * are not implemented by Redis (the server will return a "-ERR unknown command"
+ * error responses).
+ *
+ * When using this factory the client does not process arguments before sending
+ * commands to Redis and server responses are not further processed before being
+ * returned to the caller.
+ *
+ * @author Daniele Alessandri <suppakilla@gmail.com>
+ */
+class RawFactory implements FactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(string ...$commandIDs): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $commandID, array $arguments = []): CommandInterface
+    {
+        return new RawCommand($commandID, $arguments);
+    }
+}

--- a/tests/Predis/Command/RawFactoryTest.php
+++ b/tests/Predis/Command/RawFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) Daniele Alessandri <suppakilla@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command;
+
+use PredisTestCase;
+
+/**
+ *
+ */
+class RawFactoryTest extends PredisTestCase
+{
+    /**
+     * @group disconnected
+     */
+    public function testSupportForAnyCommand(): void
+    {
+        $factory = new RawFactory();
+
+        $this->assertTrue($factory->supports('info'));
+        $this->assertTrue($factory->supports('INFO'));
+
+        $this->assertTrue($factory->supports('unknown'));
+        $this->assertTrue($factory->supports('UNKNOWN'));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testSupportForAnyCommands(): void
+    {
+        $factory = new RawFactory();
+
+        $this->assertTrue($factory->supports('get', 'set'));
+        $this->assertTrue($factory->supports('GET', 'SET'));
+
+        $this->assertTrue($factory->supports('get', 'unknown'));
+
+        $this->assertTrue($factory->supports('unknown1', 'unknown2'));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testCreateInstanceOfRawCommand(): void
+    {
+        $factory = new RawFactory();
+
+        $command = $factory->create('info');
+        $this->assertInstanceOf('Predis\Command\CommandInterface', $command);
+        $this->assertInstanceOf('Predis\Command\RawCommand', $command);
+
+        $command = $factory->create('unknown');
+        $this->assertInstanceOf('Predis\Command\CommandInterface', $command);
+        $this->assertInstanceOf('Predis\Command\RawCommand', $command);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testCreateCommandWithoutArguments(): void
+    {
+        $factory = new RawFactory();
+
+        $command = $factory->create('info');
+
+        $this->assertInstanceOf('Predis\Command\RawCommand', $command);
+        $this->assertEquals('INFO', $command->getId());
+        $this->assertEquals(array(), $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testCreateCommandWithArguments(): void
+    {
+        $factory = new RawFactory();
+
+        $arguments = array('foo', 'bar');
+        $command = $factory->create('set', $arguments);
+
+        $this->assertInstanceOf('Predis\Command\RawCommand', $command);
+        $this->assertEquals('SET', $command->getId());
+        $this->assertEquals($arguments, $command->getArguments());
+    }
+}

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -11,7 +11,10 @@
 
 namespace Predis\Configuration\Option;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Configuration\OptionsInterface;
 use Predis\Command\Processor\KeyPrefixProcessor;
+use Predis\Command\RawFactory;
 use Predis\Command\RedisFactory;
 use PredisTestCase;
 
@@ -179,6 +182,70 @@ class CommandsTest extends PredisTestCase
     /**
      * @group disconnected
      */
+    public function testAcceptsStringPredisAsValue(): void
+    {
+        $option = new Commands();
+
+        /** @var OptionsInterface */
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $commands = $option->filter($options, 'predis');
+
+        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands);
+        $this->assertInstanceOf('Predis\Command\RedisFactory', $commands);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testAcceptsStringRawAsValue(): void
+    {
+        $option = new Commands();
+
+        /** @var OptionsInterface */
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $commands = $option->filter($options, 'raw');
+
+        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands);
+        $this->assertInstanceOf('Predis\Command\RawFactory', $commands);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testAcceptsStringDefaultAsValue(): void
+    {
+        $option = new Commands();
+
+        /** @var OptionsInterface */
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $commands = $option->filter($options, 'default');
+
+        $this->assertInstanceOf('Predis\Command\FactoryInterface', $commands);
+        $this->assertInstanceOf('Predis\Command\RedisFactory', $commands);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testThrowsExceptionOnInvalidStringAsValue()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Predis\Configuration\Option\Commands does not recognize `unknown` as a supported configuration string');
+
+        $option = new Commands();
+
+        /** @var OptionsInterface */
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+
+        $option->filter($options, 'unknown');
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testThrowsExceptionOnInvalidTypeReturnedByCallable()
     {
         $this->expectException('InvalidArgumentException');
@@ -214,5 +281,26 @@ class CommandsTest extends PredisTestCase
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $option->filter($options, new \stdClass());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testThrowsExceptionOnPrefixWithRawFactory(): void
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Predis\Command\RawFactory does not support key prefixing');
+
+        $option = new Commands();
+
+        /** @var OptionsInterface|MockObject */
+        $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
+        $options
+            ->expects($this->once())
+            ->method('__isset')
+            ->with('prefix')
+            ->willReturn(true);
+
+        $option->filter($options, 'raw');
     }
 }


### PR DESCRIPTION
This command factory creates instances of Redis commands using the [`Predis\Command\RawCommand`](https://github.com/predis/predis/blob/1285951243577764a84e83f9ab53d50408cc7f24/src/Command/RawCommand.php) class.

Any command ID supplied to `create()` will return a command instance meaning that creating commands not implemented by Redis, e.g. `OHNOES`, will result in a `-ERR unknown command` response returned by the server.

Configuring a new client to use this factory requires passing the string `raw` to the `commands` client option:

```
>>> $client = new Predis\Client('127.0.0.1', ['commands' => 'raw']);
=> Predis\Client {#2368}

>>> $client->getCommandFactory();
=> Predis\Command\RawFactory {#2355}
```

This factory does not support key prefixing (well command processors in general) at least for now, I'm still deciding if commands and their arguments / responses should be kept as _raw_ as possible when using it. Right now an exception is thrown when `commands` is set to `raw` and the `prefix` option is present:

```
>>> $client = new Predis\Client('127.0.0.1', ['commands' => 'raw', 'prefix' => 'lolwut:']);
InvalidArgumentException with message 'Predis/Command/RawFactory does not support key prefixing'
```

Please note that currently, even in `v1.1`, the method `Predis\Client::executeRaw()` behaves exactly like that, it __does not__ apply any prefix to keys even when `prefix` is configured. I'm probably going to change this at a later stage so that:

- when the usual `Predis\Command\RedisFactory` is being used, keys are prefixed with `Predis\Client::executeRaw()`
- when the new `Predis\Command\RawCommand` is used, there's no key prefixing anywhere in the client.

I will probably add a new `createRaw(array): RawCommand` method to `Predis\Command\FactoryInterface` for consistency so that any command factory must be able to return raw commands (still allowing for different behaviours for their actual initialization).