### PR TITLE
Use env var to get changed FLUSHDB command

### DIFF
--- a/src/Command/ServerFlushDatabase.php
+++ b/src/Command/ServerFlushDatabase.php
@@ -23,6 +23,6 @@ class ServerFlushDatabase extends Command
      */
     public function getId()
     {
-        return 'FLUSHDB';
+        return getenv('REDIS_FLUSHDB_COMMAND', true) ? getenv('REDIS_FLUSHDB_COMMAND') : 'FLUSHDB';
     }
 }


### PR DESCRIPTION
It's common to change certain commands in Redis for security reasons. When using Laravel and running artisan command cache:clear the command will throw an error because FLUSHDB command was changed. My change uses an optional env variable to set the changed FLUSHDB command. I'm open to doing this for other critical command if necessary. 