### PR TITLE
Fix PHP 8.1 strlen breakage

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -387,7 +387,7 @@ class StreamConnection extends AbstractConnection
         $buffer = "*{$reqlen}\r\n\${$cmdlen}\r\n{$commandID}\r\n";
 
         foreach ($arguments as $argument) {
-            $arglen = strlen(is_null($argument) ? '' : $argument);
+            $arglen = strlen(strval($argument));
             $buffer .= "\${$arglen}\r\n{$argument}\r\n";
         }
 

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -387,7 +387,7 @@ class StreamConnection extends AbstractConnection
         $buffer = "*{$reqlen}\r\n\${$cmdlen}\r\n{$commandID}\r\n";
 
         foreach ($arguments as $argument) {
-            $arglen = strlen($argument ?? '');
+            $arglen = strlen(is_null($argument) ? '' : $argument);
             $buffer .= "\${$arglen}\r\n{$argument}\r\n";
         }
 

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -387,7 +387,7 @@ class StreamConnection extends AbstractConnection
         $buffer = "*{$reqlen}\r\n\${$cmdlen}\r\n{$commandID}\r\n";
 
         foreach ($arguments as $argument) {
-            $arglen = strlen($argument);
+            $arglen = strlen($argument ?? '');
             $buffer .= "\${$arglen}\r\n{$argument}\r\n";
         }
 


### PR DESCRIPTION
This adds a fallback to an empty string if the argument is `null` for some reason.

Atm this is failing our test suite at Laravel for PHP 8.1 builds. 