### PR TITLE
Optionally disable load balancing reads to slaves when using a replication topology.

### DIFF
--- a/src/Replication/ReplicationStrategy.php
+++ b/src/Replication/ReplicationStrategy.php
@@ -23,6 +23,7 @@ class ReplicationStrategy
     protected $disallowed;
     protected $readonly;
     protected $readonlySHA1;
+    protected $loadBalancing = true;
 
     public function __construct()
     {
@@ -42,6 +43,10 @@ class ReplicationStrategy
      */
     public function isReadOperation(CommandInterface $command)
     {
+        if (!$this->loadBalancing) {
+            return false;
+        }
+
         if (isset($this->disallowed[$id = $command->getId()])) {
             throw new NotSupportedException(
                 "The command '$id' is not allowed in replication mode."
@@ -271,4 +276,18 @@ class ReplicationStrategy
             'GEORADIUSBYMEMBER' => [$this, 'isGeoradiusReadOnly'],
         ];
     }
+
+    /**
+     * Disables reads to slaves when using
+     * a replication topology.
+     *
+     * @return self
+     */
+    public function disableLoadBalancing(): self
+    {
+        $this->loadBalancing = false;
+
+        return $this;
+    }
+
 }

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -21,6 +21,29 @@ class ReplicationStrategyTest extends PredisTestCase
     /**
      * @group disconnected
      */
+    public function testLoadBalancing(): void
+    {
+        $commands = $this->getCommandFactory();
+        $strategy = new ReplicationStrategy();
+
+        $command = $commands->create('GET', ['key']);
+
+        $this->assertTrue(
+            $strategy->isReadOperation($command),
+            'GET is expected to be a read operation.'
+        );
+
+        $strategy->disableLoadBalancing();
+
+        $this->assertFalse(
+            $strategy->isReadOperation($command),
+            'GET is expected to be a write operation.'
+        );
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testReadCommands(): void
     {
         $commands = $this->getCommandFactory();


### PR DESCRIPTION
Following on from #1144 here is a solution for users who do not wish to load balance reads to slaves. This is via the configuration of the replication strategy in the configuration file.

```php
'sentinel-cache' => array_merge(
    array_map(
        function ($a, $b) {
            return ['host' => $a, 'port' => $b];
        },
        explode(',', env('REDIS_HOST', 'localhost')),
        explode(',', env('REDIS_PORT', 26379))
    ),
    ['options' => [
        'replication' => function () {
                              $strategy = new Predis\Replication\ReplicationStrategy();
                              $strategy->disableLoadBalancing();
                              return new Predis\Connection\Replication\SentinelReplication($strategy);
                          },
        'service' =>  env('REDIS_SENTINEL_SERVICE', 'mymaster'),
        'sentinel_timeout' => 3.0,
        'parameters' => [
            'password' => env('REDIS_PASSWORD', null),
            'database' => env('REDIS_CACHE_DB', 1),
        ],
    ]]
),
```

This will ensure all read/writes are delivered to the master redis server.