### PR TITLE
Fix a few issues (group relay-todo)

### DIFF
--- a/src/Command/Redis/HGETALL.php
+++ b/src/Command/Redis/HGETALL.php
@@ -35,7 +35,13 @@ class HGETALL extends RedisCommand
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            $result[$data[$i]] = $data[++$i];
+            if ($data[$i] ?? false) {
+                $result[$data[$i]] = $data[++$i];
+            }
+        }
+
+        if (!count($result)) {
+            $result = $data;
         }
 
         return $result;

--- a/src/Command/Redis/HGETALL.php
+++ b/src/Command/Redis/HGETALL.php
@@ -32,16 +32,14 @@ class HGETALL extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if ($data !== array_values($data)) {
+            return $data; // Relay
+        }
+
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            if ($data[$i] ?? false) {
-                $result[$data[$i]] = $data[++$i];
-            }
-        }
-
-        if (!count($result)) {
-            $result = $data;
+            $result[$data[$i]] = $data[++$i];
         }
 
         return $result;

--- a/src/Command/Redis/LCS.php
+++ b/src/Command/Redis/LCS.php
@@ -57,9 +57,11 @@ class LCS extends RedisCommand
     public function parseResponse($data)
     {
         if (is_array($data)) {
-            return array_key_exists(0, $data)
-                ? [$data[0] => $data[1], $data[2] => $data[3]]
-                : $data;
+            if ($data !== array_values($data)) {
+                return $data; // Relay
+            }
+
+            return [$data[0] => $data[1], $data[2] => $data[3]];
         }
 
         return $data;

--- a/src/Command/Redis/LCS.php
+++ b/src/Command/Redis/LCS.php
@@ -57,7 +57,9 @@ class LCS extends RedisCommand
     public function parseResponse($data)
     {
         if (is_array($data)) {
-            return [$data[0] => $data[1], $data[2] => $data[3]];
+            return array_key_exists(0, $data)
+                ? [$data[0] => $data[1], $data[2] => $data[3]]
+                : $data;
         }
 
         return $data;

--- a/src/Command/Redis/ZPOPMAX.php
+++ b/src/Command/Redis/ZPOPMAX.php
@@ -36,9 +36,9 @@ class ZPOPMAX extends RedisCommand
 
         for ($i = 0; $i < count($data); ++$i) {
             if (is_array($data[$i])) {
-                $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+                $result[$data[$i][0]] = $data[$i][1]; // Relay
             } else {
-                $result[$data[$i]] = sprintf('%s', (int) $data[++$i]);
+                $result[$data[$i]] = $data[++$i];
             }
         }
 

--- a/src/Command/Redis/ZPOPMAX.php
+++ b/src/Command/Redis/ZPOPMAX.php
@@ -35,7 +35,11 @@ class ZPOPMAX extends RedisCommand
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            $result[$data[$i]] = $data[++$i];
+            if (is_array($data[$i])) {
+                $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+            } else {
+                $result[$data[$i]] = $data[++$i];
+            }
         }
 
         return $result;

--- a/src/Command/Redis/ZPOPMAX.php
+++ b/src/Command/Redis/ZPOPMAX.php
@@ -38,7 +38,7 @@ class ZPOPMAX extends RedisCommand
             if (is_array($data[$i])) {
                 $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
             } else {
-                $result[$data[$i]] = $data[++$i];
+                $result[$data[$i]] = sprintf('%s', (int) $data[++$i]);
             }
         }
 

--- a/src/Command/Redis/ZPOPMIN.php
+++ b/src/Command/Redis/ZPOPMIN.php
@@ -36,9 +36,9 @@ class ZPOPMIN extends RedisCommand
 
         for ($i = 0; $i < count($data); ++$i) {
             if (is_array($data[$i])) {
-                $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+                $result[$data[$i][0]] = $data[$i][1]; // Relay
             } else {
-                $result[$data[$i]] = sprintf('%s', (int) $data[++$i]);
+                $result[$data[$i]] = $data[++$i];
             }
         }
 

--- a/src/Command/Redis/ZPOPMIN.php
+++ b/src/Command/Redis/ZPOPMIN.php
@@ -35,7 +35,11 @@ class ZPOPMIN extends RedisCommand
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            $result[$data[$i]] = $data[++$i];
+            if (is_array($data[$i])) {
+                $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+            } else {
+                $result[$data[$i]] = $data[++$i];
+            }
         }
 
         return $result;

