### PR TITLE
Allow PubSub / MultiExec with Replication

### DIFF
--- a/src/Monitor/Consumer.php
+++ b/src/Monitor/Consumer.php
@@ -12,7 +12,7 @@
 namespace Predis\Monitor;
 
 use Predis\ClientInterface;
-use Predis\Connection\AggregateConnectionInterface;
+use Predis\Connection\Cluster\ClusterInterface;
 use Predis\NotSupportedException;
 
 /**
@@ -56,9 +56,9 @@ class Consumer implements \Iterator
      */
     private function assertClient(ClientInterface $client)
     {
-        if ($client->getConnection() instanceof AggregateConnectionInterface) {
+        if ($client->getConnection() instanceof ClusterInterface) {
             throw new NotSupportedException(
-                'Cannot initialize a monitor consumer over aggregate connections.'
+                'Cannot initialize a monitor consumer over cluster connections.'
             );
         }
 

--- a/src/PubSub/Consumer.php
+++ b/src/PubSub/Consumer.php
@@ -14,7 +14,7 @@ namespace Predis\PubSub;
 use Predis\ClientException;
 use Predis\ClientInterface;
 use Predis\Command\Command;
-use Predis\Connection\AggregateConnectionInterface;
+use Predis\Connection\Cluster\ClusterInterface;
 use Predis\NotSupportedException;
 
 /**
@@ -62,9 +62,9 @@ class Consumer extends AbstractConsumer
      */
     private function checkCapabilities(ClientInterface $client)
     {
-        if ($client->getConnection() instanceof AggregateConnectionInterface) {
+        if ($client->getConnection() instanceof ClusterInterface) {
             throw new NotSupportedException(
-                'Cannot initialize a PUB/SUB consumer over aggregate connections.'
+                'Cannot initialize a PUB/SUB consumer over cluster connections.'
             );
         }
 

--- a/src/Transaction/MultiExec.php
+++ b/src/Transaction/MultiExec.php
@@ -16,7 +16,7 @@ use Predis\ClientException;
 use Predis\ClientInterface;
 use Predis\Command\CommandInterface;
 use Predis\CommunicationException;
-use Predis\Connection\AggregateConnectionInterface;
+use Predis\Connection\Cluster\ClusterInterface;
 use Predis\NotSupportedException;
 use Predis\Protocol\ProtocolException;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
@@ -66,9 +66,9 @@ class MultiExec implements ClientContextInterface
      */
     private function assertClient(ClientInterface $client)
     {
-        if ($client->getConnection() instanceof AggregateConnectionInterface) {
+        if ($client->getConnection() instanceof ClusterInterface) {
             throw new NotSupportedException(
-                'Cannot initialize a MULTI/EXEC transaction over aggregate connections.'
+                'Cannot initialize a MULTI/EXEC transaction over cluster connections.'
             );
         }
 

--- a/tests/Predis/Monitor/ConsumerTest.php
+++ b/tests/Predis/Monitor/ConsumerTest.php
@@ -46,9 +46,9 @@ class ConsumerTest extends PredisTestCase
     public function testMonitorConsumerDoesNotWorkOnClusters(): void
     {
         $this->expectException('Predis\NotSupportedException');
-        $this->expectExceptionMessage('Cannot initialize a monitor consumer over aggregate connections');
+        $this->expectExceptionMessage('Cannot initialize a monitor consumer over cluster connections');
 
-        $cluster = $this->getMockBuilder('Predis\Connection\AggregateConnectionInterface')->getMock();
+        $cluster = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
         $client = new Client($cluster);
 
         new MonitorConsumer($client);

--- a/tests/Predis/PubSub/ConsumerTest.php
+++ b/tests/Predis/PubSub/ConsumerTest.php
@@ -45,7 +45,7 @@ class ConsumerTest extends PredisTestCase
     public function testPubSubConsumerDoesNotWorkOnClusters(): void
     {
         $this->expectException('Predis\NotSupportedException');
-        $this->expectExceptionMessage('Cannot initialize a PUB/SUB consumer over aggregate connections');
+        $this->expectExceptionMessage('Cannot initialize a PUB/SUB consumer over cluster connections');
 
         $cluster = $this->getMockBuilder('Predis\Connection\Cluster\ClusterInterface')->getMock();
         $client = new Client($cluster);


### PR DESCRIPTION
This is a rebase of #514 for the v2 branch. It allows to use PUB/SUB and MULTI/EXEC with a Redis Master/Slave replication setup. 

Currently, Predis throws an exception when using these commands with any _aggregate_ connection. This exception should only be thrown for _cluster_ connections but not for _replication_ connections.

I have been using this patch for several years in a Redis master/slave setup and it is working fine.