### PR TITLE
Fix no sentinel server available for autodiscovery on Swoole

### DIFF
--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -10,6 +10,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Util\Test as TestUtil;
 use Predis\Client;
 use Predis\Command;
 use Predis\Connection;
@@ -315,7 +316,10 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getRequiredRedisServerVersion(): ?string
     {
-        $annotations = $this->getAnnotations();
+        $annotations = TestUtil::parseTestMethodAnnotations(
+            get_class($this),
+            $this->getName(false)
+        );
 
         if (isset($annotations['method']['requiresRedisVersion'], $annotations['method']['group']) &&
             !empty($annotations['method']['requiresRedisVersion']) &&


### PR DESCRIPTION
Question:
In the Swoole to close or restart sentinel may cause the node invalidation forever,
the node deleted because of in the SentinelReplication.php use array_shift($this->sentinels)

Solution:
Using $this->sentinels[$this->sentinelIndex] to replace array_shift($this->sentinels) can solve the problem, also can use  if ($this->sentinelIndex >= count($this->sentinels)) in the same time to replace  if (!$this->sentinels) prevent  undefined offset.