### PR TITLE
Do not use password for sentinel

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -268,6 +268,7 @@ class SentinelReplication implements ReplicationInterface
             // in a later release.
             $parameters['database'] = null;
             $parameters['username'] = null;
+            $parameters['password'] = null;
 
             if (!isset($parameters['timeout'])) {
                 $parameters['timeout'] = $this->sentinelTimeout;

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -38,7 +38,7 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParametersForSentinelConnectionShouldUsePasswordForAuthentication(): void
+    public function testParametersForSentinelConnectionShouldNotUsePasswordForAuthentication(): void
     {
         $replication = $this->getReplicationConnection('svc', array(
             'tcp://127.0.0.1:5381?alias=sentinel1&password=secret',
@@ -46,7 +46,7 @@ class SentinelReplicationTest extends PredisTestCase
 
         $parameters = $replication->getSentinelConnection()->getParameters()->toArray();
 
-        $this->assertArrayHasKey('password', $parameters, 'Parameter `passwords` was expected to exist in connection parameters');
+        $this->assertArrayNotHasKey('password', $parameters, 'Parameter `passwords` was expected to exist in connection parameters');
     }
 
     /**


### PR DESCRIPTION
After update to 2.0 it's not possible to connect to sentinel server that worked fine with 1.1.10. I went over 

#783 and #782 fixed unit tests there and I'm opened up if something more needs to be created (maybe adding some new option rather to use sentinel auth or no)