### PR TITLE
CommandInterface::parseResponse() can accept array and null argument

### DIFF
--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -73,7 +73,7 @@ interface CommandInterface
     /**
      * Parses a raw response and returns a PHP object.
      *
-     * @param string $data Binary string containing the whole response.
+     * @param string|array|null $data Binary string containing the whole response.
      *
      * @return mixed
      */


### PR DESCRIPTION
Method can accept array on commands with multiple responses (such as `HGETALL`, `ZRANGE`, etc) and null (for a not existent key, for example - `GET` command with an unknown key).

Can you help me with updating the argument description?
"Binary string containing the whole response." no more true.