### PR TITLE
Deprecate webdis and phpiredis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fix `@template` in `Predis\Client` (#1017)
 - Fix support options array in `ZINTERSTORE` and `ZUNIONSTORE` (#1018)
 
+## Deprecated
+- Deprecated phpiredis and webdis connections
+
 ## v2.1.0 (2023-01-16)
 
 ## New Features

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ More details about this project can be found on the [frequently asked questions]
 - Abstraction for `SCAN`, `SSCAN`, `ZSCAN` and `HSCAN` (Redis >= 2.8) based on PHP iterators.
 - Connections are established lazily by the client upon the first command and can be persisted.
 - Connections can be established via TCP/IP (also TLS/SSL-encrypted) or UNIX domain sockets.
-- Support for [Webdis](http://webd.is) (requires both `ext-curl` and `ext-phpiredis`).
 - Support for custom connection classes for providing different network or protocol backends.
 - Flexible system for defining custom commands and override the default ones.
 
@@ -396,31 +395,6 @@ $response = $client->lpushrand('random_values', $seed = mt_rand());
 
 
 ### Customizable connection backends ###
-
-Predis can use different connection backends to connect to Redis. Two of them leverage a third party
-extension such as [phpiredis](https://github.com/nrk/phpiredis) resulting in major performance gains
-especially when dealing with big multibulk responses. While one is based on PHP streams, the other
-is based on socket resources provided by `ext-socket`. Both support TCP/IP and UNIX domain sockets:
-
-```php
-$client = new Predis\Client('tcp://127.0.0.1', [
-    'connections' => [
-        'tcp'  => 'Predis\Connection\PhpiredisStreamConnection',  // PHP stream resources
-        'unix' => 'Predis\Connection\PhpiredisSocketConnection',  // ext-socket resources
-    ],
-]);
-```
-
-The client can also be configured to rely on a [phpiredis](https://github.com/nrk/phpiredis)-backend
-by specifying a descriptive string for the `connections` client option. Supported string values are:
-
-- `phpiredis-stream` maps `tcp`, `redis` and `unix` to `Predis\Connection\PhpiredisStreamConnection`
-- `phpiredis-socket` maps `tcp`, `redis` and `unix` to `Predis\Connection\PhpiredisSocketConnection`
-- `phpiredis` is simply an alias of `phpiredis-stream`
-
-```php
-$client = new Predis\Client('tcp://127.0.0.1', ['connections' => 'phpiredis']);
-```
 
 Developers can create their own connection classes to support whole new network backends, extend
 existing classes or provide completely different implementations. Connection classes must implement

--- a/src/Cluster/Hash/PhpiredisCRC16.php
+++ b/src/Cluster/Hash/PhpiredisCRC16.php
@@ -16,6 +16,8 @@ use Predis\NotSupportedException;
 
 /**
  * Hash generator implementing the CRC-CCITT-16 algorithm used by redis-cluster.
+ * 
+ * @deprecated 2.1.2
  */
 class PhpiredisCRC16 implements HashGeneratorInterface
 {

--- a/src/Cluster/Hash/PhpiredisCRC16.php
+++ b/src/Cluster/Hash/PhpiredisCRC16.php
@@ -16,7 +16,7 @@ use Predis\NotSupportedException;
 
 /**
  * Hash generator implementing the CRC-CCITT-16 algorithm used by redis-cluster.
- * 
+ *
  * @deprecated 2.1.2
  */
 class PhpiredisCRC16 implements HashGeneratorInterface

--- a/src/Connection/PhpiredisSocketConnection.php
+++ b/src/Connection/PhpiredisSocketConnection.php
@@ -44,6 +44,7 @@ use Predis\Response\Status as StatusResponse;
  *  - read_write_timeout: timeout of read / write operations.
  *
  * @see http://github.com/nrk/phpiredis
+ * @deprecated 2.1.2
  */
 class PhpiredisSocketConnection extends AbstractConnection
 {

--- a/src/Connection/PhpiredisStreamConnection.php
+++ b/src/Connection/PhpiredisStreamConnection.php
@@ -46,6 +46,7 @@ use Predis\Response\Status as StatusResponse;
  *  - persistent: the connection is left intact after a GC collection.
  *
  * @see https://github.com/nrk/phpiredis
+ * @deprecated 2.1.2
  */
 class PhpiredisStreamConnection extends StreamConnection
 {

--- a/src/Connection/WebdisConnection.php
+++ b/src/Connection/WebdisConnection.php
@@ -43,6 +43,7 @@ use Predis\Response\Status as StatusResponse;
  * @see http://webd.is
  * @see http://github.com/nicolasff/webdis
  * @see http://github.com/seppo0010/phpiredis
+ * @deprecated 2.1.2
  */
 class WebdisConnection implements NodeConnectionInterface
 {


### PR DESCRIPTION
Will be replaced with [Relay](https://github.com/cachewerk/relay) in v3.0.

See #1084.