### PR TITLE
Fix for changing return types for PHP8.1

### DIFF
--- a/src/Session/Handler.php
+++ b/src/Session/Handler.php
@@ -65,6 +65,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function open($save_path, $session_id)
     {
         // NOOP
@@ -74,6 +75,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         // NOOP
@@ -83,6 +85,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         // NOOP
@@ -92,6 +95,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function read($session_id)
     {
         if ($data = $this->client->get($session_id)) {
@@ -103,6 +107,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function write($session_id, $session_data)
     {
         $this->client->setex($session_id, $this->ttl, $session_data);
@@ -113,6 +118,7 @@ class Handler implements \SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function destroy($session_id)
     {
         $this->client->del($session_id);


### PR DESCRIPTION
This PR fixes the return types that change for PHP 8.1

Fixes: #727. This is a followup for #712.
The fix prevents below error for showing when using the Predis Session Handler
```
phpfpm_1   | [Wed Dec 08 14:36:30.364115 2021] [php:notice] [pid 19] [client 172.19.0.2:47686] PHP Deprecated:  Return type of Predis\\Session\\Handler::open($save_path, $session_id) should either be compatible with SessionHandlerInterface::open(string $path, string $name): bool, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/predis/predis/src/Session/Handler.php on line 68, referer: 
```