--- a/src/Command/Redis/ZPOPMIN.php
+++ b/src/Command/Redis/ZPOPMIN.php
@@ -38,7 +38,7 @@ class ZPOPMIN extends RedisCommand
             if (is_array($data[$i])) {
                 $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
             } else {
-                $result[$data[$i]] = $data[++$i];
+                $result[$data[$i]] = sprintf('%s', (int) $data[++$i]);
             }
         }
 

--- a/src/Command/Redis/ZRANGE.php
+++ b/src/Command/Redis/ZRANGE.php
@@ -95,7 +95,7 @@ class ZRANGE extends RedisCommand
 
             for ($i = 0; $i < count($data); ++$i) {
                 if (is_array($data[$i])) {
-                    $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+                    $result[$data[$i][0]] = $data[$i][1]; // Relay
                 } else {
                     $result[$data[$i]] = $data[++$i];
                 }

--- a/src/Command/Redis/ZRANGE.php
+++ b/src/Command/Redis/ZRANGE.php
@@ -94,7 +94,11 @@ class ZRANGE extends RedisCommand
             $result = [];
 
             for ($i = 0; $i < count($data); ++$i) {
-                $result[$data[$i]] = $data[++$i];
+                if (is_array($data[$i])) {
+                    $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+                } else {
+                    $result[$data[$i]] = $data[++$i];
+                }
             }
 
             return $result;

--- a/src/Command/Traits/With/WithScores.php
+++ b/src/Command/Traits/With/WithScores.php
@@ -53,7 +53,9 @@ trait WithScores
             $result = [];
 
             for ($i = 0, $iMax = count($data); $i < $iMax; ++$i) {
-                if ($data[$i + 1] ?? false) {
+                if (is_array($data[$i])) {
+                    $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
+                } elseif ($data[$i + 1] ?? false) {
                     $result[$data[$i]] = $data[++$i];
                 }
             }

--- a/src/Command/Traits/With/WithScores.php
+++ b/src/Command/Traits/With/WithScores.php
@@ -54,8 +54,8 @@ trait WithScores
 
             for ($i = 0, $iMax = count($data); $i < $iMax; ++$i) {
                 if (is_array($data[$i])) {
-                    $result[$data[$i][0]] = sprintf('%s', (int) $data[$i][1]);
-                } elseif ($data[$i + 1] ?? false) {
+                    $result[$data[$i][0]] = $data[$i][1]; // Relay
+                } elseif (array_key_exists($i + 1, $data)) {
                     $result[$data[$i]] = $data[++$i];
                 }
             }

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -109,15 +109,15 @@ class RelayConnection extends StreamConnection
      */
     protected function assertParameters(ParametersInterface $parameters)
     {
-        if (! in_array($parameters->scheme, ['tcp', 'tls', 'unix', 'redis', 'rediss'])) {
+        if (!in_array($parameters->scheme, ['tcp', 'tls', 'unix', 'redis', 'rediss'])) {
             throw new InvalidArgumentException("Invalid scheme: '{$parameters->scheme}'.");
         }
 
-        if (! in_array($parameters->serializer, [null, 'php', 'igbinary', 'msgpack', 'json'])) {
+        if (!in_array($parameters->serializer, [null, 'php', 'igbinary', 'msgpack', 'json'])) {
             throw new InvalidArgumentException("Invalid serializer: '{$parameters->serializer}'.");
         }
 
-        if (! in_array($parameters->compression, [null, 'lzf', 'lz4', 'zstd'])) {
+        if (!in_array($parameters->compression, [null, 'lzf', 'lz4', 'zstd'])) {
             throw new InvalidArgumentException("Invalid compression algorithm: '{$parameters->compression}'.");
         }
 

--- a/tests/PHPUnit/OneOfConstraint.php
+++ b/tests/PHPUnit/OneOfConstraint.php
@@ -33,6 +33,8 @@ class OneOfConstraint extends Constraint
     protected function matches($other): bool
     {
         if (is_array($other)) {
+            $other = is_array($other[0]) ? array_merge(...$other) : $other;
+
             return !empty(array_intersect($other, $this->array));
         }
 

--- a/tests/PHPUnit/OneOfConstraint.php
+++ b/tests/PHPUnit/OneOfConstraint.php
@@ -33,8 +33,6 @@ class OneOfConstraint extends Constraint
     protected function matches($other): bool
     {
         if (is_array($other)) {
-            $other = is_array($other[0]) ? array_merge(...$other) : $other;
-
             return !empty(array_intersect($other, $this->array));
         }
 

--- a/tests/Predis/Command/Redis/HGETALL_Test.php
+++ b/tests/Predis/Command/Redis/HGETALL_Test.php
@@ -63,7 +63,6 @@ class HGETALL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-todo
      * @requiresRedisVersion >= 2.0.0
      */
     public function testReturnsAllTheFieldsAndTheirValues(): void

--- a/tests/Predis/Command/Redis/LCS_Test.php
+++ b/tests/Predis/Command/Redis/LCS_Test.php
@@ -57,7 +57,6 @@ class LCS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-todo
      * @dataProvider stringsProvider
      * @param array $stringsArguments
      * @param array $functionArguments

--- a/tests/Predis/Command/Redis/ZPOPMAX_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMAX_Test.php
@@ -67,7 +67,6 @@ class ZPOPMAX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-todo
      * @requiresRedisVersion >= 5.0.0
      */
     public function testReturnsElements(): void
@@ -80,8 +79,8 @@ class ZPOPMAX_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
         $this->assertEquals(['f' => '30'], $redis->zpopmax('letters'));
-        $this->assertSame(['e' => '20', 'd' => '20', 'c' => '10'], $redis->zpopmax('letters', 3));
-        $this->assertSame(['b' => '0', 'a' => '-10'], $redis->zpopmax('letters', 3));
+        $this->assertEquals(['e' => '20', 'd' => '20', 'c' => '10'], $redis->zpopmax('letters', 3));
+        $this->assertEquals(['b' => '0', 'a' => '-10'], $redis->zpopmax('letters', 3));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZPOPMIN_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMIN_Test.php
@@ -67,7 +67,6 @@ class ZPOPMIN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-todo
      * @requiresRedisVersion >= 5.0.0
      */
     public function testReturnsElements(): void
@@ -80,8 +79,8 @@ class ZPOPMIN_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
         $this->assertEquals(['a' => '-10'], $redis->zpopmin('letters'));
-        $this->assertSame(['b' => '0', 'c' => '10', 'd' => '20'], $redis->zpopmin('letters', 3));
-        $this->assertSame(['e' => '20', 'f' => '30'], $redis->zpopmin('letters', 3));
+        $this->assertEquals(['b' => '0', 'c' => '10', 'd' => '20'], $redis->zpopmin('letters', 3));
+        $this->assertEquals(['e' => '20', 'f' => '30'], $redis->zpopmin('letters', 3));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZRANGE_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGE_Test.php
@@ -129,7 +129,6 @@ class ZRANGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-todo
      */
     public function testRangeWithWithscoresModifier(): void
     {
@@ -138,8 +137,8 @@ class ZRANGE_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
         $expected = ['c' => '10', 'd' => '20', 'e' => '20'];
 
-        $this->assertSame($expected, $redis->zrange('letters', 2, 4, 'withscores'));
-        $this->assertSame($expected, $redis->zrange('letters', 2, 4, ['withscores' => true]));
+        $this->assertEquals($expected, $redis->zrange('letters', 2, 4, 'withscores'));
+        $this->assertEquals($expected, $redis->zrange('letters', 2, 4, ['withscores' => true]));
     }
 
     /**


### PR DESCRIPTION
This is an attempt to fix a few bugs, currently the errors went down from 55 to 19 using Redis 7 and to 3 using Redis 6)

```
(Redis 7)
./vendor/bin/phpunit -c phpunit.relay.xml --group relay-todo

ERRORS!
Tests: 140, Assertions: 195, Errors: 19, Failures: 13.
```

```
(Redis 6)
./vendor/bin/phpunit -c phpunit.relay.xml --group relay-todo

Tests: 140, Assertions: 174, Errors: 3, Failures: 9, Skipped: 30.
```

@tillkruss most of what is left related to relay like `Wrong number of arguments for 'MOVE' command (argc: 2, arity: 2) (RELAY_ERR_OTHER; commands.c:7344)` so any feedback on how to deal with that would be great.

if you think the PR is ready, feel free to merge.
