### PR TITLE
Added support for container commands

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,8 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use Predis\Command\CommandInterface;
 use Predis\Command\RawCommand;
+use Predis\Command\Redis\Container\ContainerFactory;
+use Predis\Command\Redis\Container\ContainerInterface;
 use Predis\Command\ScriptCommand;
 use Predis\Configuration\Options;
 use Predis\Configuration\OptionsInterface;
@@ -31,6 +33,7 @@ use Predis\Response\ResponseInterface;
 use Predis\Response\ServerException;
 use Predis\Transaction\MultiExec as MultiExecTransaction;
 use ReturnTypeWillChange;
+use RuntimeException;
 use Traversable;
 
 /**
@@ -308,6 +311,34 @@ class Client implements ClientInterface, IteratorAggregate
     public function createCommand($commandID, $arguments = [])
     {
         return $this->commands->create($commandID, $arguments);
+    }
+
+    /**
+     * @param $name
+     * @return ContainerInterface
+     */
+    public function __get($name)
+    {
+        return ContainerFactory::create($this, $name);
+    }
+
+    /**
+     * @param $name
+     * @param $value
+     * @return mixed
+     */
+    public function __set($name, $value)
+    {
+        throw new RuntimeException('Not allowed');
+    }
+
+    /**
+     * @param $name
+     * @return mixed
+     */
+    public function __isset($name)
+    {
+        throw new RuntimeException('Not allowed');
     }
 
     /**

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -16,6 +16,7 @@ use Predis\Command\Argument\Geospatial\ByInterface;
 use Predis\Command\Argument\Geospatial\FromInterface;
 use Predis\Command\Argument\Server\To;
 use Predis\Command\CommandInterface;
+use Predis\Command\Redis\Container\FunctionContainer;
 
 /**
  * Interface defining a client-side context such as a pipeline or transaction.
@@ -53,6 +54,7 @@ use Predis\Command\CommandInterface;
  * @method $this decr($key)
  * @method $this decrby($key, $decrement)
  * @method $this failover(?To $to = null, bool $abort = false, int $timeout = -1)
+ * @method $this fcall(string $function, array $keys, ...$args)
  * @method $this get($key)
  * @method $this getbit($key, $offset)
  * @method $this getex(string $key, $modifier = '', $value = false)
@@ -195,6 +197,9 @@ use Predis\Command\CommandInterface;
  * @method $this georadiusbymember($key, $member, $radius, $unit, array $options = null)
  * @method $this geosearch(string $key, FromInterface $from, ByInterface $by, ?string $sorting = null, int $count = -1, bool $any = false, bool $withCoord = false, bool $withDist = false, bool $withHash = false)
  * @method $this geosearchstore(string $destination, string $source, FromInterface $from, ByInterface $by, ?string $sorting = null, int $count = -1, bool $any = false, bool $storeDist = false)
+ *
+ * Container commands
+ * @property FunctionContainer $function
  */
 interface ClientContextInterface
 {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -17,6 +17,7 @@ use Predis\Command\Argument\Geospatial\FromInterface;
 use Predis\Command\Argument\Server\To;
 use Predis\Command\CommandInterface;
 use Predis\Command\FactoryInterface;
+use Predis\Command\Redis\Container\FunctionContainer;
 use Predis\Configuration\OptionsInterface;
 use Predis\Connection\ConnectionInterface;
 use Predis\Response\Status;
@@ -62,6 +63,7 @@ use Predis\Response\Status;
  * @method int               decr(string $key)
  * @method int               decrby(string $key, int $decrement)
  * @method Status            failover(?To $to = null, bool $abort = false, int $timeout = -1)
+ * @method mixed             fcall(string $function, array $keys, ...$args)
  * @method string|null       get(string $key)
  * @method int               getbit(string $key, $offset)
  * @method int|null          getex(string $key, $modifier = '', $value = false)
@@ -213,6 +215,9 @@ use Predis\Response\Status;
  * @method array             georadiusbymember(string $key, $member, $radius, $unit, array $options = null)
  * @method array             geosearch(string $key, FromInterface $from, ByInterface $by, ?string $sorting = null, int $count = -1, bool $any = false, bool $withCoord = false, bool $withDist = false, bool $withHash = false)
  * @method int               geosearchstore(string $destination, string $source, FromInterface $from, ByInterface $by, ?string $sorting = null, int $count = -1, bool $any = false, bool $storeDist = false)
+ *
+ * Container commands
+ * @property FunctionContainer $function
  */
 interface ClientInterface
 {

--- a/src/Command/Redis/Container/AbstractContainer.php
+++ b/src/Command/Redis/Container/AbstractContainer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis\Container;
+
+use Predis\ClientInterface;
+
+class AbstractContainer implements ContainerInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    protected $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __call($commandID, $arguments)
+    {
+        array_unshift($arguments, strtoupper($commandID));
+
+        return $this->client->executeCommand(
+            $this->client->createCommand($this->getContainerId(), $arguments)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getContainerId(): string
+    {
+        return static::$containerId;
+    }
+}

--- a/src/Command/Redis/Container/AbstractContainer.php
+++ b/src/Command/Redis/Container/AbstractContainer.php
@@ -14,7 +14,7 @@ namespace Predis\Command\Redis\Container;
 
 use Predis\ClientInterface;
 
-class AbstractContainer implements ContainerInterface
+abstract class AbstractContainer implements ContainerInterface
 {
     /**
      * @var ClientInterface
@@ -38,11 +38,5 @@ class AbstractContainer implements ContainerInterface
         );
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getContainerCommandId(): string
-    {
-        return static::$containerCommandId;
-    }
+    abstract public function getContainerCommandId(): string;
 }

--- a/src/Command/Redis/Container/AbstractContainer.php
+++ b/src/Command/Redis/Container/AbstractContainer.php
@@ -26,24 +26,23 @@ class AbstractContainer implements ContainerInterface
         $this->client = $client;
     }
 
-
     /**
      * {@inheritDoc}
      */
-    public function __call($commandID, $arguments)
+    public function __call($subcommandID, $arguments)
     {
-        array_unshift($arguments, strtoupper($commandID));
+        array_unshift($arguments, strtoupper($subcommandID));
 
         return $this->client->executeCommand(
-            $this->client->createCommand($this->getContainerId(), $arguments)
+            $this->client->createCommand($this->getContainerCommandId(), $arguments)
         );
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getContainerId(): string
+    public function getContainerCommandId(): string
     {
-        return static::$containerId;
+        return static::$containerCommandId;
     }
 }

--- a/src/Command/Redis/Container/ContainerFactory.php
+++ b/src/Command/Redis/Container/ContainerFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis\Container;
+
+use Predis\ClientInterface;
+use UnexpectedValueException;
+
+class ContainerFactory
+{
+    private const CONTAINER_NAMESPACE = "Predis\Command\Redis\Container";
+
+    /**
+     * Mappings for class names that corresponds to PHP reserved words.
+     *
+     * @var array
+     */
+    private static $specialMappings = [
+        'FUNCTION' => FunctionContainer::class,
+    ];
+
+    /**
+     * Creates container command.
+     *
+     * @param  ClientInterface    $client
+     * @param  string             $containerCommandID
+     * @return ContainerInterface
+     */
+    public static function create(ClientInterface $client, string $containerCommandID): ContainerInterface
+    {
+        $containerCommandID = strtoupper($containerCommandID);
+
+        if (class_exists($containerClass = self::CONTAINER_NAMESPACE . '\\' . $containerCommandID)) {
+            return new $containerClass($client);
+        }
+
+        if (array_key_exists($containerCommandID, self::$specialMappings)) {
+            $containerClass = self::$specialMappings[$containerCommandID];
+
+            return new $containerClass($client);
+        }
+
+        throw new UnexpectedValueException('Given command is not supported.');
+    }
+}

--- a/src/Command/Redis/Container/ContainerInterface.php
+++ b/src/Command/Redis/Container/ContainerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis\Container;
+
+interface ContainerInterface
+{
+    /**
+     * Creates Redis container command with subcommand as virtual method name
+     * and sends a request to the server.
+     *
+     * @param $commandID
+     * @param $arguments
+     * @return mixed
+     */
+    public function __call($commandID, $arguments);
+
+    /**
+     * Returns containerId of specific container.
+     *
+     * @return string
+     */
+    public function getContainerId(): string;
+}

--- a/src/Command/Redis/Container/ContainerInterface.php
+++ b/src/Command/Redis/Container/ContainerInterface.php
@@ -18,16 +18,16 @@ interface ContainerInterface
      * Creates Redis container command with subcommand as virtual method name
      * and sends a request to the server.
      *
-     * @param $commandID
+     * @param $subcommandID
      * @param $arguments
      * @return mixed
      */
-    public function __call($commandID, $arguments);
+    public function __call($subcommandID, $arguments);
 
     /**
-     * Returns containerId of specific container.
+     * Returns containerCommandId of specific container command.
      *
      * @return string
      */
-    public function getContainerId(): string;
+    public function getContainerCommandId(): string;
 }

--- a/src/Command/Redis/Container/FunctionContainer.php
+++ b/src/Command/Redis/Container/FunctionContainer.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis\Container;
+
+use Predis\Response\Status;
+
+/**
+ * @method string load(string $functionCode, bool $replace = 'false')
+ * @method Status delete(string $libraryName)
+ */
+class FunctionContainer extends AbstractContainer
+{
+    protected static $containerId = 'function';
+}

--- a/src/Command/Redis/Container/FunctionContainer.php
+++ b/src/Command/Redis/Container/FunctionContainer.php
@@ -20,5 +20,8 @@ use Predis\Response\Status;
  */
 class FunctionContainer extends AbstractContainer
 {
-    protected static $containerCommandId = 'function';
+    public function getContainerCommandId(): string
+    {
+        return 'functions';
+    }
 }

--- a/src/Command/Redis/Container/FunctionContainer.php
+++ b/src/Command/Redis/Container/FunctionContainer.php
@@ -20,5 +20,5 @@ use Predis\Response\Status;
  */
 class FunctionContainer extends AbstractContainer
 {
-    protected static $containerId = 'function';
+    protected static $containerCommandId = 'function';
 }

--- a/src/Command/Redis/FCALL.php
+++ b/src/Command/Redis/FCALL.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Command\Command as RedisCommand;
+use Predis\Command\Traits\Keys;
+
+/**
+ * @see https://redis.io/commands/fcall/
+ *
+ * Invoke a function.
+ */
+class FCALL extends RedisCommand
+{
+    use Keys;
+
+    protected static $keysArgumentPositionOffset = 1;
+
+    public function getId()
+    {
+        return 'FCALL';
+    }
+}

--- a/src/Command/Redis/FUNCTIONS.php
+++ b/src/Command/Redis/FUNCTIONS.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Command\Command as RedisCommand;
+use Predis\Command\Strategy\StrategyResolverInterface;
+use Predis\Command\Strategy\SubcommandStrategyResolver;
+
+/**
+ * @see https://redis.io/commands/?name=function
+ *
+ * Container command corresponds to any FUNCTION *.
+ * Represents any FUNCTION command with subcommand as first argument.
+ */
+class FUNCTIONS extends RedisCommand
+{
+    /**
+     * @var StrategyResolverInterface
+     */
+    private $strategyResolver;
+
+    public function __construct()
+    {
+        $this->strategyResolver = new SubcommandStrategyResolver();
+    }
+
+    public function getId()
+    {
+        return 'FUNCTION';
+    }
+
+    public function setArguments(array $arguments)
+    {
+        $strategy = $this->strategyResolver->resolve('functions', $arguments[0]);
+        $arguments = $strategy->processArguments($arguments);
+
+        parent::setArguments($arguments);
+        $this->filterArguments();
+    }
+}

--- a/src/Command/RedisFactory.php
+++ b/src/Command/RedisFactory.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command;
 
+use Predis\Command\Redis\FUNCTIONS;
+
 /**
  * Command factory for mainline Redis servers.
  *
@@ -29,6 +31,8 @@ class RedisFactory extends Factory
             'ECHO' => 'Predis\Command\Redis\ECHO_',
             'EVAL' => 'Predis\Command\Redis\EVAL_',
             'OBJECT' => 'Predis\Command\Redis\OBJECT_',
+            // Class name corresponds to PHP reserved word "function", added mapping to bypass restrictions
+            'FUNCTION' => FUNCTIONS::class,
         ];
     }
 

--- a/src/Command/Strategy/ContainerCommands/Functions/DeleteStrategy.php
+++ b/src/Command/Strategy/ContainerCommands/Functions/DeleteStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy\ContainerCommands\Functions;
+
+use Predis\Command\Strategy\SubcommandStrategyInterface;
+
+class DeleteStrategy implements SubcommandStrategyInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function processArguments(array $arguments): array
+    {
+        return $arguments;
+    }
+}

--- a/src/Command/Strategy/ContainerCommands/Functions/LoadStrategy.php
+++ b/src/Command/Strategy/ContainerCommands/Functions/LoadStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy\ContainerCommands\Functions;
+
+use Predis\Command\Strategy\SubcommandStrategyInterface;
+
+class LoadStrategy implements SubcommandStrategyInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function processArguments(array $arguments): array
+    {
+        if (count($arguments) <= 2) {
+            return $arguments;
+        }
+
+        $processedArguments = [$arguments[0]];
+        $replace = array_pop($arguments);
+
+        if (is_bool($replace) && $replace) {
+            $processedArguments[] = 'REPLACE';
+        } elseif (!is_bool($replace)) {
+            $processedArguments[] = $replace;
+        }
+
+        $processedArguments[] = $arguments[1];
+
+        return $processedArguments;
+    }
+}

--- a/src/Command/Strategy/StrategyResolverInterface.php
+++ b/src/Command/Strategy/StrategyResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy;
+
+interface StrategyResolverInterface
+{
+    /**
+     * Resolves subcommand strategy.
+     *
+     * @param  string                      $commandId
+     * @param  string                      $subcommandId
+     * @return SubcommandStrategyInterface
+     */
+    public function resolve(string $commandId, string $subcommandId): SubcommandStrategyInterface;
+}

--- a/src/Command/Strategy/SubcommandStrategyInterface.php
+++ b/src/Command/Strategy/SubcommandStrategyInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy;
+
+interface SubcommandStrategyInterface
+{
+    /**
+     * Process arguments for given subcommand.
+     *
+     * @param  array $arguments
+     * @return array
+     */
+    public function processArguments(array $arguments): array;
+}

--- a/src/Command/Strategy/SubcommandStrategyResolver.php
+++ b/src/Command/Strategy/SubcommandStrategyResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy;
+
+use InvalidArgumentException;
+
+class SubcommandStrategyResolver implements StrategyResolverInterface
+{
+    private const CONTAINER_COMMANDS_NAMESPACE = 'Predis\Command\Strategy\ContainerCommands';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolve(string $commandId, string $subcommandId): SubcommandStrategyInterface
+    {
+        $subcommandStrategyClass = ucfirst(strtolower($subcommandId)) . 'Strategy';
+        $commandDirectoryName = ucfirst(strtolower($commandId));
+
+        if (class_exists(
+            $containerCommandClass = self::CONTAINER_COMMANDS_NAMESPACE . '\\' . $commandDirectoryName . '\\' . $subcommandStrategyClass
+        )) {
+            return new $containerCommandClass();
+        }
+
+        throw new InvalidArgumentException('Non-existing container command given');
+    }
+}

--- a/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
+++ b/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Predis\Command\Redis\Container;
+
+use PHPUnit\Framework\TestCase;
+use Predis\ClientInterface;
+use Predis\Command\CommandInterface;
+
+class AbstractContainerTest extends TestCase
+{
+    /**
+     * @var AbstractContainer
+     */
+    private $testClass;
+
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @var array
+     */
+    private $expectedValue;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|ClientInterface
+     */
+    private $mockClient;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|CommandInterface
+     */
+    private $mockCommand;
+
+    protected function setUp(): void
+    {
+        $this->arguments = ['arg1', 'arg2'];
+        $this->expectedValue = ['value'];
+        $this->mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $this->mockClient = $this->getMockBuilder(ClientInterface::class)->getMock();
+
+        $this->testClass = new class($this->mockClient) extends AbstractContainer {
+            protected static $containerId = 'test';
+        };
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetContainerId(): void
+    {
+        $this->assertSame('test', $this->testClass->getContainerId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCallReturnsValidCommandResponse(): void
+    {
+        $modifiedArguments = ['TEST', ['arg1', 'arg2']];
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('createCommand')
+            ->with($this->equalTo('test'), $modifiedArguments)
+            ->willReturn($this->mockCommand);
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('executeCommand')
+            ->with($this->mockCommand)
+            ->willReturn($this->expectedValue);
+
+        $this->assertSame($this->expectedValue, $this->testClass->test($this->arguments));
+    }
+}

--- a/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
+++ b/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Predis\Command\Redis\Container;
 
 use PHPUnit\Framework\TestCase;
@@ -41,7 +51,7 @@ class AbstractContainerTest extends TestCase
         $this->mockClient = $this->getMockBuilder(ClientInterface::class)->getMock();
 
         $this->testClass = new class($this->mockClient) extends AbstractContainer {
-            protected static $containerId = 'test';
+            protected static $containerCommandId = 'test';
         };
     }
 
@@ -50,7 +60,7 @@ class AbstractContainerTest extends TestCase
      */
     public function testGetContainerId(): void
     {
-        $this->assertSame('test', $this->testClass->getContainerId());
+        $this->assertSame('test', $this->testClass->getContainerCommandId());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
+++ b/tests/Predis/Command/Redis/Container/AbstractContainerTest.php
@@ -51,7 +51,10 @@ class AbstractContainerTest extends TestCase
         $this->mockClient = $this->getMockBuilder(ClientInterface::class)->getMock();
 
         $this->testClass = new class($this->mockClient) extends AbstractContainer {
-            protected static $containerCommandId = 'test';
+            public function getContainerCommandId(): string
+            {
+                return 'test';
+            }
         };
     }
 

--- a/tests/Predis/Command/Redis/Container/ContainerFactoryTest.php
+++ b/tests/Predis/Command/Redis/Container/ContainerFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis\Container;
+
+use PHPUnit\Framework\TestCase;
+use Predis\ClientInterface;
+use UnexpectedValueException;
+
+class ContainerFactoryTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|ClientInterface
+     */
+    private $mockClient;
+
+    /**
+     * @var ContainerFactory
+     */
+    private $factory;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $expectedContainer;
+
+    protected function setUp(): void
+    {
+        $this->mockClient = $this->getMockBuilder(ClientInterface::class)->getMock();
+        $this->expectedContainer = new FunctionContainer($this->mockClient);
+        $this->factory = new ContainerFactory();
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreatesReturnsExistingCommandContainerClass(): void
+    {
+        $this->assertEquals(
+            $this->expectedContainer,
+            $this->factory::create($this->mockClient, 'function')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionOnNonExistingCommand(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Given command is not supported.');
+
+        $this->factory::create($this->mockClient, 'foobar');
+    }
+}

--- a/tests/Predis/Command/Redis/FCALL_Test.php
+++ b/tests/Predis/Command/Redis/FCALL_Test.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Response\ServerException;
+
+/**
+ * @group commands
+ * @group realm-scripting
+ */
+class FCALL_Test extends PredisCommandTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommand(): string
+    {
+        return FCALL::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedId(): string
+    {
+        return 'FCALL';
+    }
+
+    /**
+     * @group disconnected
+     * @dataProvider argumentsProvider
+     */
+    public function testFilterArguments(array $actualArguments, array $expectedArguments): void
+    {
+        $command = $this->getCommand();
+        $command->setArguments($actualArguments);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testParseResponse(): void
+    {
+        $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group connected
+     * @dataProvider functionsProvider
+     * @param string $function
+     * @param array  $functionArguments
+     * @param $expectedResponse
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testInvokeGivenFunction(
+        string $function,
+        array $functionArguments,
+        $expectedResponse
+    ): void {
+        $redis = $this->getClient();
+
+        $this->assertSame('mylib', $redis->function->load($function));
+
+        $actualResponse = $redis->fcall(...$functionArguments);
+        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals('OK', $redis->function->delete('mylib'));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testThrowsExceptionOnNonExistingFunctionGiven(): void
+    {
+        $redis = $this->getClient();
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('ERR Function not found');
+
+        $redis->fcall('function', []);
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with default arguments' => [
+                ['function', []],
+                ['function', 0],
+            ],
+            'with provided keys' => [
+                ['function', ['key1', 'key2']],
+                ['function', 2, 'key1', 'key2'],
+            ],
+            'with provided keys and arguments' => [
+                ['function', ['key1', 'key2'], 'arg1', 'arg2'],
+                ['function', 2, 'key1', 'key2', 'arg1', 'arg2'],
+            ],
+        ];
+    }
+
+    public function functionsProvider(): array
+    {
+        return [
+            'with default arguments' => [
+                "#!lua name=mylib \n redis.register_function('myfunc', function(keys, args) return 'hello' end)",
+                ['myfunc', []],
+                'hello',
+            ],
+            'with provided keys' => [
+                "#!lua name=mylib \n redis.register_function('myfunc', function(keys, args) return keys[1] end)",
+                ['myfunc', ['key1']],
+                'key1',
+            ],
+            'with provided keys and arguments' => [
+                "#!lua name=mylib \n redis.register_function('myfunc', function(keys, args) return keys[1] .. ' ' .. args[1] end)",
+                ['myfunc', ['key1'], 'arg1'],
+                'key1 arg1',
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Redis/FUNCTIONS_Test.php
+++ b/tests/Predis/Command/Redis/FUNCTIONS_Test.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Response\ServerException;
+
+/**
+ * @group commands
+ * @group realm-scripting
+ */
+class FUNCTIONS_Test extends PredisCommandTestCase
+{
+    /**
+     * @var string
+     */
+    private $libName = 'mylib';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommand(): string
+    {
+        return FUNCTIONS::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedId(): string
+    {
+        return 'FUNCTION';
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testLoadFilterArguments(): void
+    {
+        $arguments = ['LOAD', 'function-code', true];
+        $expected = ['LOAD', 'function-code', 'REPLACE'];
+
+        $command = $this->getCommand();
+        $command->setArguments($arguments);
+
+        $this->assertSameValues($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testDeleteFilterArguments(): void
+    {
+        $arguments = ['DELETE', 'libraryName'];
+        $expected = ['DELETE', 'libraryName'];
+
+        $command = $this->getCommand();
+        $command->setArguments($arguments);
+
+        $this->assertSameValues($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testParseResponse(): void
+    {
+        $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testLoadFunctionAddFunctionIntoGivenLibrary(): void
+    {
+        $redis = $this->getClient();
+
+        $actualResponse = $redis->function->load(
+            "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
+        );
+
+        $this->assertSame('mylib', $actualResponse);
+        $this->assertSame('arg1', $redis->fcall('myfunc', [], 'arg1'));
+        $this->assertEquals('OK', $redis->function->delete($this->libName));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testLoadFunctionOverridesExistingFunctionWithReplaceArgumentGiven(): void
+    {
+        $redis = $this->getClient();
+
+        $actualResponse = $redis->function->load(
+            "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
+        );
+
+        $this->assertSame($this->libName, $actualResponse);
+        $this->assertSame('arg1', $redis->fcall('myfunc', [], 'arg1'));
+
+        $overriddenResponse = $redis->function->load(
+            "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[2] end)",
+            true
+        );
+
+        $this->assertSame($this->libName, $overriddenResponse);
+        $this->assertSame('arg2', $redis->fcall('myfunc', [], 'arg1', 'arg2'));
+        $this->assertEquals('OK', $redis->function->delete($this->libName));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testLoadFunctionThrowsErrorOnAlreadyExistingLibraryGiven(): void
+    {
+        $redis = $this->getClient();
+
+        $actualResponse = $redis->function->load(
+            "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
+        );
+
+        $this->assertSame($this->libName, $actualResponse);
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage("ERR Library '{$this->libName}' already exists");
+
+        try {
+            $redis->function->load(
+                "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
+            );
+        } finally {
+            $this->assertEquals('OK', $redis->function->delete($this->libName));
+        }
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testDeleteFunctionRemovesAlreadyExistingLibrary(): void
+    {
+        $redis = $this->getClient();
+
+        $actualResponse = $redis->function->load(
+            "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
+        );
+
+        $this->assertSame($this->libName, $actualResponse);
+        $this->assertEquals('OK', $redis->function->delete($this->libName));
+    }
+
+    /**
+     * @group connected
+     * @return void
+     * @requiresRedisVersion >= 7.0.0
+     */
+    public function testDeleteFunctionThrowsErrorOnNonExistingLibrary(): void
+    {
+        $redis = $this->getClient();
+
+        $this->expectException(ServerException::class);
+        $this->expectExceptionMessage('ERR Library not found');
+
+        $redis->function->delete($this->libName);
+    }
+}

--- a/tests/Predis/Command/Strategy/ContainerCommands/Functions/DeleteStrategyTest.php
+++ b/tests/Predis/Command/Strategy/ContainerCommands/Functions/DeleteStrategyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy\ContainerCommands\Functions;
+
+use PredisTestCase;
+
+class DeleteStrategyTest extends PredisTestCase
+{
+    /**
+     * @var DeleteStrategy
+     */
+    private $strategy;
+
+    protected function setUp(): void
+    {
+        $this->strategy = new DeleteStrategy();
+    }
+
+    public function testProcessArguments(): void
+    {
+        $this->assertSame(['arg1', 'arg2'], $this->strategy->processArguments(['arg1', 'arg2']));
+    }
+}

--- a/tests/Predis/Command/Strategy/ContainerCommands/Functions/LoadStrategyTest.php
+++ b/tests/Predis/Command/Strategy/ContainerCommands/Functions/LoadStrategyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy\ContainerCommands\Functions;
+
+use PredisTestCase;
+
+class LoadStrategyTest extends PredisTestCase
+{
+    /**
+     * @var LoadStrategy
+     */
+    private $strategy;
+
+    protected function setUp(): void
+    {
+        $this->strategy = new LoadStrategy();
+    }
+
+    /**
+     * @dataProvider argumentsProvider
+     * @param  array $actualArguments
+     * @param  array $expectedArguments
+     * @return void
+     */
+    public function testProcessArgumentsReturnsCorrectArguments(
+        array $actualArguments,
+        array $expectedArguments
+    ): void {
+        $this->assertSame($expectedArguments, $this->strategy->processArguments($actualArguments));
+    }
+
+    public function argumentsProvider(): array
+    {
+        return [
+            'with less then or equal 2 arguments' => [
+                ['arg1', 'arg2'],
+                ['arg1', 'arg2'],
+            ],
+            'with last argument equals true' => [
+                ['arg1', 'arg2', true],
+                ['arg1', 'REPLACE', 'arg2'],
+            ],
+            'with last argument equals false' => [
+                ['arg1', 'arg2', false],
+                ['arg1', 'arg2'],
+            ],
+        ];
+    }
+}

--- a/tests/Predis/Command/Strategy/SubcommandStrategyResolverTest.php
+++ b/tests/Predis/Command/Strategy/SubcommandStrategyResolverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Strategy;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Predis\Command\Strategy\ContainerCommands\Functions\LoadStrategy;
+
+class SubcommandStrategyResolverTest extends TestCase
+{
+    /**
+     * @var StrategyResolverInterface
+     */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new SubcommandStrategyResolver();
+    }
+
+    /**
+     * @return void
+     */
+    public function testResolveCorrectStrategy(): void
+    {
+        $expectedStrategy = new LoadStrategy();
+
+        $this->assertEquals($expectedStrategy, $this->resolver->resolve('functions', 'load'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testResolveThrowsExceptionOnNonExistingStrategy(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-existing container command given');
+
+        $this->resolver->resolve('foo', 'bar');
+    }
+}


### PR DESCRIPTION
Within this PR, introduced a new way to handle container commands:

1. All non-existing properties within Client consider as Containers. Within __get() method creating new instance of container.
2. Containers are just decorators for clients and works in the same manner - holding non-existing methods that equals to container commands subcommands and execute given container command with subcommand.
3. Container command extends abstract Command the same way as other redis command instances.
4. Container commands may use different strategies to process different subcommands arguments set

Closes #950 
Closes #953 
Closes #959 