### PR TITLE
FixedPasswordForSentinel

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -263,6 +263,7 @@ class SentinelReplication implements ReplicationInterface
             // in a later release.
             $parameters['database'] = null;
             $parameters['username'] = null;
+            $parameters['password'] = null;
 
             if (!isset($parameters['timeout'])) {
                 $parameters['timeout'] = $this->sentinelTimeout;


### PR DESCRIPTION
Hi, 
There is an issue when creating a redis-sentinel connection. Your password is not taken into consideration and you get No sentinel server available for autodiscovery.

After testing older versions where it worked, I looked it up. Apparently this was also a bug in an earlier version that was fixed. See: https://github.com/predis/predis/commit/16957f3b39679b42b08ed2100debf4af89170fa4

My fix does not include the Unit Tests, only the fix that I needed to get the Sentinels working. Please let me know if this gets in a version since I would like to stay up to date from composer with this library, instead having to copy it locally or downgrade to an older version.

Thanks!