### PR TITLE
added annotations to suppress PHP 8.1 return type deprecation warning…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,8 @@
 
 namespace Predis;
 
+use Traversable;
+
 use Predis\Command\CommandInterface;
 use Predis\Command\RawCommand;
 use Predis\Command\ScriptCommand;
@@ -26,7 +28,6 @@ use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ResponseInterface;
 use Predis\Response\ServerException;
 use Predis\Transaction\MultiExec as MultiExecTransaction;
-use Traversable;
 
 /**
  * Client class used for connecting and executing commands on Redis.

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,6 +26,7 @@ use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ResponseInterface;
 use Predis\Response\ServerException;
 use Predis\Transaction\MultiExec as MultiExecTransaction;
+use Traversable;
 
 /**
  * Client class used for connecting and executing commands on Redis.
@@ -35,6 +36,9 @@ use Predis\Transaction\MultiExec as MultiExecTransaction;
  * one with its own responsibility and scope.
  *
  * {@inheritdoc}
+ * @template TKey
+ * @template TValue
+ * @template-implements Traversable<TKey, TValue>
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
@@ -378,7 +382,7 @@ class Client implements ClientInterface, \IteratorAggregate
                     : $this->$initializer(null, $argv[0]);
 
             case 2:
-                list($arg0, $arg1) = $argv;
+                [$arg0, $arg1] = $argv;
 
                 return $this->$initializer($arg0, $arg1);
 
@@ -512,6 +516,7 @@ class Client implements ClientInterface, \IteratorAggregate
 
     /**
      * {@inheritdoc}
+     * @return Traversable<TKey, TValue>|TValue[]
      */
     #[\ReturnTypeWillChange]
     public function getIterator()
@@ -519,7 +524,7 @@ class Client implements ClientInterface, \IteratorAggregate
         $clients = array();
         $connection = $this->getConnection();
 
-        if (!$connection instanceof \Traversable) {
+        if (!$connection instanceof Traversable) {
             return new \ArrayIterator(array(
                 (string) $connection => new static($connection, $this->getOptions())
             ));


### PR DESCRIPTION
… for `IteratorAggregate::toIterator()`
fixes #736 