### PR TITLE
Add retry logic to support temporary redis cluster failure

### DIFF
--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -12,7 +12,6 @@
 namespace Predis\Connection\Cluster;
 
 use Predis\ClientException;
-use Predis\NotSupportedException;
 use Predis\Cluster\RedisStrategy as RedisClusterStrategy;
 use Predis\Cluster\SlotMap;
 use Predis\Cluster\StrategyInterface;
@@ -21,6 +20,7 @@ use Predis\Command\RawCommand;
 use Predis\Connection\ConnectionException;
 use Predis\Connection\FactoryInterface;
 use Predis\Connection\NodeConnectionInterface;
+use Predis\NotSupportedException;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
 use Predis\Response\Error as ErrorResponse;
@@ -56,7 +56,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     private $strategy;
     private $connections;
     private $retryLimit = 5;
-    private $retryInterval = 50;
+    private $retryInterval = 10;
 
     /**
      * @param FactoryInterface  $connections Optional connection factory.

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -80,7 +80,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
      *
      * @param int $retry Number of retry attempts.
      */
-    public function setRetryInterval($retry)
+    public function setRetryLimit($retry)
     {
         $this->retryLimit = (int) $retry;
     }
@@ -88,7 +88,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     /**
      * Sets the initial retry interval (milliseconds).
      * 
-     * @param float $retry After Retry time (second).
+     * @param float $retryInterval Milliseconds between retries.
      */
     public function setRetryInterval($retryInterval)
     {

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -495,18 +495,20 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
             try {
                 $response = $this->getConnectionByCommand($command)->$method($command);
 
-                if ($response instanceof \Predis\Response\Error){
-                    $message = $response->getMessage() ;
-                    if (strpos($message, "CLUSTERDOWN") === 0 ) {
-                        sleep (2**($retries+1)); 
-                        throw new ServerException($message) ;
+                if ($response instanceof \Predis\Response\Error) {
+                    $message = $response->getMessage();
+
+                    if (strpos($message, "CLUSTERDOWN") === 0) {
+                        sleep (2**($retries+1));
+
+                        throw new ServerException($message);
                     }
                 }
             } catch (\Throwable $exception) {
-                if ($exception instanceof \Predis\Connection\ConnectionException){
+                if ($exception instanceof \Predis\Connection\ConnectionException) {
                     $connection = $exception->getConnection();
                     
-                    if ($connection){
+                    if ($connection) {
                         $connection->disconnect();
                         $this->remove($connection);
                     }
@@ -518,8 +520,12 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
                     $this->askSlotMap();
                 }
 
-                ++$retries ;
-                if ($retries === $this->retryLimit ) $failure = true;
+                ++$retries;
+
+                if ($retries === $this->retryLimit) {
+                    $failure = true;
+                }
+
                 sleep(2**$retries);
 
                 goto RETRY_COMMAND;

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -24,7 +24,6 @@ use Predis\NotSupportedException;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
 
-
 /**
  * Abstraction for a Redis-backed cluster of nodes (Redis >= 3.0.0).
  *

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -527,7 +527,6 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
                     }
                 }
             } catch (\Throwable $exception) {
-
                 usleep($retryAfter * 1000000);
                 $retryAfter = $retryAfter * 2;
 

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -88,21 +88,21 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     /**
      * Sets the initial retry interval (milliseconds).
      * 
-     * @param float $retryInterval Milliseconds between retries.
+     * @param int $retryInterval Milliseconds between retries.
      */
     public function setRetryInterval($retryInterval)
     {
-        $this->retryInterval = (float) $retryInterval;
+        $this->retryInterval = (int) $retryInterval;
     }
 
     /**
      * Returns the retry interval (milliseconds).
      *
-     * @return float
+     * @return int Milliseconds between retries.
      */
     public function getRetryInterval()
     {
-        return (float) $this->retryInterval;
+        return (int) $this->retryInterval;
     }
 
     /**

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -86,10 +86,9 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * Sets the first minimal retry time duration upon server failure.
+     * Sets the first retry time upon server failure.
      * 
-     * @param float $retryAfter Retry time (second).
-     *
+     * @param float $retry After Retry time (second).
      */
     public function setMinRetryAfter($retryAfter)
     {
@@ -97,8 +96,9 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * gets the first minimal retry time duration upon server failure.
+     * Returns the initial retry time.
      *
+     * @return float
      */
     public function getMinRetryAfter()
     {
@@ -522,7 +522,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
                 if ($response instanceof ErrorResponse) {
                     $message = $response->getMessage();
 
-                    if (strpos($message, "CLUSTERDOWN") === 0) {
+                    if (strpos($message, 'CLUSTERDOWN') !== false) {
                         throw new ServerException($message);
                     }
                 }

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -23,6 +23,7 @@ use Predis\Connection\NodeConnectionInterface;
 use Predis\NotSupportedException;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
+use Predis\Response\Error as ErrorResponse;
 
 /**
  * Abstraction for a Redis-backed cluster of nodes (Redis >= 3.0.0).
@@ -510,7 +511,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
      */
     private function retryCommandOnFailure(CommandInterface $command, $method)
     {
-        $retries = 0 ;
+        $retries = 0;
 
         $retryAfter = $this->minRetryAfter;
 
@@ -518,7 +519,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
             try {
                 $response = $this->getConnectionByCommand($command)->$method($command);
 
-                if ($response instanceof \Predis\Response\Error) {
+                if ($response instanceof ErrorResponse) {
                     $message = $response->getMessage();
 
                     if (strpos($message, "CLUSTERDOWN") === 0) {
@@ -530,7 +531,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
                 usleep($retryAfter * 1000000);
                 $retryAfter = $retryAfter * 2;
 
-                if ($exception instanceof \Predis\Connection\ConnectionException) {
+                if ($exception instanceof ConnectionException) {
                     $connection = $exception->getConnection();
                     
                     if ($connection) {

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1431,7 +1431,10 @@ class RedisClusterTest extends PredisTestCase
         $cluster->askSlotMap();
         $endTime = time();
         $totalTime=$endTime-$startTime;
-        $expectedTime = (2 + 2**2 )  ; // expected time for 2 retries (fail 1=wait 2s, fail 2=wait 4s , OK)
+        $t1 = $cluster->getMinRetryAfter()  ;
+        $t2 = $t1 * 2;
+
+        $expectedTime = ($t1 + $t2 )  ; // expected time for 2 retries (fail 1=wait 2s, fail 2=wait 4s , OK)
         $this->AssertEqualsWithDelta($expectedTime, $totalTime, 1, "Unexpected execution time") ;
 
         $this->assertCount(16384, $cluster->getSlotMap());

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1427,7 +1427,7 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection2);
         $cluster->add($connection3);
 
-	$cluster->setRetryInterval(2000);
+        $cluster->setRetryInterval(2000);
 
         $startTime = time() ;
         $cluster->askSlotMap();

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1301,4 +1301,139 @@ class RedisClusterTest extends PredisTestCase
 
         $this->assertEquals($cluster, $unserialized);
     }
+
+    /**
+     * @medium
+     * @group disconnected
+     * @group slow 
+     */
+    public function testRetryCommandSuccessOnClusterDownErrors()
+    {
+        $clusterDownError= new Response\Error("CLUSTERDOWN") ;
+
+	    $command = Command\RawCommand::create('get', 'node:1001');
+
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
+        $connection1->expects($this->exactly(3))
+                    ->method('executeCommand')
+                    ->with($command)
+                    ->will($this->onConsecutiveCalls(
+                            $clusterDownError,
+                            $clusterDownError,
+                            'foobar'));
+
+        $cluster = new RedisCluster(new Connection\Factory());
+        $cluster->useClusterSlots(false);
+        $cluster->setRetryLimit(2);
+        $cluster->add($connection1);
+
+        $this->assertSame('foobar', $cluster->executeCommand($command));
+    }
+
+    /**
+     * @medium
+     * @group disconnected
+     * @group slow 
+     */
+    public function testRetryCommandFailureOnClusterDownErrors()
+    {
+        $this->expectException('Predis\Response\ServerException');
+        $this->expectExceptionMessage('CLUSTERDOWN');
+
+        $clusterDownError= new Response\Error("CLUSTERDOWN") ;
+
+        $command = Command\RawCommand::create('get', 'node:1001');
+
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
+        $connection1->expects($this->exactly(3))
+                    ->method('executeCommand')
+                    ->with($command)
+                    ->will($this->onConsecutiveCalls(
+                            $clusterDownError,
+                            $clusterDownError,
+                            $clusterDownError
+                            ));
+
+
+        $cluster = new RedisCluster(new Connection\Factory());
+        $cluster->useClusterSlots(false);
+        $cluster->setRetryLimit(2);
+        $cluster->add($connection1);
+
+        $cluster->executeCommand($command);
+    }
+
+    /**
+     * @medium
+     * @group disconnected
+     * @group slow 
+     */
+    public function testQueryClusterNodeForSlotMapPauseDurationOnRetry()
+    {
+        $slotsmap = array(
+            array(0, 5460, array('127.0.0.1', 9381), array()),
+            array(5461, 10922, array('127.0.0.1', 6382), array()),
+            array(10923, 16383, array('127.0.0.1', 6383), array()),
+        );
+
+        $connection1 = $this->getMockConnection('tcp://127.0.0.1:6381?slots=0-5460');
+        $connection1
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->isRedisCommand(
+                'CLUSTER', array('SLOTS')
+            ))
+            ->willThrowException(
+                new Connection\ConnectionException($connection1, 'Unknown connection error [127.0.0.1:6381]')
+            );
+
+        $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382?slots=5461-10922');
+        $connection2
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->isRedisCommand(
+                'CLUSTER', array('SLOTS')
+            ))
+            ->willThrowException(
+                new Connection\ConnectionException($connection2, 'Unknown connection error [127.0.0.1:6383]')
+            );
+
+        $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383?slots=10923-16383');
+        $connection3
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->isRedisCommand(
+                'CLUSTER', array('SLOTS')
+            ))
+            ->willReturn($slotsmap);
+
+        $factory = $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock();
+        $factory
+            ->expects($this->never())
+            ->method('create');
+
+        // TODO: I'm not sure about mocking a protected method, but it'll do for now
+        /** @var Connection\Cluster\RedisCluster|MockObject */
+        $cluster = $this->getMockBuilder('Predis\Connection\Cluster\RedisCluster')
+            ->onlyMethods(array('getRandomConnection'))
+            ->setConstructorArgs(array($factory))
+            ->getMock();
+        $cluster
+            ->expects($this->exactly(3))
+            ->method('getRandomConnection')
+            ->willReturnOnConsecutiveCalls($connection1, $connection2, $connection3);
+
+        $cluster->add($connection1);
+        $cluster->add($connection2);
+        $cluster->add($connection3);
+
+        $startTime = time() ;
+        $cluster->askSlotMap();
+        $endTime = time();
+        $totalTime=$endTime-$startTime;
+        $expectedTime = (2 + 2**2 )  ; // expected time for 2 retries (fail 1=wait 2s, fail 2=wait 4s , OK)
+        $this->AssertEqualsWithDelta($expectedTime, $totalTime, 1, "Unexpected execution time") ;
+
+        $this->assertCount(16384, $cluster->getSlotMap());
+    }
 }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1427,14 +1427,16 @@ class RedisClusterTest extends PredisTestCase
         $cluster->add($connection2);
         $cluster->add($connection3);
 
+	$cluster->setRetryInterval(2000);
+
         $startTime = time() ;
         $cluster->askSlotMap();
         $endTime = time();
         $totalTime=$endTime-$startTime;
-        $t1 = $cluster->getMinRetryAfter()  ;
+        $t1 = $cluster->getRetryInterval()  ;
         $t2 = $t1 * 2;
 
-        $expectedTime = ($t1 + $t2 )  ; // expected time for 2 retries (fail 1=wait 2s, fail 2=wait 4s , OK)
+        $expectedTime = ($t1 + $t2 )/1000  ; // expected time for 2 retries (fail 1=wait 2s, fail 2=wait 4s , OK)
         $this->AssertEqualsWithDelta($expectedTime, $totalTime, 1, "Unexpected execution time") ;
 
         $this->assertCount(16384, $cluster->getSlotMap());


### PR DESCRIPTION
This changes are trying to complete the retry logic in order to increase the tolerance to a temporary unavailability of a redis cluster.

Tests are slow (retries...), so I added the to group "slow": 

`vendor/bin/phpunit --group slow --filter RedisClusterTest
`
Related to PR #732