### PR TITLE
Add clear method to pipeline

### DIFF
--- a/src/Pipeline/Pipeline.php
+++ b/src/Pipeline/Pipeline.php
@@ -232,8 +232,9 @@ class Pipeline implements ClientContextInterface
      */
     public function clear()
     {
-        $this->pipeline = new \SplQueue();
         $this->responses = array();
+        $this->pipeline = new \SplQueue();
+
         return $this;
     }
 

--- a/src/Pipeline/Pipeline.php
+++ b/src/Pipeline/Pipeline.php
@@ -226,6 +226,18 @@ class Pipeline implements ClientContextInterface
     }
 
     /**
+     * Clear the buffer holding all of the commands and responses.
+     *
+     * @return $this
+     */
+    public function clear()
+    {
+        $this->pipeline = new \SplQueue();
+        $this->responses = array();
+        return $this;
+    }
+
+    /**
      * Returns if the pipeline should throw exceptions on server errors.
      *
      * @return bool


### PR DESCRIPTION
Using Predis in the pipelines context, I noticed that the current solution does not allow to optimally efficient way to reusing pipelines. It is related to the `flushPipeline()` method which cleans the pipeline itself, but it does not clean the responses. For scripts that execute a large number of commands responses starts to consume a huge amount of memory.
This is very easy to solve, when cleaning the pipeline we can also clean the responses array. I decided to add a new method `clear()` - to clear the buffer and the responses array.

A small example of memory increase in solutions ( A simple benchmark for a million echo('.') calls in a pipeline with `execute()` and `flushPipeline()` in chunks of 100000 elements ).

Current:

> Start: 651.09 KB
> Before: 50.09 MB
> After: 5.66 MB
> Before: 54.41 MB
> After: 9.66 MB
> Before: 57.88 MB
> After: 17.66 MB
> Before: 66.1 MB
> After: 17.66 MB
> Before: 66.26 MB
> After: 17.66 MB
> Before: 66.41 MB
> After: 33.66 MB
> Before: 80.96 MB
> After: 33.66 MB
> Before: 80.96 MB
> After: 33.66 MB
> Before: 80.96 MB
> After: 33.66 MB
> Before: 80.96 MB
> After: 33.66 MB
> Finish: 33.66 MB


When using `clear()` method after `execute()`:

> Start: 651.09 KB
> Before: 50.09 MB
> After: 1.65 MB
> Before: 50.41 MB
> After: 1.65 MB
> Before: 49.87 MB
> After: 1.65 MB
> Before: 50.1 MB
> After: 1.65 MB
> Before: 50.25 MB
> After: 1.65 MB
> Before: 50.41 MB
> After: 1.65 MB
> Before: 48.95 MB
> After: 1.65 MB
> Before: 48.95 MB
> After: 1.65 MB
> Before: 48.95 MB
> After: 1.65 MB
> Before: 48.95 MB
> After: 1.65 MB
> Finish: 1.65 MB


**Why not clear array of results using `flushPipeline()`?**

Example:
```
    public function flushPipeline($send = true)
    {
        if ($send && !$this->pipeline->isEmpty()) {
            $responses = $this->executePipeline($this->getConnection(), $this->pipeline);
            $this->responses = array_merge($this->responses, $responses);
        } else {
            $this->pipeline = new \SplQueue();
            $this->responses = array();
        }

        return $this;
    }
```
Unfortunately, even though there is no logical reason in my opinion to follow instructions order like this:

```
$pipeline->flushPipelines();
$responses = $pipeline->execute();
```

I can't confirm that anyone is using it this way, for this example `$responses` will no longer hold the array of old responses, which can probably cause some problems in such a solution.
Which can also be noticed in the test:

> Predis\Pipeline\PipelineTest::testExecuteWithFilledBuffer

Of course, if there was a wish to take that risk, I could propose such a change at the `flushPipeline()` level.