### PR TITLE
Add a more precise blpop definition for static analysers

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -83,6 +83,7 @@ use Predis\Profile\ProfileInterface;
  * @method array       hvals($key)
  * @method int         hstrlen($key, $field)
  * @method array|null  blpop(array|string $keys, $timeout)
+ * @psalm-method array{0: string, 1: string}|null blpop(array<string>|string $keys, int<0, max> $timeout)
  * @method array|null  brpop(array|string $keys, $timeout)
  * @method string|null brpoplpush($source, $destination, $timeout)
  * @method string|null lindex($key, $index)


### PR DESCRIPTION
This commit makes popular static analysers (tested with Psalm and PHPStan) much happier by letting them know one can safely assume there are keys 0 and 1 in the array returned from blpop(), while IDEs can still use an old definition.