### PR TITLE
Apply patches on initial install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "php": ">=5.3.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
-        "cweagans/composer-patches": "^1.6"
+        "phpunit/phpunit": "~4.8"
     },
     "suggest": {
         "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol",
@@ -43,16 +42,7 @@
             "Predis\\": "src/"
         }
     },
-    "extra": {
- 		"composer-exit-on-patch-failure": true,
- 		"patches": {
- 			"phpunit/phpunit-mock-objects": {
- 				"Fix PHP 7 and 8 compatibility": "./tests/phpunit_mock_objects.patch"
- 			},
- 			"phpunit/phpunit": {
- 				"Fix PHP 7 compatibility": "./tests/phpunit_php7.patch",
- 				"Fix PHP 8 compatibility": "./tests/phpunit_php8.patch"
- 			}
- 		}
- 	}
+    "scripts": {
+        "post-update-cmd": "@php -f tests/apply-patches.php"
+    }
 }

--- a/tests/apply-patches.php
+++ b/tests/apply-patches.php
@@ -3,11 +3,11 @@
  * Apply patches to support newer PHP versions.
  */
 
-$patches = [
+$patches = array(
     'phpunit_mock_objects.patch' => 'phpunit/phpunit-mock-objects',
     'phpunit_php7.patch' => 'phpunit/phpunit',
     'phpunit_php8.patch' => 'phpunit/phpunit',
-];
+);
 
 foreach ($patches as $patch => $package) {
     chdir(__DIR__.'/../vendor/'.$package);

--- a/tests/apply-patches.php
+++ b/tests/apply-patches.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Apply patches to support newer PHP versions.
+ */
+
+$patches = [
+    'phpunit_mock_objects.patch' => 'phpunit/phpunit-mock-objects',
+    'phpunit_php7.patch' => 'phpunit/phpunit',
+    'phpunit_php8.patch' => 'phpunit/phpunit',
+];
+
+foreach ($patches as $patch => $package) {
+    chdir(__DIR__.'/../vendor/'.$package);
+    passthru(sprintf('patch -p1 -f < ../../../tests/%s', $patch));
+}


### PR DESCRIPTION
The patches to get PHPUnit working are causing problems for other projects that use both `cweagans/composer-patches` and `predis/predis` along with PHPUnit.

This change moves the patch application to a simple PHP script run on the `post-update-cmd` composer event and removes the dependency on the patch installer package.

Addresses #660 