### PR TITLE
Add `ReturnTypeWillChange` attribute to CursorBasedIterator

### DIFF
--- a/src/Collection/Iterator/CursorBasedIterator.php
+++ b/src/Collection/Iterator/CursorBasedIterator.php
@@ -139,6 +139,7 @@ abstract class CursorBasedIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->reset();
@@ -148,6 +149,7 @@ abstract class CursorBasedIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -156,6 +158,7 @@ abstract class CursorBasedIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -164,6 +167,7 @@ abstract class CursorBasedIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         tryFetch: {
@@ -184,6 +188,7 @@ abstract class CursorBasedIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->valid;


### PR DESCRIPTION
Similar to #706, this adds the `ReturnTypeWillChange` attribute to the inherited methods of `CursorBasedIterator` from `Iterator` interface in order to suppress the fatal error in PHP 8.1