### PR TITLE
Fix return type of ReplicationInterface::getSlaves

### DIFF
--- a/src/Connection/Replication/ReplicationInterface.php
+++ b/src/Connection/Replication/ReplicationInterface.php
@@ -47,7 +47,7 @@ interface ReplicationInterface extends AggregateConnectionInterface
     /**
      * Returns a list of connections to slave servers.
      *
-     * @return NodeConnectionInterface
+     * @return NodeConnectionInterface[]
      */
     public function getSlaves();
 }


### PR DESCRIPTION
The method returns a list of `NodeConnectionInterface`, not a single `NodeConnectionInterface`