### PR TITLE
Adding key processor prefix for the newly added FCALL command

### DIFF
--- a/src/Command/Processor/KeyPrefixProcessor.php
+++ b/src/Command/Processor/KeyPrefixProcessor.php
@@ -184,6 +184,8 @@ class KeyPrefixProcessor implements ProcessorInterface
             'XDEL' => $prefixFirst,
             'XLEN' => $prefixFirst,
             'XACK' => $prefixFirst,
+            /* ---------------- Redis 7.0 ---------------- */
+            'FCALL' => $prefixEvalKeys,
         ];
     }
 


### PR DESCRIPTION

Key prefix processor for functions [Redis 7.0] is missing. The new-brand function feature has been added to this package, but unfortunately, the prefix processor has not been implemented.

