### PR TITLE
Added response parser for WithScore trait

### DIFF
--- a/src/Command/Traits/WithScores.php
+++ b/src/Command/Traits/WithScores.php
@@ -39,7 +39,9 @@ trait WithScores
             $result = [];
 
             for ($i = 0, $iMax = count($data); $i < $iMax; ++$i) {
-                $result[$data[$i]] = $data[++$i];
+                if ($data[$i + 1] ?? false) {
+                    $result[$data[$i]] = $data[++$i];
+                }
             }
 
             return $result;

--- a/src/Command/Traits/WithScores.php
+++ b/src/Command/Traits/WithScores.php
@@ -19,4 +19,32 @@ trait WithScores
 
         parent::setArguments($arguments);
     }
+
+    /**
+     * Checks for the presence of the WITHSCORES modifier.
+     *
+     * @return bool
+     */
+    private function isWithScoreModifier(): bool
+    {
+        $arguments = parent::getArguments();
+        $lastArgument = $arguments[count($arguments) - 1];
+
+        return is_string($lastArgument) && strtoupper($lastArgument) === 'WITHSCORES';
+    }
+
+    public function parseResponse($data)
+    {
+        if ($this->isWithScoreModifier()) {
+            $result = [];
+
+            for ($i = 0, $iMax = count($data); $i < $iMax; ++$i) {
+                $result[$data[$i]] = $data[++$i];
+            }
+
+            return $result;
+        }
+
+        return $data;
+    }
 }

--- a/tests/Predis/Command/Redis/ZDIFF_test.php
+++ b/tests/Predis/Command/Redis/ZDIFF_test.php
@@ -76,7 +76,7 @@ class ZDIFF_test extends PredisCommandTestCase
     {
         $redis = $this->getClient();
         $membersDictionary = [1, 'member1', 2, 'member2', 3, 'member3'];
-        $expectedResponse = ['member1', '1', 'member2', '2', 'member3', '3'];
+        $expectedResponse = ['member1' => '1', 'member2' => '2', 'member3' => '3'];
 
         $redis->zadd('test-zset-1', ...$membersDictionary);
         $this->assertSame($expectedResponse, $redis->zdiff(['test-zset-1', 'test-zset-2'], true));
@@ -130,13 +130,13 @@ class ZDIFF_test extends PredisCommandTestCase
             'no intersection - with score' => [
                 [1, 'member1', 2, 'member2', 3, 'member3'],
                 [1, 'member4', 2, 'member5', 3, 'member6'],
-                ['member1', '1', 'member2', '2', 'member3', '3'],
+                ['member1' => '1', 'member2' => '2', 'member3' => '3'],
                 true
             ],
             'partial intersection - with score' => [
                 [1, 'member1', 2, 'member2', 3, 'member3'],
                 [1, 'member1', 2, 'member2', 3, 'member4'],
-                ['member3', '3'],
+                ['member3' => '3'],
                 true
             ],
         ];

--- a/tests/Predis/Command/Redis/ZRANDMEMBER_test.php
+++ b/tests/Predis/Command/Redis/ZRANDMEMBER_test.php
@@ -111,19 +111,19 @@ class ZRANDMEMBER_test extends PredisCommandTestCase
                 ['member1', 'member1'],
                 false
             ],
-            'one member - with score' => ['test-zset', 1, [1, 'member1'], ['member1', 1], true],
+            'one member - with score' => ['test-zset', 1, [1, 'member1'], ['member1' => '1'], true],
             'multiple members - positive count - with score' => [
                 'test-zset',
                 2,
                 [1, 'member1', 2, 'member2'],
-                ['member1', 1, 'member2', 2],
+                ['member1' => '1', 'member2' => '2'],
                 true
             ],
             'multiple members - negative count - with score' => [
                 'test-zset',
-                -2,
+                -1,
                 [1, 'member1'],
-                ['member1', 1, 'member1', 1],
+                ['member1' => '1'],
                 true
             ],
         ];

--- a/tests/Predis/Command/Traits/WithScoresTest.php
+++ b/tests/Predis/Command/Traits/WithScoresTest.php
@@ -39,12 +39,42 @@ class WithScoresTest extends PredisTestCase
         $this->assertSame($expectedArguments, $this->testClass->getArguments());
     }
 
+    /**
+     * @dataProvider dataProvider
+     * @param array $actualData
+     * @param array $expectedResponse
+     * @return void
+     */
+    public function testParseDataReturnsCorrectResponse(array $actualData, array $expectedResponse): void
+    {
+        $this->testClass->setArguments($actualData);
+
+        $arguments = $this->testClass->getArguments();
+
+        $this->assertSame($expectedResponse, $this->testClass->parseResponse($arguments));
+    }
+
     public function valuesProvider(): array
     {
         return [
             'with last argument boolean - true' => [['test', 'test1', true], ['test', 'test1', 'WITHSCORES']],
             'with last argument boolean - false' => [['test', 'test1', false], ['test', 'test1']],
             'with last argument non boolean' => [['test', 'test1', 1], ['test', 'test1', 1]],
+        ];
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            'without modifier' => [['member1', '1', 'member2', '2'], ['member1', '1', 'member2', '2']],
+            'with wrong modifier' => [
+                ['member1', '1', 'member2', '2', 'WITHSCOREE'],
+                ['member1', '1', 'member2', '2', 'WITHSCOREE'],
+            ],
+            'with modifier' => [
+                ['member1', '1', 'member2', '2', 'WITHSCORES'],
+                ['member1' => '1', 'member2' => '2'],
+            ]
         ];
     }
 }


### PR DESCRIPTION
I notice that I missed response parsing in case if WITHSCORE modifier will be applied to command. According to other commands, it needs to be converted into key-value pairs.