### PR TITLE
Add sentinels back after connecting to it

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -286,6 +286,7 @@ class SentinelReplication implements ReplicationInterface
             }
 
             $sentinel = array_shift($this->sentinels);
+            $this->sentinels[] = $sentinel;
             $this->sentinelConnection = $this->createSentinelConnection($sentinel);
         }
 


### PR DESCRIPTION
Hi,

I'm sending this PR to fix an issue where all sentinels go down and you have a long lived php process it will not reconnect to the sentinels because of that and you will receive `throw new \Predis\ClientException('No sentinel server available for autodiscovery.');` all the time after.

The problem is that when we create connections we remove the sentinel from the list of available sentinels ($this->sentinels) and when we do not have any valid connection anymore (it's removed by SentinelReplication:321) it will not be able to reconnect