### PR TITLE
Fix misleading argument name in SentinelReplication

### DIFF
--- a/src/Connection/Aggregate/SentinelReplication.php
+++ b/src/Connection/Aggregate/SentinelReplication.php
@@ -146,14 +146,14 @@ class SentinelReplication implements ReplicationInterface
     }
 
     /**
-     * Sets the time to wait (in seconds) before fetching a new configuration
+     * Sets the time to wait (in milliseconds) before fetching a new configuration
      * from one of the sentinels.
      *
-     * @param float $seconds Time to wait before the next attempt.
+     * @param float $milliseconds Time to wait before the next attempt.
      */
-    public function setRetryWait($seconds)
+    public function setRetryWait($milliseconds)
     {
-        $this->retryWait = (float) $seconds;
+        $this->retryWait = (float) $milliseconds;
     }
 
     /**


### PR DESCRIPTION
In `SentinelReplication`, `$this->retryWait` is in milliseconds.
It's setter misleadingly document it as seconds. Fixing by renaming the variable name without altering the functionality.

I believe this patch would also apply to the `main` branch in https://github.com/predis/predis/blob/main/src/Connection/Replication/SentinelReplication.php#L153-L163.