### PR TITLE
Fix support options array in `ZINTERSTORE` and `ZUNIONSTORE`

### DIFF
--- a/src/Command/Redis/ZINTERSTORE.php
+++ b/src/Command/Redis/ZINTERSTORE.php
@@ -25,24 +25,4 @@ class ZINTERSTORE extends ZUNIONSTORE
     {
         return 'ZINTERSTORE';
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setArguments(array $arguments)
-    {
-        if (! isset($arguments[3]) && (isset($arguments[2]['weights']) || isset($arguments[2]['aggregate']))) {
-            $options = array_pop($arguments);
-            array_push($arguments, $options['weights'] ?? []);
-            array_push($arguments, $options['aggregate'] ?? 'sum');
-        }
-
-        $this->setAggregate($arguments);
-        $arguments = $this->getArguments();
-
-        $this->setWeights($arguments);
-        $arguments = $this->getArguments();
-
-        $this->setKeys($arguments);
-    }
 }

--- a/src/Command/Redis/ZINTERSTORE.php
+++ b/src/Command/Redis/ZINTERSTORE.php
@@ -37,6 +37,12 @@ class ZINTERSTORE extends ZUNIONSTORE
             array_push($arguments, $options['aggregate'] ?? 'sum');
         }
 
-        parent::setArguments($arguments);
+        $this->setAggregate($arguments);
+        $arguments = $this->getArguments();
+
+        $this->setWeights($arguments);
+        $arguments = $this->getArguments();
+
+        $this->setKeys($arguments);
     }
 }

--- a/src/Command/Redis/ZINTERSTORE.php
+++ b/src/Command/Redis/ZINTERSTORE.php
@@ -25,4 +25,18 @@ class ZINTERSTORE extends ZUNIONSTORE
     {
         return 'ZINTERSTORE';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setArguments(array $arguments)
+    {
+        if (! isset($arguments[3]) && (isset($arguments[2]['weights']) || isset($arguments[2]['aggregate']))) {
+            $options = array_pop($arguments);
+            array_push($arguments, $options['weights'] ?? []);
+            array_push($arguments, $options['aggregate'] ?? 'sum');
+        }
+
+        parent::setArguments($arguments);
+    }
 }

--- a/src/Command/Redis/ZUNIONSTORE.php
+++ b/src/Command/Redis/ZUNIONSTORE.php
@@ -50,6 +50,7 @@ class ZUNIONSTORE extends RedisCommand
      */
     public function setArguments(array $arguments)
     {
+        // support old `$options` array for backwards compatibility
         if (! isset($arguments[3]) && (isset($arguments[2]['weights']) || isset($arguments[2]['aggregate']))) {
             $options = array_pop($arguments);
             array_push($arguments, $options['weights'] ?? []);

--- a/src/Command/Redis/ZUNIONSTORE.php
+++ b/src/Command/Redis/ZUNIONSTORE.php
@@ -50,6 +50,12 @@ class ZUNIONSTORE extends RedisCommand
      */
     public function setArguments(array $arguments)
     {
+        if (! isset($arguments[3]) && (isset($arguments[2]['weights']) || isset($arguments[2]['aggregate']))) {
+            $options = array_pop($arguments);
+            array_push($arguments, $options['weights'] ?? []);
+            array_push($arguments, $options['aggregate'] ?? 'sum');
+        }
+
         $this->setAggregate($arguments);
         $arguments = $this->getArguments();
 

--- a/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
@@ -157,7 +157,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
             'with options array' => [
                 ['destination', ['key1', 'key2'], [
                     'weights' => [1, 2],
-                    'aggregate' => 'MIN',
+                    'aggregate' => 'min',
                 ]],
                 ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'MIN'],
             ],

--- a/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
@@ -157,9 +157,9 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
             'with options array' => [
                 ['destination', ['key1', 'key2'], [
                     'weights' => [1, 2],
-                    'aggregate' => 'sum',
+                    'aggregate' => 'MIN',
                 ]],
-                ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'SUM'],
+                ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'MIN'],
             ],
         ];
     }

--- a/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
@@ -153,7 +153,14 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
             'with all arguments' => [
                 ['destination', ['key1', 'key2'], [1, 2], 'min'],
                 ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'MIN'],
-            ]
+            ],
+            'with options array' => [
+                ['destination', ['key1', 'key2'], [
+                    'weights' => [1, 2],
+                    'aggregate' => 'sum',
+                ]],
+                ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'SUM'],
+            ],
         ];
     }
 

--- a/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
@@ -153,7 +153,14 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
             'with all arguments' => [
                 ['destination', ['key1', 'key2'], [1, 2], 'min'],
                 ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'MIN'],
-            ]
+            ],
+            'with options array' => [
+                ['destination', ['key1', 'key2'], [
+                    'weights' => [1, 2],
+                    'aggregate' => 'min',
+                ]],
+                ['destination', 2, 'key1', 'key2', 'WEIGHTS', 1, 2, 'AGGREGATE', 'MIN'],
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #1016.

The culprit: https://github.com/predis/predis/pull/858