### PR TITLE
Added support for Redis JSON module commands, added JSON.SET and JSON.GET commands

### DIFF
--- a/.github/workflows/redis-server-tests.yml
+++ b/.github/workflows/redis-server-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Redis server tests
 
 on:
   - push
@@ -12,7 +12,7 @@ jobs:
 
     services:
       redis:
-        image: redis-stack-server:${{ matrix.redis-versions }}
+        image: redis:${{ matrix.redis-versions }}
         ports:
         - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        redis-versions: ['3', '4', '5', '6', '7']
+        redis-versions: ['3', '4', '5']
 
     steps:
     - name: Checkout

--- a/.github/workflows/redis-stack-tests.yml
+++ b/.github/workflows/redis-stack-tests.yml
@@ -7,12 +7,12 @@ on:
 jobs:
 
   predis:
-    name: PHP ${{ matrix.php-versions }} (Redis ${{ matrix.redis-versions }})
+    name: PHP ${{ matrix.php-versions }} (Redis stack ${{ matrix.redis-stack-versions }})
     runs-on: ubuntu-latest
 
     services:
       redis:
-        image: redis-stack-server:${{ matrix.redis-stack-versions }}
+        image: redis/redis-stack-server:${{ matrix.redis-stack-versions }}
         ports:
         - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/.github/workflows/redis-stack-tests.yml
+++ b/.github/workflows/redis-stack-tests.yml
@@ -1,0 +1,52 @@
+name: Redis stack tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+
+  predis:
+    name: PHP ${{ matrix.php-versions }} (Redis ${{ matrix.redis-versions }})
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis-stack-server:${{ matrix.redis-stack-versions }}
+        ports:
+        - 6379:6379
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        redis-stack-versions: ['6.2.6-v0', '7.0.6-RC2']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup PHP with Composer and extensions
+      with:
+        php-version: ${{ matrix.php-versions }}
+      uses: shivammathur/setup-php@v2
+
+    - name: Get Composer cache directory
+      id: composercache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composercache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install Composer dependencies
+      env:
+        PHP_VERSION: ${{ matrix.php-versions }}
+      run: composer install --no-progress --prefer-dist --optimize-autoloader $(if [ "$PHP_VERSION" == "8.0" ]; then echo "--ignore-platform-reqs"; fi;)
+
+    - name: Test with PHPUnit
+      run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       redis:
-        image: redis:${{ matrix.redis-versions }}
+        image: redis-stack-server:${{ matrix.redis-versions }}
         ports:
         - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Predis;
+
+class ClientConfiguration
+{
+    /**
+     * @var array{modules: array}|string[][]
+     */
+    private static $config = [
+        'modules' => [
+            ['name' => 'Json', 'commandPrefix' => 'JSON'],
+            ['name' => 'Graph', 'commandPrefix' => 'GRAPH'],
+            ['name' => 'Search', 'commandPrefix' => 'FT'],
+            ['name' => 'TimeSeries', 'commandPrefix' => 'TS'],
+        ]
+    ];
+
+    /**
+     * Returns available modules with configuration.
+     *
+     * @return array|string[][]
+     */
+    public static function getModules(): array
+    {
+        return self::$config['modules'];
+    }
+}

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -77,6 +77,7 @@ use Predis\Command\CommandInterface;
  * @method $this hsetnx($key, $field, $value)
  * @method $this hvals($key)
  * @method $this hstrlen($key, $field)
+ * @method $this jsonset(string $key, string $path, string $value, ?string $subcommand = null)
  * @method $this blmove(string $source, string $destination, string $where, string $to, int $timeout)
  * @method $this blpop(array|string $keys, $timeout)
  * @method $this brpop(array|string $keys, $timeout)

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -77,6 +77,7 @@ use Predis\Command\CommandInterface;
  * @method $this hsetnx($key, $field, $value)
  * @method $this hvals($key)
  * @method $this hstrlen($key, $field)
+ * @method $this jsonget(string $key, string $indent = '', string $newline = '', string $space = '', string ...$paths)
  * @method $this jsonset(string $key, string $path, string $value, ?string $subcommand = null)
  * @method $this blmove(string $source, string $destination, string $where, string $to, int $timeout)
  * @method $this blpop(array|string $keys, $timeout)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -86,6 +86,7 @@ use Predis\Response\Status;
  * @method int               hsetnx(string $key, string $field, string $value)
  * @method array             hvals(string $key)
  * @method int               hstrlen(string $key, string $field)
+ * @method array             jsonget(string $key, string $indent = '', string $newline = '', string $space = '', string ...$paths)
  * @method string            jsonset(string $key, string $path, string $value, ?string $subcommand = null)
  * @method string            blmove(string $source, string $destination, string $where, string $to, int $timeout)
  * @method array|null        blpop(array|string $keys, int|float $timeout)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -86,7 +86,7 @@ use Predis\Response\Status;
  * @method int               hsetnx(string $key, string $field, string $value)
  * @method array             hvals(string $key)
  * @method int               hstrlen(string $key, string $field)
- * @method array             jsonget(string $key, string $indent = '', string $newline = '', string $space = '', string ...$paths)
+ * @method string             jsonget(string $key, string $indent = '', string $newline = '', string $space = '', string ...$paths)
  * @method string            jsonset(string $key, string $path, string $value, ?string $subcommand = null)
  * @method string            blmove(string $source, string $destination, string $where, string $to, int $timeout)
  * @method array|null        blpop(array|string $keys, int|float $timeout)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -86,6 +86,7 @@ use Predis\Response\Status;
  * @method int               hsetnx(string $key, string $field, string $value)
  * @method array             hvals(string $key)
  * @method int               hstrlen(string $key, string $field)
+ * @method string            jsonset(string $key, string $path, string $value, ?string $subcommand = null)
  * @method string            blmove(string $source, string $destination, string $where, string $to, int $timeout)
  * @method array|null        blpop(array|string $keys, int|float $timeout)
  * @method array|null        brpop(array|string $keys, int|float $timeout)

--- a/src/Command/Redis/INFO.php
+++ b/src/Command/Redis/INFO.php
@@ -98,6 +98,10 @@ class INFO extends RedisCommand
      */
     protected function parseRow($row)
     {
+        if (preg_match('/^module:name/', $row)) {
+            return $this->parseModuleRow($row);
+        }
+
         list($k, $v) = explode(':', $row, 2);
 
         if (preg_match('/^db\d+$/', $k)) {
@@ -124,5 +128,31 @@ class INFO extends RedisCommand
         }
 
         return $db;
+    }
+
+    /**
+     * Parsing module rows because of different format.
+     *
+     * @param string $row
+     * @return array
+     */
+    protected function parseModuleRow(string $row): array
+    {
+        [$moduleKeyword, $moduleData] = explode(':', $row);
+        $explodedData = explode(',', $moduleData);
+        $parsedData = [];
+
+        foreach ($explodedData as $moduleDataRow) {
+            [$k, $v] = explode('=', $moduleDataRow);
+
+            if ($k === 'name') {
+                $parsedData[0] = $v;
+                continue;
+            }
+
+            $parsedData[1][$k] = $v;
+        }
+
+        return $parsedData;
     }
 }

