### PR TITLE
#742 create new context for socket connection

### DIFF
--- a/src/Connection/PhpiredisStreamConnection.php
+++ b/src/Connection/PhpiredisStreamConnection.php
@@ -123,8 +123,9 @@ class PhpiredisStreamConnection extends StreamConnection
     {
         $socket = null;
         $timeout = (isset($parameters->timeout) ? (float) $parameters->timeout : 5.0);
+        $context = stream_context_create();
 
-        $resource = @stream_socket_client($address, $errno, $errstr, $timeout, $flags);
+        $resource = @stream_socket_client($address, $errno, $errstr, $timeout, $flags, $context);
 
         if (!$resource) {
             $this->onConnectionError(trim($errstr), $errno);

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -123,8 +123,9 @@ class StreamConnection extends AbstractConnection
     protected function createStreamSocket(ParametersInterface $parameters, $address, $flags)
     {
         $timeout = (isset($parameters->timeout) ? (float) $parameters->timeout : 5.0);
+        $context = stream_context_create();
 
-        if (!$resource = @stream_socket_client($address, $errno, $errstr, $timeout, $flags)) {
+        if (!$resource = @stream_socket_client($address, $errno, $errstr, $timeout, $flags, $context)) {
             $this->onConnectionError(trim($errstr), $errno);
         }
 


### PR DESCRIPTION
Connection created without context will use default context. When TLS connection is created subsequent call of `stream_context_set_option()` function may modify default (global) context.