### PR TITLE
Testing code against Redis 7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        redis-versions: ['3', '4', '5', '6']
+        redis-versions: ['3', '4', '5', '6', '7']
 
     steps:
     - name: Checkout

--- a/tests/Predis/Command/Redis/COMMAND_Test.php
+++ b/tests/Predis/Command/Redis/COMMAND_Test.php
@@ -106,11 +106,32 @@ class COMMAND_Test extends PredisCommandTestCase
 
         // NOTE: starting with Redis 6.0 and the introduction of Access Control
         // Lists, COMMAND INFO returns an additional array for each specified
-        // command in yhe request with a list of the ACL categories associated
+        // command in the request with a list of the ACL categories associated
         // to a command. We simply append this additional array in the expected
         // response if the test suite is executed against Redis >= 6.0.
         if ($this->isRedisServerVersion('>=', '6.0')) {
             $expected[0][] = array('@read', '@string', '@fast');
+        }
+
+        // NOTE: starting with Redis 7.0 COMMAND INFO returns an additional arrays:
+        // - Command tips: https://redis.io/topics/command-tips.
+        // - Key specifications: https://redis.io/topics/key-specs.
+        // - Subcommands: https://redis.io/commands/command/#subcommands.
+        // We simply append this additional array in the expected response if the
+        // test suite is executed against Redis >= 7.0.
+        if ($this->isRedisServerVersion('>=', '7.0')) {
+            $expected[0][] = array();
+            $expected[0][] = array(
+                array(
+                    'flags',
+                    array('RO','access'),
+                    'begin_search',
+                    array('type','index','spec', array('index',1)),
+                    'find_keys',
+                    array('type','range','spec', array('lastkey',0,'keystep',1,'limit',0))
+                )
+            );
+            $expected[0][] = array();
         }
 
         $this->assertCount(1, $response = $redis->command('INFO', 'GET'));

--- a/tests/Predis/Command/Redis/CONFIG_Test.php
+++ b/tests/Predis/Command/Redis/CONFIG_Test.php
@@ -143,7 +143,7 @@ class CONFIG_Test extends PredisCommandTestCase
     public function testThrowsExceptionWhenSettingUnknownConfiguration(): void
     {
         $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR Unsupported CONFIG parameter: foo');
+        $this->expectExceptionMessageMatches("/ERR|CONFIG|foo|arguments|parameter/");
 
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/CONFIG_Test.php
+++ b/tests/Predis/Command/Redis/CONFIG_Test.php
@@ -143,7 +143,13 @@ class CONFIG_Test extends PredisCommandTestCase
     public function testThrowsExceptionWhenSettingUnknownConfiguration(): void
     {
         $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessageMatches("/ERR|CONFIG|foo|arguments|parameter/");
+        if ($this->isRedisServerVersion('<=', '6.0')) {
+            $this->expectExceptionMessage('ERR Unsupported CONFIG parameter: foo');
+        }
+
+        if ($this->isRedisServerVersion('>=', '7.0')) {
+            $this->expectExceptionMessage("ERR Unknown option or number of arguments for CONFIG SET - 'foo'");
+        }
 
         $redis = $this->getClient();
 


### PR DESCRIPTION
This PR make sure that tests will pass against Redis 7.

PS: this PR will just make tests pass against redis 7, it does not add any new feature or changes which was implemented in redis 7 like the changes in the replication naming.