### PR TITLE
Throw an exception if factory parameters are not an array

### DIFF
--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -146,6 +146,10 @@ class Factory implements FactoryInterface
         } else {
             $parameters = $parameters ?: array();
         }
+        
+        if (!is_array($parameters)) {
+            throw new \UnexpectedValueException('Invalid type for parameters, expected array but got ' . gettype($parameters));
+        }
 
         if ($this->defaults) {
             $parameters += $this->defaults;


### PR DESCRIPTION
We are running into an issue in production where we randomly get a `Error: Unsupported operand types` exception about this line:
https://github.com/predis/predis/blob/4c1aada5aebf0afde266b512ed069f822148c3a2/src/Connection/Factory.php#L151

The exception added by this PR will hopefully help us determine the cause of `$parameters` not being an array.