### PR TITLE
Use SENTINEL REPLICAS instead of SENTINEL SLAVES, closes #754

### DIFF
--- a/src/Command/ServerSentinel.php
+++ b/src/Command/ServerSentinel.php
@@ -45,7 +45,7 @@ class ServerSentinel extends Command
     }
 
     /**
-     * Returns a processed response to SENTINEL MASTERS or SENTINEL SLAVES.
+     * Returns a processed response to SENTINEL MASTERS or SENTINEL REPLICAS.
      *
      * @param array $servers List of Redis servers.
      *

--- a/src/Connection/Aggregate/SentinelReplication.php
+++ b/src/Connection/Aggregate/SentinelReplication.php
@@ -381,7 +381,7 @@ class SentinelReplication implements ReplicationInterface
         $slaves = array();
 
         $payload = $sentinel->executeCommand(
-            RawCommand::create('SENTINEL', 'slaves', $service)
+            RawCommand::create('SENTINEL', 'replicas', $service)
         );
 
         if ($payload instanceof ErrorResponseInterface) {


### PR DESCRIPTION
Use SENTINEL REPLICAS instead of SENTINEL SLAVES, which was removed in Redis 7.

Trivial implementation. This breaks compatibility with Redis Sentinel setups based on Redis < 5.0. If this is not acceptable, the code will need some refactoring to support all Redis versions.