--- a/src/Command/Redis/Json/JSONGET.php
+++ b/src/Command/Redis/Json/JSONGET.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Predis\Command\Redis\Json;
+
+use Predis\Command\Command as RedisCommand;
+use Predis\Command\Traits\Json\Indent;
+use Predis\Command\Traits\Json\Newline;
+use Predis\Command\Traits\Json\Space;
+
+/**
+ * @link https://redis.io/commands/json.get/
+ *
+ * Return the value at path in JSON serialized form
+ */
+class JSONGET extends RedisCommand
+{
+    use Indent {
+        Indent::setArguments as setIndent;
+    }
+    use Newline {
+        Newline::setArguments as setNewline;
+    }
+    use Space {
+        Space::setArguments as setSpace;
+    }
+
+    protected static $indentArgumentPositionOffset = 1;
+    protected static $newlineArgumentPositionOffset = 2;
+    protected static $spaceArgumentPositionOffset = 3;
+
+    public function getId()
+    {
+        return 'JSON.GET';
+    }
+
+    public function setArguments(array $arguments)
+    {
+        $this->setIndent($arguments);
+        $arguments = $this->getArguments();
+
+        $this->setNewline($arguments);
+        $arguments = $this->getArguments();
+
+        $this->setSpace($arguments);
+        $this->filterArguments();
+    }
+}

--- a/src/Command/Redis/Json/JSONGET.php
+++ b/src/Command/Redis/Json/JSONGET.php
@@ -35,13 +35,13 @@ class JSONGET extends RedisCommand
 
     public function setArguments(array $arguments)
     {
-        $this->setIndent($arguments);
+        $this->setSpace($arguments);
         $arguments = $this->getArguments();
 
         $this->setNewline($arguments);
         $arguments = $this->getArguments();
 
-        $this->setSpace($arguments);
+        $this->setIndent($arguments);
         $this->filterArguments();
     }
 }

--- a/src/Command/Redis/Json/JSONSET.php
+++ b/src/Command/Redis/Json/JSONSET.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Predis\Command\Redis\Json;
+
+use Predis\Command\Command as RedisCommand;
+use Predis\Command\Traits\Json\NxXxSubcommand;
+
+/**
+ * @link https://redis.io/commands/json.set/
+ *
+ * Set the JSON value at path in key
+ */
+class JSONSET extends RedisCommand
+{
+    use NxXxSubcommand {
+        setArguments as setSubcommand;
+    }
+
+    protected static $nxXxArgumentPositionOffset = 3;
+
+    public function getId()
+    {
+        return 'JSON.SET';
+    }
+
+    public function setArguments(array $arguments)
+    {
+        $this->setSubcommand($arguments);
+        $this->filterArguments();
+    }
+}

--- a/src/Command/RedisFactory.php
+++ b/src/Command/RedisFactory.php
@@ -52,7 +52,14 @@ class RedisFactory extends Factory
             return $this->commands[$commandID];
         }
 
-        return $this->commandResolver->resolve($commandID);
+        $commandClass = $this->commandResolver->resolve($commandID);
+
+        if (null === $commandClass) {
+            return null;
+        }
+
+        $this->commands[$commandID] = $commandClass;
+        return $commandClass;
     }
 
     /**

--- a/src/Command/RedisFactory.php
+++ b/src/Command/RedisFactory.php
@@ -11,6 +11,8 @@
 
 namespace Predis\Command;
 
+use Predis\Command\Resolver\CommandResolverInterface;
+
 /**
  * Command factory for mainline Redis servers.
  *
@@ -25,15 +27,18 @@ namespace Predis\Command;
 class RedisFactory extends Factory
 {
     /**
-     *
+     * @var CommandResolverInterface
      */
-    public function __construct()
+    private $commandResolver;
+
+    public function __construct(CommandResolverInterface $commandResolver)
     {
         $this->commands = array(
             'ECHO' => 'Predis\Command\Redis\ECHO_',
             'EVAL' => 'Predis\Command\Redis\EVAL_',
             'OBJECT' => 'Predis\Command\Redis\OBJECT_',
         );
+        $this->commandResolver = $commandResolver;
     }
 
     /**
@@ -44,14 +49,10 @@ class RedisFactory extends Factory
         $commandID = strtoupper($commandID);
 
         if (isset($this->commands[$commandID]) || array_key_exists($commandID, $this->commands)) {
-            $commandClass = $this->commands[$commandID];
-        } elseif (class_exists($commandClass = "Predis\Command\Redis\\$commandID")) {
-            $this->commands[$commandID] = $commandClass;
-        } else {
-            return null;
+            return $this->commands[$commandID];
         }
 
-        return $commandClass;
+        return $this->commandResolver->resolve($commandID);
     }
 
     /**

--- a/src/Command/Resolver/CommandResolver.php
+++ b/src/Command/Resolver/CommandResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Predis\Command\Resolver;
+
+class CommandResolver implements CommandResolverInterface
+{
+    private const COMMANDS_NAMESPACE = "Predis\Command\Redis";
+
+    /**
+     * @var array
+     */
+    private $modules;
+
+    public function __construct(array $modules)
+    {
+        $this->modules = $modules;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(string $commandID): ?string
+    {
+        if (class_exists($commandClass = self::COMMANDS_NAMESPACE . "\\" . $commandID)) {
+            return $commandClass;
+        }
+
+        $commandModule = $this->resolveCommandModuleByPrefix($commandID);
+
+        if (null === $commandModule) {
+            return null;
+        }
+
+        if (class_exists($commandClass = self::COMMANDS_NAMESPACE . "\\" . $commandModule . "\\" . $commandID)) {
+            return $commandClass;
+        }
+
+        return null;
+    }
+
+    private function resolveCommandModuleByPrefix(string $commandID): ?string
+    {
+        foreach ($this->modules as $module) {
+            if (preg_match("/^{$module['commandPrefix']}/", $commandID)) {
+                return $module['name'];
+            }
+        }
+        return null;
+    }
+}

--- a/src/Command/Resolver/CommandResolver.php
+++ b/src/Command/Resolver/CommandResolver.php
@@ -2,6 +2,8 @@
 
 namespace Predis\Command\Resolver;
 
