### PR TITLE
Remove redundant variables

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -209,9 +209,7 @@ class Client implements ClientInterface, \IteratorAggregate
             throw new \InvalidArgumentException("Cannot find a connection by $selector matching `$value`");
         }
 
-        $client = new static($connection, $this->getOptions());
-
-        return $client;
+        return new static($connection, $this->getOptions());
     }
 
     /**

--- a/src/Cluster/Distributor/HashRing.php
+++ b/src/Cluster/Distributor/HashRing.php
@@ -239,9 +239,8 @@ class HashRing implements DistributorInterface, HashGeneratorInterface
     public function get($value)
     {
         $hash = $this->hash($value);
-        $node = $this->getByHash($hash);
 
-        return $node;
+        return $this->getByHash($hash);
     }
 
     /**

--- a/src/Cluster/PredisStrategy.php
+++ b/src/Cluster/PredisStrategy.php
@@ -40,9 +40,8 @@ class PredisStrategy extends ClusterStrategy
     {
         $key = $this->extractKeyTag($key);
         $hash = $this->distributor->hash($key);
-        $slot = $this->distributor->getSlot($hash);
 
-        return $slot;
+        return $this->distributor->getSlot($hash);
     }
 
     /**

--- a/src/Cluster/RedisStrategy.php
+++ b/src/Cluster/RedisStrategy.php
@@ -41,9 +41,8 @@ class RedisStrategy extends ClusterStrategy
     public function getSlotByKey($key)
     {
         $key = $this->extractKeyTag($key);
-        $slot = $this->hashGenerator->hash($key) & 0x3FFF;
 
-        return $slot;
+        return $this->hashGenerator->hash($key) & 0x3FFF;
     }
 
     /**

--- a/src/Command/RawCommand.php
+++ b/src/Command/RawCommand.php
@@ -51,9 +51,8 @@ final class RawCommand implements CommandInterface
     public static function create($commandID /* [ $arg, ... */)
     {
         $arguments = func_get_args();
-        $command = new static(array_shift($arguments), $arguments);
 
-        return $command;
+        return new static(array_shift($arguments), $arguments);
     }
 
     /**

--- a/src/Connection/Cluster/PredisCluster.php
+++ b/src/Connection/Cluster/PredisCluster.php
@@ -138,9 +138,7 @@ class PredisCluster implements ClusterInterface, \IteratorAggregate, \Countable
             );
         }
 
-        $node = $this->distributor->getBySlot($slot);
-
-        return $node;
+        return $this->distributor->getBySlot($slot);
     }
 
     /**
@@ -189,9 +187,7 @@ class PredisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     public function getConnectionByKey($key)
     {
         $hash = $this->strategy->getSlotByKey($key);
-        $node = $this->distributor->getBySlot($hash);
-
-        return $node;
+        return $this->distributor->getBySlot($hash);
     }
 
     /**

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -442,9 +442,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
         }
 
         $this->move($connection, $slot);
-        $response = $this->executeCommand($command);
-
-        return $response;
+        return $this->executeCommand($command);
     }
 
     /**
@@ -465,9 +463,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
         }
 
         $connection->executeCommand(RawCommand::create('ASKING'));
-        $response = $connection->executeCommand($command);
-
-        return $response;
+        return $connection->executeCommand($command);
     }
 
     /**

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -266,9 +266,7 @@ class SentinelReplication implements ReplicationInterface
             }
         }
 
-        $connection = $this->connectionFactory->create($parameters);
-
-        return $connection;
+        return $this->connectionFactory->create($parameters);
     }
 
     /**

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -151,9 +151,7 @@ class StreamConnection extends AbstractConnection
             }
         }
 
-        $resource = $this->createStreamSocket($parameters, $address, $flags);
-
-        return $resource;
+        return $this->createStreamSocket($parameters, $address, $flags);
     }
 
     /**
@@ -183,9 +181,7 @@ class StreamConnection extends AbstractConnection
             }
         }
 
-        $resource = $this->createStreamSocket($parameters, "unix://{$parameters->path}", $flags);
-
-        return $resource;
+        return $this->createStreamSocket($parameters, "unix://{$parameters->path}", $flags);
     }
 
     /**

--- a/src/Protocol/Text/ResponseReader.php
+++ b/src/Protocol/Text/ResponseReader.php
@@ -95,9 +95,7 @@ class ResponseReader implements ResponseReaderInterface
             $this->onProtocolError($connection, "Unknown response prefix: '$prefix'");
         }
 
-        $payload = $this->handlers[$prefix]->handle($connection, substr($header, 1));
-
-        return $payload;
+        return $this->handlers[$prefix]->handle($connection, substr($header, 1));
     }
 
     /**


### PR DESCRIPTION
This PR has no significant code change, or solve any specific problem. 

It just remove the usage of redundant variables when using the `return` statement.

for example, instead of having 

```php
$client = new static($connection, $this->getOptions());

return $client;
```

it will return the client directly like

```php
return new static($connection, $this->getOptions());
```
 