### PR TITLE
sentinel default to no password when replica authentication is used

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -268,6 +268,9 @@ class SentinelReplication implements ReplicationInterface
             // in a later release.
             $parameters['database'] = null;
             $parameters['username'] = null;
+            if (!isset($parameters['password'])) {
+                $parameters['password'] = null;
+            }
 
             if (!isset($parameters['timeout'])) {
                 $parameters['timeout'] = $this->sentinelTimeout;

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -268,7 +268,10 @@ class SentinelReplication implements ReplicationInterface
             // in a later release.
             $parameters['database'] = null;
             $parameters['username'] = null;
-            if (!isset($parameters['password'])) {
+
+            // don't leak password from between configurations
+            // https://github.com/predis/predis/pull/807/#discussion_r985764770
+            if (! isset($parameters['password'])) {
                 $parameters['password'] = null;
             }
 

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -62,6 +62,7 @@ class SentinelReplicationTest extends PredisTestCase
 
         $this->assertArrayNotHasKey('database', $parameters, 'Parameter `database` was expected to not exist in connection parameters');
         $this->assertArrayNotHasKey('username', $parameters, 'Parameter `username` was expected to not exist in connection parameters');
+        $this->assertArrayNotHasKey('password', $parameters, 'Parameter `password` was expected to not exist in connection parameters');
     }
 
     /**
@@ -115,6 +116,30 @@ class SentinelReplicationTest extends PredisTestCase
         $this->assertSame($originalParameters, $parameters);
         $this->assertNotNull($parameters->password);
         $this->assertNotNull($parameters->database);
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testConnectionParametersInstanceForSentinelConnectionIsNotModifiedEmptyPassword(): void
+    {
+        $sentinel1 = Connection\Parameters::create('tcp://127.0.0.1:5381?role=sentinel&database=1&password=');
+        $sentinel2 = Connection\Parameters::create('tcp://127.0.0.1:5381?role=sentinel&database=1');
+
+        $replication1 = $this->getReplicationConnection('svc', array($sentinel1));
+        $replication2 = $this->getReplicationConnection('svc', array($sentinel2));
+
+        $parameters1 = $replication1->getSentinelConnection()->getParameters();
+        $parameters2 = $replication2->getSentinelConnection()->getParameters();
+
+        $this->assertSame($sentinel1, $parameters1);
+        $this->assertSame($sentinel2, $parameters2);
+
+        $this->assertNull($parameters1->password);
+        $this->assertNull($parameters2->password);
+
+        $this->assertNotNull($parameters1->database);
+        $this->assertNotNull($parameters2->database);
     }
 
     /**

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -62,7 +62,6 @@ class StreamConnectionTest extends PredisConnectionTestCase
      */
     public function testDoesntThrowErrorOnInvalidResource(): void
     {
-        var_dump('PHP v' . PHP_VERSION);
         $this->expectException('Predis\Connection\ConnectionException');
 
         $cmdSelect = RawCommand::create('SELECT', '1000');


### PR DESCRIPTION
In order to work with replica authentication but no sentinel authentication, empty password (`password=`) needs to be added to the sentinel uri but this is not documented and possibly not expected.

This pr removes the requirement for empty password and defaults to no password if it is not provided.