### PR TITLE
Add ReturnTypeWillChange

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -529,6 +529,7 @@ class Client implements ClientInterface, \IteratorAggregate
     /**
      * @return \Traversable<string, static>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $clients = array();


### PR DESCRIPTION
PHP 8.1 triggers a deprecation warning if a class implements `IteratorAggregate` without specifying a return type for `getIterator()`. Doing so would break PHP 5 compatibility, so I've added the `ReturnTypeWillChange` attribute which tells PHP that the return type will be added in a future release. This way, the error is not triggered.