### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Predis/Cluster/SlotMapTest.php
+++ b/tests/Predis/Cluster/SlotMapTest.php
@@ -236,7 +236,7 @@ class SlotMapTest extends PredisTestCase
     {
         $slotmap = new SlotMap();
 
-        $this->assertSame(0, count($slotmap));
+        $this->assertCount(0, $slotmap);
     }
 
     /**
@@ -247,13 +247,13 @@ class SlotMapTest extends PredisTestCase
         $slotmap = new SlotMap();
 
         $slotmap->setSlots(0, 5460, '127.0.0.1:6379');
-        $this->assertSame(5461, count($slotmap));
+        $this->assertCount(5461, $slotmap);
 
         $slotmap->setSlots(5461, 10922, '127.0.0.1:6380');
-        $this->assertSame(10923, count($slotmap));
+        $this->assertCount(10923, $slotmap);
 
         $slotmap->setSlots(10923, 16383, '127.0.0.1:6381');
-        $this->assertSame(16384, count($slotmap));
+        $this->assertCount(16384, $slotmap);
     }
 
     /**

--- a/tests/Predis/Command/Redis/CONFIG_Test.php
+++ b/tests/Predis/Command/Redis/CONFIG_Test.php
@@ -104,7 +104,7 @@ class CONFIG_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $this->assertIsArray($configs = $redis->config('GET', 'dbfilename'));
-        $this->assertEquals(1, count($configs));
+        $this->assertCount(1, $configs);
         $this->assertArrayHasKey('dbfilename', $configs);
     }
 

--- a/tests/Predis/Command/Redis/INFO_Test.php
+++ b/tests/Predis/Command/Redis/INFO_Test.php
@@ -320,7 +320,7 @@ BUFFER;
         $redis = $this->getClient();
         $command = $this->getCommand();
 
-        $this->assertInternalType('array', $info = $redis->executeCommand($command));
+        $this->assertIsArray($info = $redis->executeCommand($command));
         $this->assertArrayHasKey('redis_version', $info);
     }
 }

--- a/tests/Predis/Command/Redis/SORT_Test.php
+++ b/tests/Predis/Command/Redis/SORT_Test.php
@@ -185,11 +185,11 @@ class SORT_Test extends PredisCommandTestCase
         $redis = $this->getClient();
         $redis->lpush('list:unordered', $unordered = array(2, 100, 3, 1, 30, 10));
 
-        $this->assertEquals(
-            count($unordered),
+        $this->assertCount(
             $redis->sort('list:unordered', array(
                 'store' => 'list:ordered',
-            ))
+            )),
+            $unordered
         );
 
         $this->assertEquals(array(1, 2, 3, 10, 30, 100),  $redis->lrange('list:ordered', 0, -1));

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -90,7 +90,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->assertTrue($factory->supports('mock'));
         $this->assertTrue($factory->supports('MOCK'));
 
-        $this->assertSame(get_class($command), $factory->getCommandClass('mock'));
+        $this->assertInstanceOf($factory->getCommandClass('mock'), $command);
     }
 
     /**

--- a/tests/Predis/Connection/Cluster/PredisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/PredisClusterTest.php
@@ -40,7 +40,7 @@ class PredisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
         $this->assertSame($connection1, $cluster->getConnectionById('127.0.0.1:7001'));
         $this->assertSame($connection2, $cluster->getConnectionById('127.0.0.1:7002'));
     }
@@ -58,7 +58,7 @@ class PredisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
         $this->assertSame($connection1, $cluster->getConnectionByAlias('node01'));
         $this->assertSame($connection2, $cluster->getConnectionByAlias('node02'));
     }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -71,7 +71,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection1);
         $cluster->add($connection2);
 
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
         $this->assertSame($connection1, $cluster->getConnectionById('127.0.0.1:6379'));
         $this->assertSame($connection2, $cluster->getConnectionById('127.0.0.1:6380'));
     }
@@ -92,7 +92,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertTrue($cluster->remove($connection1));
         $this->assertFalse($cluster->remove($connection3));
-        $this->assertSame(1, count($cluster));
+        $this->assertCount(1, $cluster);
     }
 
     /**
@@ -110,7 +110,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertTrue($cluster->removeById('127.0.0.1:6380'));
         $this->assertFalse($cluster->removeById('127.0.0.1:6390'));
-        $this->assertSame(1, count($cluster));
+        $this->assertCount(1, $cluster);
     }
 
     /**
@@ -128,11 +128,11 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection2);
         $cluster->add($connection3);
 
-        $this->assertSame(3, count($cluster));
+        $this->assertCount(3, $cluster);
 
         $cluster->remove($connection3);
 
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
     }
 
     /**
@@ -977,7 +977,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertSame('foobar', $cluster->executeCommand($command));
         $this->assertSame('foobar', $cluster->executeCommand($command));
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
     }
 
     /**
@@ -1033,7 +1033,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertSame('foobar', $cluster->executeCommand($command));
         $this->assertSame('foobar', $cluster->executeCommand($command));
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
     }
 
     /**
@@ -1071,7 +1071,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertSame('foobar', $cluster->executeCommand($command));
         $this->assertSame('foobar', $cluster->executeCommand($command));
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
     }
 
     /**
@@ -1121,7 +1121,7 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertSame('foobar', $cluster->executeCommand($command));
         $this->assertSame('foobar', $cluster->executeCommand($command));
-        $this->assertSame(3, count($cluster));
+        $this->assertCount(3, $cluster);
     }
 
     /**
@@ -1259,7 +1259,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection1);
 
         $this->assertSame('foobar', $cluster->executeCommand($cmdGET));
-        $this->assertSame(2, count($cluster));
+        $this->assertCount(2, $cluster);
     }
 
     /**

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -749,7 +749,7 @@ class MultiExecTest extends PredisTestCase
             $tx->set('hoge', 'piyo');
         });
 
-        $this->assertSame(1, count($responses));
+        $this->assertCount(1, $responses);
         $this->assertSame(0, $client->exists('foo'));
         $this->assertSame(1, $client->exists('hoge'));
     }


### PR DESCRIPTION
# Changed log

- Using the `assertCount` to assert expected is same as result.
- Using the `assertInstanceOf` to assert expected is same as result instance.