### PR TITLE
PHP 8.1 and symfony/error handler deprecations

### DIFF
--- a/src/Collection/Iterator/CursorBasedIterator.php
+++ b/src/Collection/Iterator/CursorBasedIterator.php
@@ -138,6 +138,7 @@ abstract class CursorBasedIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -148,6 +149,7 @@ abstract class CursorBasedIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -157,6 +159,7 @@ abstract class CursorBasedIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -166,6 +169,7 @@ abstract class CursorBasedIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next()
@@ -187,6 +191,7 @@ abstract class CursorBasedIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function valid()

--- a/src/Collection/Iterator/ListKey.php
+++ b/src/Collection/Iterator/ListKey.php
@@ -127,6 +127,7 @@ class ListKey implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -137,6 +138,7 @@ class ListKey implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -146,6 +148,7 @@ class ListKey implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -155,6 +158,7 @@ class ListKey implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next()
@@ -172,6 +176,7 @@ class ListKey implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function valid()

--- a/src/Command/Processor/ProcessorChain.php
+++ b/src/Command/Processor/ProcessorChain.php
@@ -99,6 +99,7 @@ class ProcessorChain implements \ArrayAccess, ProcessorInterface
 
     /**
      * {@inheritdoc}
+     * @return ProcessorInterface|null
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($index)
@@ -108,6 +109,7 @@ class ProcessorChain implements \ArrayAccess, ProcessorInterface
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($index, $processor)
@@ -124,6 +126,7 @@ class ProcessorChain implements \ArrayAccess, ProcessorInterface
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($index)

--- a/src/Monitor/Consumer.php
+++ b/src/Monitor/Consumer.php
@@ -90,6 +90,7 @@ class Consumer implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -110,6 +111,7 @@ class Consumer implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -119,6 +121,7 @@ class Consumer implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next()

--- a/src/Monitor/Consumer.php
+++ b/src/Monitor/Consumer.php
@@ -24,7 +24,7 @@ class Consumer implements \Iterator
 {
     private $client;
     private $valid;
-    private $position;
+    private $position = 0;
 
     /**
      * @param ClientInterface $client Client instance used by the consumer.

--- a/src/PubSub/AbstractConsumer.php
+++ b/src/PubSub/AbstractConsumer.php
@@ -30,7 +30,7 @@ abstract class AbstractConsumer implements \Iterator
     const STATUS_SUBSCRIBED = 2;  // 0b0010
     const STATUS_PSUBSCRIBED = 4; // 0b0100
 
-    private $position = null;
+    private $position = 0;
     private $statusFlags = self::STATUS_VALID;
 
     /**

--- a/src/PubSub/AbstractConsumer.php
+++ b/src/PubSub/AbstractConsumer.php
@@ -150,6 +150,7 @@ abstract class AbstractConsumer implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -171,6 +172,7 @@ abstract class AbstractConsumer implements \Iterator
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     #[\ReturnTypeWillChange]
     public function key()

--- a/src/Response/Iterator/MultiBulkIterator.php
+++ b/src/Response/Iterator/MultiBulkIterator.php
@@ -33,6 +33,7 @@ abstract class MultiBulkIterator implements \Iterator, \Countable, ResponseInter
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function rewind()
@@ -42,6 +43,7 @@ abstract class MultiBulkIterator implements \Iterator, \Countable, ResponseInter
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -51,6 +53,7 @@ abstract class MultiBulkIterator implements \Iterator, \Countable, ResponseInter
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     #[\ReturnTypeWillChange]
     public function key()
@@ -60,6 +63,7 @@ abstract class MultiBulkIterator implements \Iterator, \Countable, ResponseInter
 
     /**
      * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next()
@@ -71,6 +75,7 @@ abstract class MultiBulkIterator implements \Iterator, \Countable, ResponseInter
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function valid()

--- a/src/Response/Iterator/MultiBulkTuple.php
+++ b/src/Response/Iterator/MultiBulkTuple.php
@@ -60,6 +60,7 @@ class MultiBulkTuple extends MultiBulk implements \OuterIterator
 
     /**
      * {@inheritdoc}
+     * @return \Iterator
      */
     #[\ReturnTypeWillChange]
     public function getInnerIterator()

--- a/src/Session/Handler.php
+++ b/src/Session/Handler.php
@@ -64,6 +64,7 @@ class Handler implements \SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($save_path, $session_id)
@@ -74,6 +75,7 @@ class Handler implements \SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -84,6 +86,7 @@ class Handler implements \SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @return int|bool
      */
     #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
@@ -94,6 +97,7 @@ class Handler implements \SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @return string
      */
     #[\ReturnTypeWillChange]
     public function read($session_id)
@@ -106,6 +110,7 @@ class Handler implements \SessionHandlerInterface
     }
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($session_id, $session_data)
@@ -117,6 +122,7 @@ class Handler implements \SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($session_id)


### PR DESCRIPTION
Using predis with `symfony/error-handler:5.4+` and PHP 8.1 leads to many triggered deprecation errors (from `symfony/error-handler`) like a:

```
2022-03-09T16:04:49+00:00 [info] User Deprecated: Method "Iterator::rewind()" might add "void" as a native return type declaration in the future. Do the same in implementation "Predis\Collection\Iterator\CursorBasedIterator" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T16:04:49+00:00 [info] User Deprecated: Method "Iterator::current()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Predis\Collection\Iterator\CursorBasedIterator" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T16:04:49+00:00 [info] User Deprecated: Method "Iterator::key()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Predis\Collection\Iterator\CursorBasedIterator" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T16:04:49+00:00 [info] User Deprecated: Method "Iterator::next()" might add "void" as a native return type declaration in the future. Do the same in implementation "Predis\Collection\Iterator\CursorBasedIterator" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T16:04:49+00:00 [info] User Deprecated: Method "Iterator::valid()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Predis\Collection\Iterator\CursorBasedIterator" now to avoid errors or add an explicit @return annotation to suppress this message.
```

They may be fixed by using utility script from `symfony/error-handler` - https://github.com/symfony/symfony/blob/v5.4.6/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations

I applied fixed from this script and added some manual fixes over changes:
- ensure return type of `\Iterator::key()` implementations as a `int` (instead of possible `int|null`)
- narrow down return type in some methods from `mixed` to more specific (example - `ProcessorInterface|null`)
- dropped return types from methods `__sleep` as there is no interface for this method in PHP with future signature change (they were automatically added by script - `@return array`)

There are one open issue with proper return type - https://github.com/predis/predis/blob/ab0c46332c1f5956e93693586123017dbf62198e/src/PubSub/AbstractConsumer.php#L181-L192
PHP will change return type for `\Iterator::rewind()` to `: void` in PHP 9, so this code won't be valid with next PHP major update.
I left this without changes for initiate a discussion - what I need to do about this method signature - possibly break BC with changing return (drop return a value) or just specify "invalid" return type in phpdoc (`@return void`) to suppress error from `symfony/error-handler`