+use Predis\ClientConfiguration;
+
 class CommandResolver implements CommandResolverInterface
 {
     private const COMMANDS_NAMESPACE = "Predis\Command\Redis";
@@ -11,9 +13,9 @@ class CommandResolver implements CommandResolverInterface
      */
     private $modules;
 
-    public function __construct(array $modules)
+    public function __construct()
     {
-        $this->modules = $modules;
+        $this->modules = ClientConfiguration::getModules();
     }
 
     /**

--- a/src/Command/Resolver/CommandResolverInterface.php
+++ b/src/Command/Resolver/CommandResolverInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Predis\Command\Resolver;
+
+interface CommandResolverInterface
+{
+    /**
+     * Resolves command object from given command ID
+     *
+     * @param string $commandID Command ID of virtual method call
+     * @return string FQDN of corresponding command object
+     */
+    public function resolve(string $commandID): ?string;
+}

--- a/src/Command/Traits/Json/Indent.php
+++ b/src/Command/Traits/Json/Indent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use UnexpectedValueException;
+
+trait Indent
+{
+    private static $indentModifier = 'INDENT';
+
+    public function setArguments(array $arguments)
+    {
+        $argumentsLength = count($arguments);
+
+        if (static::$indentArgumentPositionOffset >= $argumentsLength) {
+            parent::setArguments($arguments);
+            return;
+        }
+
+        if ($arguments[static::$indentArgumentPositionOffset] === '') {
+            array_splice($arguments, static::$indentArgumentPositionOffset, 1, [false]);
+            parent::setArguments($arguments);
+            return;
+        }
+
+        $argument = $arguments[static::$indentArgumentPositionOffset];
+
+        if (!is_string($argument)) {
+            throw new UnexpectedValueException('Indent argument value should be a string');
+        }
+
+        $argumentsBefore = array_slice($arguments, 0, static::$indentArgumentPositionOffset);
+        $argumentsAfter = array_slice($arguments,  static::$indentArgumentPositionOffset + 1);
+
+        parent::setArguments(array_merge(
+            $argumentsBefore,
+            [self::$indentModifier],
+            [$argument],
+            $argumentsAfter
+        ));
+    }
+}

--- a/src/Command/Traits/Json/Newline.php
+++ b/src/Command/Traits/Json/Newline.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use UnexpectedValueException;
+
+trait Newline
+{
+    private static $newlineModifier = 'NEWLINE';
+
+    public function setArguments(array $arguments)
+    {
+        $argumentsLength = count($arguments);
+
+        if (static::$newlineArgumentPositionOffset >= $argumentsLength) {
+            parent::setArguments($arguments);
+            return;
+        }
+
+        if ($arguments[static::$newlineArgumentPositionOffset] === '') {
+            array_splice($arguments, static::$newlineArgumentPositionOffset, 1, [false]);
+            parent::setArguments($arguments);
+            return;
+        }
+
+        $argument = $arguments[static::$newlineArgumentPositionOffset];
+
+        if (!is_string($argument)) {
+            throw new UnexpectedValueException('Newline argument value should be a string');
+        }
+
+        $argumentsBefore = array_slice($arguments, 0, static::$newlineArgumentPositionOffset);
+        $argumentsAfter = array_slice($arguments,  static::$newlineArgumentPositionOffset + 1);
+
+        parent::setArguments(array_merge(
+            $argumentsBefore,
+            [self::$newlineModifier],
+            [$argument],
+            $argumentsAfter
+        ));
+    }
+}

--- a/src/Command/Traits/Json/NxXxSubcommand.php
+++ b/src/Command/Traits/Json/NxXxSubcommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use Predis\Command\Command;
+use UnexpectedValueException;
+
+/**
+ * @mixin Command
+ */
+trait NxXxSubcommand
+{
+    /**
+     * @var string[]
+     */
+    private static $subcommandEnum = [
+        'nx' => 'NX',
+        'xx' => 'XX',
+    ];
+
+    public function setArguments(array $arguments)
+    {
+        $argumentsLength = count($arguments);
+
+        if (static::$nxXxArgumentPositionOffset >= $argumentsLength) {
+            parent::setArguments($arguments);
+            return;
+        }
+
+        if (null === $arguments[static::$nxXxArgumentPositionOffset]) {
+            array_splice($arguments, static::$nxXxArgumentPositionOffset, 1, [false]);
+            parent::setArguments($arguments);
+            return;
+        }
+
+        $argument = $arguments[static::$nxXxArgumentPositionOffset];
+
+        if (!in_array(strtoupper($argument), self::$subcommandEnum, true)) {
+            $enumValues = implode(', ', array_keys(self::$subcommandEnum));
+            throw new UnexpectedValueException("Subcommand argument accepts only: {$enumValues} values");
+        }
+
+        $argumentsBefore = array_slice($arguments, 0, static::$nxXxArgumentPositionOffset);
+        $argumentsAfter = array_slice($arguments,  static::$nxXxArgumentPositionOffset + 1);
+
+        parent::setArguments(array_merge(
+            $argumentsBefore,
+            [self::$subcommandEnum[strtolower($argument)]],
+            $argumentsAfter
+        ));
+    }
+}

--- a/src/Command/Traits/Json/Space.php
+++ b/src/Command/Traits/Json/Space.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use UnexpectedValueException;
+
+trait Space
+{
+    private static $spaceModifier = 'SPACE';
+
+    public function setArguments(array $arguments)
+    {
+        $argumentsLength = count($arguments);
+
+        if (static::$spaceArgumentPositionOffset >= $argumentsLength) {
+            parent::setArguments($arguments);
+            return;
+        }
+
+        if ($arguments[static::$spaceArgumentPositionOffset] === '') {
+            array_splice($arguments, static::$spaceArgumentPositionOffset, 1, [false]);
+            parent::setArguments($arguments);
+            return;
+        }
+
+        $argument = $arguments[static::$spaceArgumentPositionOffset];
+
+        if (!is_string($argument)) {
+            throw new UnexpectedValueException('Space argument value should be a string');
+        }
+
+        $argumentsBefore = array_slice($arguments, 0, static::$spaceArgumentPositionOffset);
+        $argumentsAfter = array_slice($arguments,  static::$spaceArgumentPositionOffset + 1);
+
+        parent::setArguments(array_merge(
+            $argumentsBefore,
+            [self::$spaceModifier],
+            [$argument],
+            $argumentsAfter
+        ));
+    }
+}

--- a/src/Configuration/Option/Commands.php
+++ b/src/Configuration/Option/Commands.php
@@ -11,9 +11,11 @@
 
 namespace Predis\Configuration\Option;
 
+use Predis\ClientConfiguration;
 use Predis\Command\FactoryInterface;
 use Predis\Command\RawFactory;
 use Predis\Command\RedisFactory;
+use Predis\Command\Resolver\CommandResolver;
 use Predis\Configuration\OptionInterface;
 use Predis\Configuration\OptionsInterface;
 
