### PR TITLE
Declare `$parameters` property of `Predis\Connection\Parameters`

### DIFF
--- a/src/Connection/Parameters.php
+++ b/src/Connection/Parameters.php
@@ -27,6 +27,14 @@ class Parameters implements ParametersInterface
     );
 
     /**
+     * Set of connection paramaters already filtered
+     * for NULL or 0-length string values.
+     * 
+     * @var array
+     */
+    protected $parameters;
+
+    /**
      * @param array $parameters Named array of connection parameters.
      */
     public function __construct(array $parameters = array())


### PR DESCRIPTION
As of PHP 8.2, creation of dynamic properties is already deprecated.
```
Creation of dynamic property Predis\Connection\Parameters::$parameters is deprecated
```