### PR TITLE
Add some return types

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -527,7 +527,7 @@ class Client implements ClientInterface, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @return \Traversable<string, static>
      */
     public function getIterator()
     {

--- a/src/Command/Processor/ProcessorChain.php
+++ b/src/Command/Processor/ProcessorChain.php
@@ -71,7 +71,7 @@ class ProcessorChain implements \ArrayAccess, ProcessorInterface
     /**
      * Returns an iterator over the list of command processor in the chain.
      *
-     * @return \ArrayIterator
+     * @return \Traversable<int, ProcessorInterface>
      */
     public function getIterator()
     {
@@ -89,7 +89,7 @@ class ProcessorChain implements \ArrayAccess, ProcessorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function offsetExists($index)
     {

--- a/src/Connection/Aggregate/PredisCluster.php
+++ b/src/Connection/Aggregate/PredisCluster.php
@@ -176,7 +176,7 @@ class PredisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     public function count()
     {
@@ -184,7 +184,7 @@ class PredisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return \Traversable<string|int, NodeConnectionInterface>
      */
     public function getIterator()
     {

--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -600,7 +600,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     public function count()
     {
@@ -608,7 +608,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return \Traversable<int, NodeConnectionInterface>
      */
     public function getIterator()
     {


### PR DESCRIPTION
By making these return types explicit in the annotation, we preemptively tell consumers that some next major of Predis or PHP 9 might add real return types here.

These annotations are leveraged by Symfony's `DebugClassLoader` to help one spot some missing return types in their app. That's how I spotted these. They relate only to PHP internal's base types / magic methods.