### PR TITLE
Fixes #728

### DIFF
--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -289,7 +289,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
      *
      * @return array
      */
-    public function getSlotsMap()
+    public function &getSlotsMap()
     {
         if (!isset($this->slotsMap)) {
             $this->slotsMap = array();
@@ -319,7 +319,8 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
         }
 
         $slots = array_fill($first, $last - $first + 1, (string) $connection);
-        $this->slotsMap = $this->getSlotsMap() + $slots;
+        $slotsMap = &$this->getSlotsMap();
+        $slotsMap += $slots;
     }
 
     /**


### PR DESCRIPTION
Currently, setSlots uses getSlotsMap, which returns a new copy of
the existing slotsMap. Because setSlots is called for each master,
the array copy becomes prohibitively expensive for clusters with
a large number of masters. This commit optimizes the setSlots call
by modifying a reference to the slotsMap associative array instead
of a copy.