@@ -134,7 +136,7 @@ class Commands implements OptionInterface
      */
     public function getDefault(OptionsInterface $options)
     {
-        $commands = new RedisFactory();
+        $commands = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         if (isset($options->prefix)) {
             $commands->setProcessor($options->prefix);

--- a/src/Configuration/Option/Commands.php
+++ b/src/Configuration/Option/Commands.php
@@ -136,7 +136,7 @@ class Commands implements OptionInterface
      */
     public function getDefault(OptionsInterface $options)
     {
-        $commands = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $commands = new RedisFactory(new CommandResolver());
 
         if (isset($options->prefix)) {
             $commands->setProcessor($options->prefix);

--- a/tests/PHPUnit/PredisCommandTestCase.php
+++ b/tests/PHPUnit/PredisCommandTestCase.php
@@ -112,9 +112,10 @@ abstract class PredisCommandTestCase extends PredisTestCase
     public function testCommandId(): void
     {
         $command = $this->getCommand();
+        $sanitizedCommandId = str_replace('.', '', $command->getId());
 
         $this->assertInstanceOf('Predis\Command\CommandInterface', $command);
-        $this->assertEquals($this->getExpectedId(), $command->getId());
+        $this->assertEquals($this->getExpectedId(), $sanitizedCommandId);
     }
 
     /**

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -134,7 +134,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
     {
         return array(
             'commands' => new Command\RedisFactory(
-                new Command\Resolver\CommandResolver(ClientConfiguration::getModules())
+                new Command\Resolver\CommandResolver()
             ),
         );
     }
@@ -175,7 +175,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getCommandFactory(): Command\Factory
     {
-        return new Command\RedisFactory(new Command\Resolver\CommandResolver(ClientConfiguration::getModules()));
+        return new Command\RedisFactory(new Command\Resolver\CommandResolver());
     }
 
     /**

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -12,6 +12,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Util\Test as TestUtil;
 use Predis\Client;
+use Predis\ClientConfiguration;
 use Predis\Command;
 use Predis\Connection;
 
@@ -132,7 +133,9 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
     protected function getDefaultOptionsArray(): array
     {
         return array(
-            'commands' => new Command\RedisFactory(),
+            'commands' => new Command\RedisFactory(
+                new Command\Resolver\CommandResolver(ClientConfiguration::getModules())
+            ),
         );
     }
 
@@ -172,7 +175,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getCommandFactory(): Command\Factory
     {
-        return new Command\RedisFactory();
+        return new Command\RedisFactory(new Command\Resolver\CommandResolver(ClientConfiguration::getModules()));
     }
 
     /**

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -12,7 +12,6 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Util\Test as TestUtil;
 use Predis\Client;
-use Predis\ClientConfiguration;
 use Predis\Command;
 use Predis\Connection;
 
@@ -28,7 +27,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      * @var string[]
      */
     private $annotationsMapping = [
-        'redis' => 'requiresRedisVersion',
+        'server' => 'requiresRedisVersion',
         'json' => 'requiresRedisJsonVersion',
     ];
 
@@ -341,7 +340,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getRequiredRedisServerVersion(): ?string
     {
-        return $this->getRequiredModuleVersion($this->annotationsMapping['redis']);
+        return $this->getRequiredModuleVersion('server');
     }
 
     /**
@@ -472,19 +471,24 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getRequiredRedisJsonVersion(): ?string
     {
-        return $this->getRequiredModuleVersion($this->annotationsMapping['json']);
+        return $this->getRequiredModuleVersion('json');
     }
 
     /**
-     * Returns version of given module by its annotation.
+     * Returns version of given module for current Redis instance.
      * Runs if command belong to one of modules and marked with appropriate annotation
      * Runs on @connected tests
      *
-     * @param string $moduleAnnotation
+     * @param string $module
      * @return string
      */
-    protected function getRequiredModuleVersion(string $moduleAnnotation): ?string
+    protected function getRequiredModuleVersion(string $module): ?string
     {
+        if (!isset($this->annotationsMapping[$module])) {
+            throw new InvalidArgumentException('No existing annotation for given module');
+        }
+
+        $moduleAnnotation = $this->annotationsMapping[$module];
         $annotations = TestUtil::parseTestMethodAnnotations(
             get_class($this),
             $this->getName(false)

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -22,6 +22,22 @@ use Predis\Connection;
 abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
 {
     protected $redisServerVersion = null;
+    protected $redisJsonVersion;
+
+    /**
+     * @var string[]
+     */
+    private $annotationsMapping = [
+        'redis' => 'requiresRedisVersion',
+        'json' => 'requiresRedisJsonVersion',
+    ];
+
+    /**
+     * Info of current Redis instance.
+     *
+     * @var array
+     */
+    private $info;
 
     /**
      * {@inheritdoc}
@@ -29,6 +45,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->checkRequiredRedisServerVersion();
+        $this->checkRequiredRedisJsonModuleVersion();
     }
 
     /**
@@ -290,8 +307,12 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
             return $this->redisServerVersion;
         }
 
-        $client = $this->createClient(null, null, true);
-        $info = array_change_key_case($client->info());
+        if (isset($this->info)) {
+            $info = $this->info;
+        } else {
+            $client = $this->createClient(null, null, true);
+            $info = array_change_key_case($client->info());
+        }
 
         if (isset($info['server']['redis_version'])) {
             // Redis >= 2.6
@@ -300,6 +321,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
             // Redis < 2.6
             $version = $info['redis_version'];
         } else {
+            $client = $this->createClient(null, null, true);
             $connection = $client->getConnection();
             throw new RuntimeException("Unable to retrieve a valid server info payload from $connection");
         }
@@ -319,19 +341,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getRequiredRedisServerVersion(): ?string
     {
-        $annotations = TestUtil::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        );
-
-        if (isset($annotations['method']['requiresRedisVersion'], $annotations['method']['group']) &&
-            !empty($annotations['method']['requiresRedisVersion']) &&
-            in_array('connected', $annotations['method']['group'])
-        ) {
-            return $annotations['method']['requiresRedisVersion'][0];
-        }
-
-        return null;
+        return $this->getRequiredModuleVersion($this->annotationsMapping['redis']);
     }
 
     /**
@@ -383,6 +393,111 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
                 "Test requires a Redis server instance $reqOperator $reqVersion but target server is $serverVersion"
             );
         }
+    }
+
+    /**
+     * Ensures the current Redis JSON module matches version requirements for tests.
+     *
+     * @return void
+     */
+    protected function checkRequiredRedisJsonModuleVersion(): void
+    {
+        if (version_compare($this->getRedisServerVersion(), '6.0.0', '<')) {
+            $this->markTestSkipped(
+                "Test skipped because Redis JSON module available since Redis 6.x"
+            );
+        }
+
+        if (null === $requiredVersion = $this->getRequiredRedisJsonVersion()) {
+            return;
+        }
+
+        $requiredVersion = explode(' ', $requiredVersion, 2);
+
+        if (count($requiredVersion) === 1) {
+            $reqVersion = $requiredVersion[0];
+        } else {
+            $reqVersion = $requiredVersion[1];
+        }
+
+        if(!$this->isSatisfiedRedisJsonVersion($reqVersion)) {
+            $redisJsonVersion = $this->getRedisJsonVersion();
+
+            $this->markTestSkipped(
+                "Test requires a Redis JSON module >= $reqVersion but target module is $redisJsonVersion"
+            );
+        }
+    }
+
+    /**
+     * @param string $versionToCheck
+     * @return bool
+     */
+    protected function isSatisfiedRedisJsonVersion(string $versionToCheck): bool
+    {
+        $currentVersion = $this->getRedisJsonVersion();
+        $versionToCheck = str_replace('.', '0', $versionToCheck);
+
+        return (int)$currentVersion >= (int)$versionToCheck;
+    }
+
+    /**
+     * Returns version of Redis JSON module if it's available.
+     *
+     * @return string
+     */
+    protected function getRedisJsonVersion(): string
+    {
+        if (isset($this->redisJsonVersion)) {
+            return $this->redisJsonVersion;
+        }
+
+        if (isset($this->info)) {
+            $info = $this->info;
+        } else {
+            $client = $this->createClient(null, null, true);
+            $info = array_change_key_case($client->info());
+        }
+
+        if (isset($info['modules']['ReJSON']['ver'])) {
+            $this->redisJsonVersion = $info['modules']['ReJSON']['ver'];
+            return $info['modules']['ReJSON']['ver'];
+        }
+
+        throw new RuntimeException('Redis JSON module is not available at your Redis server instance.');
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getRequiredRedisJsonVersion(): ?string
+    {
+        return $this->getRequiredModuleVersion($this->annotationsMapping['json']);
+    }
+
+    /**
+     * Returns version of given module by its annotation.
+     * Runs if command belong to one of modules and marked with appropriate annotation
+     * Runs on @connected tests
+     *
+     * @param string $moduleAnnotation
+     * @return string
+     */
+    protected function getRequiredModuleVersion(string $moduleAnnotation): ?string
+    {
+        $annotations = TestUtil::parseTestMethodAnnotations(
+            get_class($this),
+            $this->getName(false)
+        );
+
+        if (isset($annotations['method'][$moduleAnnotation], $annotations['method']['group']) &&
+            !empty($annotations['method'][$moduleAnnotation]) &&
+            in_array('connected', $annotations['method']['group'], true)
+        ) {
+            return $annotations['method'][$moduleAnnotation][0];
+        }
+
+        return null;
     }
 
     /**

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -420,7 +420,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
             $reqVersion = $requiredVersion[1];
         }
 
-        if(!$this->isSatisfiedRedisJsonVersion($reqVersion)) {
+        if (!$this->isSatisfiedRedisJsonVersion($reqVersion)) {
             $redisJsonVersion = $this->getRedisJsonVersion();
 
             $this->markTestSkipped(

--- a/tests/Predis/Command/Redis/Json/JSONGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONGET_Test.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Predis\Command\Redis\Json;
+
+use Predis\Command\Redis\PredisCommandTestCase;
+use UnexpectedValueException;
+
+class JSONGET_Test extends PredisCommandTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedCommand(): string
+    {
+        return JSONGET::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedId(): string
+    {
+        return 'JSONGET';
+    }
+
+    /**
+     * @group disconnected
+     * @dataProvider argumentsProvider
+     */
+    public function testFilterArguments(array $actualArguments, array $expectedArguments): void
+    {
+        $command = $this->getCommand();
+        $command->setArguments($actualArguments);
+
+        $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testParseResponse(): void
+    {
+        $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group connected
+     * @dataProvider jsonProvider
+     * @param array $jsonData
+     * @param string $key
+     * @param string $indent
+     * @param string $newline
+     * @param string $space
+     * @param string $expectedResponse
+     * @return void
+     * @requiresRedisJsonVersion >= 1.0.0
+     */
+    public function testReturnsCorrectJsonResponse(
+        array $jsonData,
+        string $key,
+        string $indent,
+        string $newline,
+        string $space,
+        string $expectedResponse
+    ): void {
+        $redis = $this->getClient();
+
+        $redis->jsonset(...$jsonData);
+        $this->assertSame($expectedResponse, $redis->jsonget($key, $indent, $newline, $space));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisJsonVersion >= 1.0.0
+     */
+    public function testReturnsJsonValuesArrayOnMultiplePathsProvided(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->jsonset('key', '$', '{"key1":"value1","key2":{"key3":"value3"}}');
+        $actualResponse = $redis->jsonget('key', '', '', '', '$.key1', '$..key3');
+
+        $this->assertStringContainsString('"$.key1":["value1"]', $actualResponse);
+        $this->assertStringContainsString('"$..key3":["value3"]', $actualResponse);
+    }
+
+    /**
+     * @group connected
+     * @dataProvider unexpectedValuesProvider
+     * @param array $arguments
+     * @param string $expectedExceptionMessage
+     * @return void
+     * @requiresRedisJsonVersion >= 1.0.0
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(array $arguments, string $expectedExceptionMessage): void
+    {
+        $redis = $this->getClient();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $redis->jsonget(...$arguments);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with default arguments' => [
+                ['key'],
+                ['key']
+            ],
+            'with INDENT modifier' => [
+                ['key', '\t'],
+                ['key', 'INDENT', '\t']
+            ],
+            'with NEWLINE modifier' => [
+                ['key', '', '\n'],
+                ['key', 'NEWLINE', '\n']
+            ],
+            'with SPACE modifier' => [
+                ['key', '', '', ' '],
+                ['key', 'SPACE', ' '],
+            ],
+            'with multiple paths' => [
+                ['key', '', '', '', 'path1', 'path2'],
+                ['key', 'path1', 'path2'],
+            ],
+            'with all arguments' => [
+                ['key', '\t', '\n', ' '],
+                ['key', 'INDENT', '\t', 'NEWLINE', '\n', 'SPACE', ' '],
+            ]
+        ];
+    }
+
+    public function jsonProvider(): array
+    {
+        return [
+            'with key only' => [
+                ['key', '$', '{"key1":"value1","key2":"value2"}'],
+                'key',
+                '',
+                '',
+                '',
+                '{"key1":"value1","key2":"value2"}',
+            ],
+            'with INDENT modifier only' => [
+                ['key', '$', '{"key1":"value1","key2":"value2"}'],
+                'key',
+                '\t',
+                '',
+                '',
+                '{\t"key1":"value1",\t"key2":"value2"}',
+            ],
+            'with NEWLINE modifier only' => [
+                ['key', '$', '{"key1":"value1","key2":"value2"}'],
+                'key',
+                '',
+                '\n',
+                '',
+                '{\n"key1":"value1",\n"key2":"value2"\n}',
+            ],
+            'with SPACE modifier only' => [
+                ['key', '$', '{"key1":"value1","key2":"value2"}'],
+                'key',
+                '',
+                '',
+                ' ',
+                '{"key1": "value1","key2": "value2"}',
+            ],
+            'with all modifiers' => [
+                ['key', '$', '{"key1":"value1","key2":"value2"}'],
+                'key',
+                '\t',
+                '\n',
+                ' ',
+                '{\n\t"key1": "value1",\n\t"key2": "value2"\n}',
+            ],
+        ];
+    }
+
+    public function unexpectedValuesProvider(): array
+    {
+        return [
+            'with wrong INDENT modifier' => [
+                ['key', 1, '', ''],
+                'Indent argument value should be a string'
+            ],
+            'with wrong NEWLINE modifier' => [
+                ['key', '', 1, ''],
+                'Newline argument value should be a string'
+            ],
+            'with wrong SPACE modifier' => [
+                ['key', '', '', 1],
+                'Space argument value should be a string'
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Redis/Json/JSONSET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSET_Test.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Predis\Command\Redis\Json;
+
+use Predis\Command\Redis\PredisCommandTestCase;
+use UnexpectedValueException;
+
+class JSONSET_Test extends PredisCommandTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedCommand(): string
+    {
+        return JSONSET::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedId(): string
+    {
+        return 'JSONSET';
+    }
+
+    /**
+     * @group disconnected
+     * @dataProvider argumentsProvider
+     */
+    public function testFilterArguments(array $actualArguments, array $expectedArguments): void
+    {
+        $command = $this->getCommand();
+        $command->setArguments($actualArguments);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testParseResponse(): void
+    {
+        $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group connected
+     * @dataProvider jsonProvider
+     * @param string $key
+     * @param string $defaultJson
+     * @param string $appendedJson
+     * @param string $path
+     * @param string|null $subcommand
+     * @param string|null $expectedResponse
+     * @param string $expectedJson
+     * @return void
+     * @requiresRedisJsonVersion >= 1.0.0
+     */
+    public function testSetCorrectJsonValueAndReturnsCorrespondingResponse(
+        string $key,
+        string $defaultJson,
+        string $appendedJson,
+        string $path,
+        ?string $subcommand,
+        ?string $expectedResponse,
+        string $expectedJson
+    ): void {
+        $redis = $this->getClient();
+
+        $this->assertEquals('OK', $redis->jsonset($key, '$', $defaultJson));
+        $this->assertEquals($expectedResponse, $redis->jsonset($key, $path, $appendedJson, $subcommand));
+        $this->assertSame($expectedJson, $redis->jsonget($key));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisJsonVersion >= 1.0.0
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(): void
+    {
+        $redis = $this->getClient();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Subcommand argument accepts only: nx, xx values');
+
+        $redis->jsonset('key', '$', 'value', 'wrong');
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with default arguments' => [
+                ['key', 'path', 'value'],
+                ['key', 'path', 'value']
+            ],
+            'with NX subcommand' => [
+                ['key', 'path', 'value', 'nx'],
+                ['key', 'path', 'value', 'NX'],
+            ],
+            'with XX subcommand' => [
+                ['key', 'path', 'value', 'xx'],
+                ['key', 'path', 'value', 'XX'],
+            ],
+        ];
+    }
+
+    public function jsonProvider(): array
+    {
+        return [
+            'override json' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '{"key3":"value3"}',
+                '$',
+                null,
+                'OK',
+                '{"key3":"value3"}'
+            ],
+            'override certain key - without subcommands' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value3"',
+                '$.key2',
+                null,
+                'OK',
+                '{"key1":"value1","key2":"value3"}'
+            ],
+            'append to json - without subcommands' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value3"',
+                '$.key3',
+                null,
+                'OK',
+                '{"key1":"value1","key2":"value2","key3":"value3"}'
+            ],
+            'override certain key - with XX subcommand' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value3"',
+                '$.key2',
+                'xx',
+                'OK',
+                '{"key1":"value1","key2":"value3"}'
+            ],
+            'append to json - with NX subcommand' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value3"',
+                '$.key3',
+                'nx',
+                'OK',
+                '{"key1":"value1","key2":"value2","key3":"value3"}'
+            ],
+            'override failed with XX subcommand' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value3"',
+                '$.key3',
+                'xx',
+                null,
+                '{"key1":"value1","key2":"value2"}'
+            ],
+            'append failed with NX subcommand' => [
+                'key',
+                '{"key1":"value1","key2":"value2"}',
+                '"value2"',
+                '$.key2',
+                'nx',
+                null,
+                '{"key1":"value1","key2":"value2"}'
+            ]
+        ];
+    }
+}

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -27,7 +27,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportedCommands(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         foreach ($this->getExpectedCommands() as $commandID) {
             $this->assertTrue($factory->supports($commandID), "Command factory does not support $commandID");
@@ -39,7 +39,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportCommand(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $this->assertTrue($factory->supports('info'));
         $this->assertTrue($factory->supports('INFO'));
@@ -53,7 +53,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportCommands(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $this->assertTrue($factory->supports('get', 'set'));
         $this->assertTrue($factory->supports('GET', 'SET'));
@@ -68,7 +68,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testGetCommandClass(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('ping'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
@@ -82,7 +82,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testDefineCommand(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')
             ->getMock();
@@ -100,7 +100,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testUndefineCommandInClassAutoload(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $this->assertTrue($factory->supports('PING'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
@@ -116,7 +116,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testUndefineCommandInClassMap(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $commandClass = get_class($this->getMockBuilder('Predis\Command\CommandInterface')->getMock());
         $factory->define('MOCK', $commandClass);
@@ -138,7 +138,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Class stdClass must implement Predis\Command\CommandInterface");
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $factory->define('mock', 'stdClass');
     }
@@ -148,7 +148,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testCreateCommandWithoutArguments(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $command = $factory->create('info');
 
@@ -162,7 +162,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testCreateCommandWithArguments(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $arguments = array('foo', 'bar');
         $command = $factory->create('set', $arguments);
@@ -180,7 +180,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage("Command `UNKNOWN` is not a registered Redis command.");
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $factory->create('unknown');
     }
@@ -190,7 +190,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testGetDefaultProcessor(): void
     {
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $this->assertNull($factory->getProcessor());
     }
@@ -205,7 +205,7 @@ class RedisFactoryTest extends PredisTestCase
             ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
         $factory->setProcessor($processor);
 
         $this->assertSame($processor, $factory->getProcessor());
@@ -221,7 +221,7 @@ class RedisFactoryTest extends PredisTestCase
             ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
 
         $factory->setProcessor($processor);
         $this->assertSame($processor, $factory->getProcessor());
@@ -253,7 +253,7 @@ class RedisFactoryTest extends PredisTestCase
                 }
             );
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
         $factory->setProcessor($processor);
         $factory->create('set', array('foo', 'bar'));
 
@@ -277,7 +277,7 @@ class RedisFactoryTest extends PredisTestCase
         $chain->add($processor);
         $chain->add($processor);
 
-        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $factory = new RedisFactory(new CommandResolver());
         $factory->setProcessor($chain);
 
         $factory->create('info');

--- a/tests/Predis/Command/RedisFactoryTest.php
+++ b/tests/Predis/Command/RedisFactoryTest.php
@@ -11,8 +11,10 @@
 
 namespace Predis\Command;
 
+use Predis\ClientConfiguration;
 use Predis\Command\Processor\ProcessorChain;
 use Predis\Command\Processor\ProcessorInterface;
+use Predis\Command\Resolver\CommandResolver;
 use PredisTestCase;
 
 /**
@@ -25,7 +27,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportedCommands(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         foreach ($this->getExpectedCommands() as $commandID) {
             $this->assertTrue($factory->supports($commandID), "Command factory does not support $commandID");
@@ -37,7 +39,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportCommand(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $this->assertTrue($factory->supports('info'));
         $this->assertTrue($factory->supports('INFO'));
@@ -51,7 +53,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testSupportCommands(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $this->assertTrue($factory->supports('get', 'set'));
         $this->assertTrue($factory->supports('GET', 'SET'));
@@ -66,7 +68,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testGetCommandClass(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('ping'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
@@ -80,7 +82,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testDefineCommand(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $command = $this->getMockBuilder('Predis\Command\CommandInterface')
             ->getMock();
@@ -98,7 +100,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testUndefineCommandInClassAutoload(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $this->assertTrue($factory->supports('PING'));
         $this->assertSame('Predis\Command\Redis\PING', $factory->getCommandClass('PING'));
@@ -114,7 +116,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testUndefineCommandInClassMap(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $commandClass = get_class($this->getMockBuilder('Predis\Command\CommandInterface')->getMock());
         $factory->define('MOCK', $commandClass);
@@ -136,7 +138,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage("Class stdClass must implement Predis\Command\CommandInterface");
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $factory->define('mock', 'stdClass');
     }
@@ -146,7 +148,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testCreateCommandWithoutArguments(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $command = $factory->create('info');
 
@@ -160,7 +162,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testCreateCommandWithArguments(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $arguments = array('foo', 'bar');
         $command = $factory->create('set', $arguments);
@@ -178,7 +180,7 @@ class RedisFactoryTest extends PredisTestCase
         $this->expectException('Predis\ClientException');
         $this->expectExceptionMessage("Command `UNKNOWN` is not a registered Redis command.");
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $factory->create('unknown');
     }
@@ -188,7 +190,7 @@ class RedisFactoryTest extends PredisTestCase
      */
     public function testGetDefaultProcessor(): void
     {
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $this->assertNull($factory->getProcessor());
     }
@@ -203,7 +205,7 @@ class RedisFactoryTest extends PredisTestCase
             ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
         $factory->setProcessor($processor);
 
         $this->assertSame($processor, $factory->getProcessor());
@@ -219,7 +221,7 @@ class RedisFactoryTest extends PredisTestCase
             ->getMockBuilder('Predis\Command\Processor\ProcessorInterface')
             ->getMock();
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $factory->setProcessor($processor);
         $this->assertSame($processor, $factory->getProcessor());
@@ -251,7 +253,7 @@ class RedisFactoryTest extends PredisTestCase
                 }
             );
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
         $factory->setProcessor($processor);
         $factory->create('set', array('foo', 'bar'));
 
@@ -275,7 +277,7 @@ class RedisFactoryTest extends PredisTestCase
         $chain->add($processor);
         $chain->add($processor);
 
-        $factory = new RedisFactory();
+        $factory = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
         $factory->setProcessor($chain);
 
         $factory->create('info');

--- a/tests/Predis/Command/Resolver/CommandResolverTest.php
+++ b/tests/Predis/Command/Resolver/CommandResolverTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Predis\Command\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Command\Redis\SET;
+
+class CommandResolverTest extends TestCase
+{
+    /**
+     * @dataProvider commandsProvider
+     * @param array $modules
+     * @param string $commandID
+     * @param string|null $expectedCommandClass
+     * @return void
+     */
+    public function testResolveResolvesCorrectlyCommand(
+        array $modules,
+        string $commandID,
+        ?string $expectedCommandClass
+    ): void {
+        $resolver = new CommandResolver($modules);
+
+        $this->assertSame($expectedCommandClass, $resolver->resolve($commandID));
+    }
+
+    public function commandsProvider(): array
+    {
+        return [
+            'core command exists' => [[], 'SET', SET::class],
+            'module not exist' => [[['name' => 'foo', 'commandPrefix' => 'bar']], 'BARFOO', null],
+            'module exists, module command not exists' => [[['name' => 'foo', 'commandPrefix' => 'bar']], 'FOOBAR', null],
+        ];
+    }
+}

--- a/tests/Predis/Command/Traits/Json/IndentTest.php
+++ b/tests/Predis/Command/Traits/Json/IndentTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use PredisTestCase;
+use Predis\Command\Command as RedisCommand;
+use UnexpectedValueException;
+
+class IndentTest extends PredisTestCase
+{
+    private $testClass;
+
+    protected function setUp(): void
+    {
+        $this->testClass = new class extends RedisCommand {
+            use Indent;
+
+            public static $indentArgumentPositionOffset = 0;
+
+            public function getId()
+            {
+                return 'test';
+            }
+        };
+    }
+
+    /**
+     * @dataProvider argumentsProvider
+     * @param int $offset
+     * @param array $actualArguments
+     * @param array $expectedResponse
+     * @return void
+     */
+    public function testReturnsCorrectArguments(
+        int $offset,
+        array $actualArguments,
+        array $expectedResponse
+    ): void {
+        $this->testClass::$indentArgumentPositionOffset = $offset;
+
+        $this->testClass->setArguments($actualArguments);
+
+        $this->assertSame($expectedResponse, $this->testClass->getArguments());
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Indent argument value should be a string");
+
+        $this->testClass->setArguments([1]);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with wrong offset' => [
+                2,
+                ['argument1'],
+                ['argument1'],
+            ],
+            'with default value' => [
+                0,
+                [''],
+                [false]
+            ],
+            'with correct argument' => [
+                0,
+                ['\t'],
+                ['INDENT', '\t'],
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Traits/Json/NewlineTest.php
+++ b/tests/Predis/Command/Traits/Json/NewlineTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+use Predis\Command\Command as RedisCommand;
+use PredisTestCase;
+use UnexpectedValueException;
+
+class NewlineTest extends PredisTestCase
+{
+    private $testClass;
+
+    protected function setUp(): void
+    {
+        $this->testClass = new class extends RedisCommand {
+            use Newline;
+
+            public static $newlineArgumentPositionOffset = 0;
+
+            public function getId()
+            {
+                return 'test';
+            }
+        };
+    }
+
+    /**
+     * @dataProvider argumentsProvider
+     * @param int $offset
+     * @param array $actualArguments
+     * @param array $expectedResponse
+     * @return void
+     */
+    public function testReturnsCorrectArguments(
+        int $offset,
+        array $actualArguments,
+        array $expectedResponse
+    ): void {
+        $this->testClass::$newlineArgumentPositionOffset = $offset;
+
+        $this->testClass->setArguments($actualArguments);
+
+        $this->assertSame($expectedResponse, $this->testClass->getArguments());
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Newline argument value should be a string");
+
+        $this->testClass->setArguments([1]);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with wrong offset' => [
+                2,
+                ['argument1'],
+                ['argument1'],
+            ],
+            'with default value' => [
+                0,
+                [''],
+                [false]
+            ],
+            'with correct argument' => [
+                0,
+                ['\n'],
+                ['NEWLINE', '\n'],
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Traits/Json/NxXxSubcommandTest.php
+++ b/tests/Predis/Command/Traits/Json/NxXxSubcommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use PredisTestCase;
+use Predis\Command\Command as RedisCommand;
+use UnexpectedValueException;
+
+class NxXxSubcommandTest extends PredisTestCase
+{
+    private $testClass;
+
+    protected function setUp(): void
+    {
+        $this->testClass = new class extends RedisCommand {
+            use NxXxSubcommand;
+
+            public static $nxXxArgumentPositionOffset = 0;
+
+            public function getId()
+            {
+                return 'test';
+            }
+        };
+    }
+
+    /**
+     * @dataProvider argumentsProvider
+     * @param int $offset
+     * @param array $actualArguments
+     * @param array $expectedResponse
+     * @return void
+     */
+    public function testReturnsCorrectArguments(
+        int $offset,
+        array $actualArguments,
+        array $expectedResponse
+    ): void {
+        $this->testClass::$nxXxArgumentPositionOffset = $offset;
+
+        $this->testClass->setArguments($actualArguments);
+
+        $this->assertSame($expectedResponse, $this->testClass->getArguments());
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Subcommand argument accepts only: nx, xx values");
+
+        $this->testClass->setArguments(['wrong']);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with correct argument - NX' => [
+                0,
+                ['nx'],
+                ['NX']
+            ],
+            'with correct argument - XX' => [
+                0,
+                ['xx'],
+                ['XX']
+            ],
+            'with wrong offset' => [
+                2,
+                ['argument1'],
+                ['argument1'],
+            ],
+            'with null argument' => [
+                0,
+                [null],
+                [false]
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Traits/Json/SpaceTest.php
+++ b/tests/Predis/Command/Traits/Json/SpaceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Predis\Command\Traits\Json;
+
+use PredisTestCase;
+use Predis\Command\Command as RedisCommand;
+use UnexpectedValueException;
+
+class SpaceTest extends PredisTestCase
+{
+    private $testClass;
+
+    protected function setUp(): void
+    {
+        $this->testClass = new class extends RedisCommand {
+            use Space;
+
+            public static $spaceArgumentPositionOffset = 0;
+
+            public function getId()
+            {
+                return 'test';
+            }
+        };
+    }
+
+    /**
+     * @dataProvider argumentsProvider
+     * @param int $offset
+     * @param array $actualArguments
+     * @param array $expectedResponse
+     * @return void
+     */
+    public function testReturnsCorrectArguments(
+        int $offset,
+        array $actualArguments,
+        array $expectedResponse
+    ): void {
+        $this->testClass::$spaceArgumentPositionOffset = $offset;
+
+        $this->testClass->setArguments($actualArguments);
+
+        $this->assertSame($expectedResponse, $this->testClass->getArguments());
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionOnUnexpectedValueGiven(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Space argument value should be a string");
+
+        $this->testClass->setArguments([1]);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with wrong offset' => [
+                2,
+                ['argument1'],
+                ['argument1'],
+            ],
+            'with default value' => [
+                0,
+                [''],
+                [false]
+            ],
+            'with correct argument' => [
+                0,
+                [' '],
+                ['SPACE', ' '],
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -79,7 +79,7 @@ class CommandsTest extends PredisTestCase
         /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
-        $input = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
+        $input = new RedisFactory(new CommandResolver());
 
         $commands = $option->filter($options, $input);
 

--- a/tests/Predis/Configuration/Option/CommandsTest.php
+++ b/tests/Predis/Configuration/Option/CommandsTest.php
@@ -11,6 +11,8 @@
 
 namespace Predis\Configuration\Option;
 
+use Predis\ClientConfiguration;
+use Predis\Command\Resolver\CommandResolver;
 use PredisTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Configuration\OptionsInterface;
@@ -77,7 +79,7 @@ class CommandsTest extends PredisTestCase
         /** @var OptionsInterface */
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
-        $input = new RedisFactory();
+        $input = new RedisFactory(new CommandResolver(ClientConfiguration::getModules()));
 
         $commands = $option->filter($options, $input);
 


### PR DESCRIPTION
New functionality implemented:
1. Changed CI - Added one more workflow to run tests over redis-stack instances. Redis JSON as many other modules available in redis-stack which is based on redis-server >= 6.2.0. So now all redis-server instances <= 6.2.0 runs within "Redis server tests" workflow and >= 6.2.0 runs over "Redis stack tests" workflow.
2. Added new configuration object (for now can be used as configuration layer), that keeps information about modules.
3. Added new layer for command resolving, which is responsible for resolving Redis command objects from virtual methods of client. More logic to command resolving required as new module support was introduced, so it's make sense to keep it at separate layer.
4. Added new directory structure for module commands. Since, new module support was introduced it's make sense to keep module commands in separate directories (f.e .../Redis/Json/...), so it have more structured format. New module command directories should have the same name as module (keeps in configuration) and command ID should starts with corresponding module prefix, same as in Redis (f.e Json - JSON, Search - FT etc.)
5. New decorator. Added new requiresRedisJsonVersion annotation, so we can mark tests to run only on instances with corresponding version of Redis JSON.
6. Added support for base commands JSON.GET and JSON.SET

@dvora-h @sazzad16
