### PR TITLE
fix test expectation for redis 6.2

### DIFF
--- a/tests/Predis/Command/ConnectionSelectTest.php
+++ b/tests/Predis/Command/ConnectionSelectTest.php
@@ -83,7 +83,7 @@ class ConnectionSelectTest extends PredisCommandTestCase
     /**
      * @group connected
      * @expectedException \Predis\Response\ServerException
-     * @expectedExceptionMessage ERR invalid DB index
+     * @expectedExceptionMessageRegExp /ERR (invalid DB index|value is not)/
      */
     public function testThrowsExceptionOnUnexpectedDatabaseName()
     {

--- a/tests/Predis/Command/KeyMoveTest.php
+++ b/tests/Predis/Command/KeyMoveTest.php
@@ -82,7 +82,7 @@ class KeyMoveTest extends PredisCommandTestCase
     /**
      * @group connected
      * @expectedException \Predis\Response\ServerException
-     * @expectedExceptionMessage ERR index out of range
+     * @expectedExceptionMessageRegEx /ERR.*out of range/
      */
     public function testThrowsExceptionOnInvalidDatabases()
     {


### PR DESCRIPTION
From Fedora CI
https://koschei.fedoraproject.org/package/php-nrk-Predis

Failing since redis 6.2
```
There were 2 failures:
1) Predis\Command\ConnectionSelectTest::testThrowsExceptionOnUnexpectedDatabaseName
Failed asserting that exception message 'ERR value is not an integer or out of range' contains 'ERR invalid DB index'.
2) Predis\Command\KeyMoveTest::testThrowsExceptionOnInvalidDatabases
Failed asserting that exception message 'ERR DB index is out of range' contains 'ERR index out of range'.
```