### PR TITLE
Reuse connection scheme and SSL options from redis-sentinel parameters

### DIFF
--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -30,6 +30,7 @@ namespace Predis\Connection;
  * @property-read bool   persistent         Leaves the connection open after a GC collection.
  * @property-read string password           Password to access Redis (see the AUTH command).
  * @property-read string database           Database index (see the SELECT command).
+ * @property-read array  ssl                SSL Context options array (see http://php.net/manual/en/context.ssl.php)
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -70,6 +70,11 @@ class SentinelReplication implements ReplicationInterface
     protected $sentinels = array();
 
     /**
+     * @var int
+     */
+    protected $sentinelIndex = 0;
+
+    /**
      * @var NodeConnectionInterface
      */
     protected $sentinelConnection;
@@ -281,11 +286,13 @@ class SentinelReplication implements ReplicationInterface
     public function getSentinelConnection()
     {
         if (!$this->sentinelConnection) {
-            if (!$this->sentinels) {
+            if ($this->sentinelIndex >= count($this->sentinels)) {
+                $this->sentinelIndex = 0;
                 throw new \Predis\ClientException('No sentinel server available for autodiscovery.');
             }
 
-            $sentinel = array_shift($this->sentinels);
+            $sentinel = $this->sentinels[$this->sentinelIndex];
+            ++$this->sentinelIndex;
             $this->sentinelConnection = $this->createSentinelConnection($sentinel);
         }
 
@@ -306,6 +313,7 @@ class SentinelReplication implements ReplicationInterface
                 );
 
                 $this->sentinels = array();
+                $this->sentinelIndex = 0;
                 // NOTE: sentinel server does not return itself, so we add it back.
                 $this->sentinels[] = $sentinel->getParameters()->toArray();
 


### PR DESCRIPTION
Hi! First of all, thank you for this package, it was a pleasure using and reading your code! :)

I'm using Redis 6.2 with Sentinel and self-signed TLS. I wasn't able to get it to work because the TLS details weren't being passed back before making the forwarding connections. This fixes it.

Setting the `scheme` broke some tests (tests were finding the `scheme` prop when none was expected) so I've added the `if ($parameters->scheme !== 'tcp') {` line to bypass that. I'm happy to make adjustments if needed ✌️

I'm using this package with Laravel.