### PR TITLE
Adding the release drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,48 @@
+name-template: '$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+autolabeler:
+  - label: 'maintenance'
+    files:
+      - '*.md'
+      - '.github/*'
+  - label: 'bug'
+    branch:
+      - '/bug-.+'
+  - label: 'maintenance'
+    branch:
+      - '/maintenance-.+'
+  - label: 'feature'
+    branch:
+      - '/feature-.+'
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breakingchange'
+  - title: '🧪 Experimental Features'
+    labels:
+      - 'experimental'
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'BUG'
+  - title: '🧰 Maintenance'
+    label: 'maintenance'
+change-template: '- $TITLE (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  # Changes
+
+  $CHANGES
+
+  ## Contributors
+  We'd like to thank all the contributors who worked on this release!
+
+  $CONTRIBUTORS
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+           config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds support for the release drafter - an automated tool to help **improve** (and not replace!) writing release notes. It takes the name of a given PR, and inserts it as an entry, into a proposed "release", to be managed within the releases tab of the repository.

The drafter makes use of the following labels - which would need to be configured in this repository. A good, practical output of the drafter assisting with releases can be viewed at [this version of redis-py](https://github.com/redis/redis-py/releases/tag/v4.4.0rc3).

- bug - If a PR is marked as a bug, it will show up as a bug fixed, in the release notes
- feature - When a PR is marked thus, it shows up as a feature
- breakingchange - While we never want them, of course they're unavoidable. This is a call out that something is a breaking change
- maintenance - For CI, documentation, and other things that people sued to call "chores", but are super valuable!
- experimental - Anything marked thus, is also called out so the community can know that it's both new, and not necessarily reliable.

@tillkruss WDYT?