### PR TITLE
Implement role-specific default parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ v2.0.0 (202x-xx-xx)
   get a single connection from the pool by using its ID. It is also possible to
   retrive a connection by role using the method getConnectionByRole().
 
+- It is possible to set `role`-specific default parameters via the `parameters`
+  client option by passing named arrays to the following keys: `role.sentinel`,
+  `role.master` and `role.slave`. These parameters take precedence over global
+  default parameters but, as usual, they do not override parameters explicitly
+  set by users for each single node connection. For sentinels, "username" and
+  "database" are always stripped because they are not supported while "password"
+  is never inherited from global default parameters and must be set explicitly.
+
 - The concept of connection ID (ip:port pair) and connection alias (the `alias`
   parameter) in `Predis\Connection\Cluster\PredisCluster` has been separated.
   This change does not affect distribution and it is safe for existing clusters.

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -241,6 +241,8 @@ class SentinelReplication implements ReplicationInterface
     /**
      * Creates a new connection to a sentinel server.
      *
+     * @param mixed $parameters Connection parameters or connection instance
+     *
      * @return NodeConnectionInterface
      */
     protected function createSentinelConnection($parameters)
@@ -254,12 +256,10 @@ class SentinelReplication implements ReplicationInterface
         }
 
         if (is_array($parameters)) {
-            // Password authentication is fine now that Redis Sentinel supports
-            // password-protected sentinel instances, but we must explicitly set
-            // "database" and "username" to NULL so that no augmented AUTH (ACL)
-            // and SELECT command are sent by accident to the sentinels.
-            $parameters['database'] = null;
-            $parameters['username'] = null;
+            // NOTE: we enforce the "sentinel" role so that appropriate default
+            // parameters are applied when creating the new connection instance
+            // and blacklisted ones are stripped off from input parameters.
+            $parameters['role'] = 'sentinel';
 
             if (!isset($parameters['timeout'])) {
                 $parameters['timeout'] = $this->sentinelTimeout;


### PR DESCRIPTION
Until now users could specify some default parameters applied to all connections created by the underlying connection factory when not explicitly set in the user-supplied set of parameters of each single node connection. This is definitely handy, but it has some limits especially when dealing with sentinel nodes since there are times when it is better to use different defaults (e.g. `timeout`) and they do not support certain parameters.

This pull request adds the ability to specify role-specific default parameters that gets applied only to connections targeting specific roles. This is mostly useful for sentinels as they usually require lower timeouts than normal Redis nodes and may also have a different password. Role-specific parameters are passed as part of the `parameters` client option in the form of named sub-arrays and take precedence over global parameters, but they still do not override parameters explicitly set by the user for single nodes.

Supported keys are __`role.sentinel`__, __`role.master`__ and __`role.slave`__. In regards to `role.sentinel`, please note that:

- sentinels do not support ACL authentication or database selection so `username` and `database` are always stripped off.
- `password` is never _inherited_ from global defaults because users can have password-protected Redis nodes but unprotected Redis sentinels. In such cases, users must explicitly set a password either for each sentinel connection or just once in `role.sentinel`.

Here is a brief example showing how to configure Predis for replication supervised by redis-sentinel using different timeout and password values for sentinel nodes compared to normal master and replica nodes.

```php
$client = new Predis\Client($arrayOfSentinels, [
  'replication' => 'sentinel',
  'service' => $sentinelService,

  'parameters' => [
    // Set of global default parameters, applied to *any* connection:
    'scheme' => 'tcp',
    'tcp_nodelay' => true,
    'timeout' => 5,
    'username' => $redisUsername, // Won't be inherited by sentinels.
    'password' => $redisPassword, // Won't be inherited by sentinels.

    // Set of sentinels-specific default parameters:
    'role.sentinel' => [
      // For sentinels, "scheme" and "tcp_nodelay" are inherited from
      // default parameters and "timeout" is overridden. On the other
      // hand both "username" and "password" are never inherited but we
      // still explicitly set a password for sentinels because, in our
      // example, sentinels are indeed password-protected.
      'timeout' => 0.2,
      'password' => $sentinelPassword,
    ],
  ],
]);
```

This is mostly in response to #594 but I expanded it to support all of the common Redis _"roles"_ while at this. To be honest I would backport a simplified version of this to v1.1, just enough to support sentinel authentication like the original request, but I'm still torn if it would mean stretching the role of a patch release.