### PR TITLE
Feature/fcall prefix processor and tests

### DIFF
--- a/src/Command/Processor/KeyPrefixProcessor.php
+++ b/src/Command/Processor/KeyPrefixProcessor.php
@@ -39,6 +39,7 @@ class KeyPrefixProcessor implements ProcessorInterface
         $prefixSkipLast = static::class . '::skipLast';
         $prefixSort = static::class . '::sort';
         $prefixEvalKeys = static::class . '::evalKeys';
+        $prefixFCallKeys = static::class . '::fcallKeys';
         $prefixZsetStore = static::class . '::zsetStore';
         $prefixMigrate = static::class . '::migrate';
         $prefixGeoradius = static::class . '::georadius';
@@ -186,6 +187,8 @@ class KeyPrefixProcessor implements ProcessorInterface
             'XLEN' => $prefixFirst,
             'XACK' => $prefixFirst,
             'XTRIM' => $prefixFirst,
+            /* ---------------- Redis 7.0 ---------------- */
+            'FCALL' => $prefixFCallKeys,
         ];
     }
 
@@ -396,6 +399,23 @@ class KeyPrefixProcessor implements ProcessorInterface
      * @param string           $prefix  Prefix string.
      */
     public static function evalKeys(CommandInterface $command, $prefix)
+    {
+        if ($arguments = $command->getArguments()) {
+            for ($i = 2; $i < $arguments[1] + 2; ++$i) {
+                $arguments[$i] = "$prefix{$arguments[$i]}";
+            }
+
+            $command->setRawArguments($arguments);
+        }
+    }
+
+    /**
+     * Applies the specified prefix to the keys of an FCall-based command.
+     *
+     * @param CommandInterface $command Command instance.
+     * @param string           $prefix  Prefix string.
+     */
+    public static function fCallKeys(CommandInterface $command, $prefix)
     {
         if ($arguments = $command->getArguments()) {
             for ($i = 2; $i < $arguments[1] + 2; ++$i) {

--- a/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
+++ b/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
@@ -253,6 +253,32 @@ class KeyPrefixProcessorTest extends PredisTestCase
     /**
      * @group disconnected
      */
+    public function testPrefixFCall(): void
+    {
+        $arguments = [
+            'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', 2, 'foo', 'bar', 'hoge', 'piyo'
+        ];
+
+        $expected = [
+            'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', 2, 'prefix:foo', 'prefix:bar', 'hoge', 'piyo',
+        ];
+
+        $command = $this->getMockForAbstractClass('Predis\Command\Command');
+        $command->setRawArguments($arguments);
+
+        KeyPrefixProcessor::fCallKeys($command, 'prefix:');
+        $this->assertSame($expected, $command->getArguments());
+
+        // Empty arguments
+        $command = $this->getMockForAbstractClass('Predis\Command\Command');
+
+        KeyPrefixProcessor::fCallKeys($command, 'prefix:');
+        $this->assertEmpty($command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testPrefixMigrate(): void
     {
         $arguments = ['127.0.0.1', '6379', 'key', '0', '10', 'COPY', 'REPLACE'];

--- a/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
+++ b/tests/Predis/Command/Processor/KeyPrefixProcessorTest.php
@@ -256,7 +256,7 @@ class KeyPrefixProcessorTest extends PredisTestCase
     public function testPrefixFCall(): void
     {
         $arguments = [
-            'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', 2, 'foo', 'bar', 'hoge', 'piyo'
+            'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', 2, 'foo', 'bar', 'hoge', 'piyo',
         ];
 
         $expected = [


### PR DESCRIPTION
Since adding FCALL [functions] to Redis 7.0, the related key prefix processor method is missed in the package, it's been added, and related test also has been added for this functionality