### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,5 @@
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit.xml.travisci export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore


### PR DESCRIPTION
Make the vendor 56kb smaller,
is it possible or is there any reason not to do it?