### PR TITLE
Fix fclose() being called on invalid stream resource

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -244,7 +244,10 @@ class StreamConnection extends AbstractConnection
     public function disconnect()
     {
         if ($this->isConnected()) {
-            fclose($this->getResource());
+            $resource = $this->getResource();
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
             parent::disconnect();
         }
     }


### PR DESCRIPTION
fixes `fclose(): supplied resource is not a valid stream resource` which (as per my understanding) may occur since PHP 8.1 if the resource was already closed (or is otherwise invalid)