### PR TITLE
Fix Client template

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -36,10 +36,7 @@ use Predis\Transaction\MultiExec as MultiExecTransaction;
  * abstractions are built. Internally it aggregates various other classes each
  * one with its own responsibility and scope.
  *
- * {@inheritdoc}
- * @template TKey
- * @template TValue
- * @template-implements Traversable<TKey, TValue>
+ * @template-implements \IteratorAggregate<string, static>
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */
@@ -516,8 +513,7 @@ class Client implements ClientInterface, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
-     * @return Traversable<TKey, TValue>|TValue[]
+     * @return Traversable<string, static>
      */
     #[\ReturnTypeWillChange]
     public function getIterator()


### PR DESCRIPTION
https://github.com/predis/predis/pull/810 added generics to `Client`, that means that when using `Client` you should specify both parameters, getting this kind of message using static analysis tools:

```
Method App\My\Service::__construct() has parameter $redisClient with generic class Predis\Client but does not specify its types:
         TKey, TValue
```

Looking at what `Client::getIterator()` does:

https://github.com/predis/predis/blob/fbf270156f529a9920551c6f499c52a11ca4a1c3/src/Client.php#L523-L539

it returns an `\ArrayIterator` having as keys strings and as values instances of the class itself, so I think this class shouldn't be generic.