### PR TITLE
Remove invalid input for actions/cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Cache Composer dependencies
       uses: actions/cache@v2
       with:
-        php-version: ${{ matrix.php-versions }}
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-


### PR DESCRIPTION
`php-versions` isn't a valid input for the `actions/cache` 

Further information: https://github.com/actions/cache/blob/main/examples.md#php---composer


I think, it was copied/pasted from the above `shivammathur/setup-php@v2` action.

---

This invalid input is currently giving a warning. https://github.com/predis/predis/actions/runs/573626141

<img width="1017" alt="Screenshot 2022-01-14 at 8 15 20 AM" src="https://user-images.githubusercontent.com/1325411/149414530-d31bdc94-a258-478a-939a-8fa271c6821d.png">


