### PR TITLE
[v2.x] Relay support 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@
 /CONTRIBUTING.md export-ignore linguist-documentation
 /FAQ.md export-ignore linguist-documentation
 /VERSION export-ignore
+/phpunit.relay.xml export-ignore
 /phpunit.xml.dist export-ignore
 /phpstan.dist.neon export-ignore
 /phpstan-tests.dist.neon export-ignore

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -60,7 +60,7 @@ jobs:
         run: composer install --ansi --no-progress --prefer-dist
 
       - name: Run tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit --group realm-stack
 
       - name: Run tests using Relay
-        run: vendor/bin/phpunit --verbose -c phpunit.relay.xml
+        run: vendor/bin/phpunit --group realm-stack -c phpunit.relay.xml

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -41,6 +41,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: relay
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -58,5 +59,8 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
         run: composer install --ansi --no-progress --prefer-dist
 
-      - name: Run PHPUnit tests
-        run: vendor/bin/phpunit
+      - name: Run tests
+        run: vendor/bin/phpunit --verbose
+
+      - name: Run tests using Relay
+        run: vendor/bin/phpunit --verbose -c phpunit.relay.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,15 +61,15 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.php != '8.1' || matrix.redis != '7' }}
-        run: vendor/bin/phpunit --verbose --exclude-group realm-stack
+        run: vendor/bin/phpunit
 
       - name: Run tests with coverage
         if: ${{ matrix.php == '8.1' && matrix.redis == '7' }}
-        run: vendor/bin/phpunit --verbose --exclude-group realm-stack --coverage-clover build/logs/clover.xml --coverage-filter ./src
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-filter ./src
 
       - name: Run tests using Relay
         if: ${{ matrix.redis >= '6' }}
-        run: vendor/bin/phpunit --verbose -c phpunit.relay.xml
+        run: vendor/bin/phpunit -c phpunit.relay.xml
 
       - name: Send coverage to Coveralls
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
 
   predis:
-    name: PHP ${{ matrix.php }} Redis ${{ matrix.redis }}
+    name: PHP ${{ matrix.php }} (Redis ${{ matrix.redis }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -50,6 +50,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: relay
           coverage: ${{ (matrix.php == '8.1' && matrix.redis == '7') && 'xdebug' || 'none' }}
 
       - name: Install Composer dependencies
@@ -58,13 +59,17 @@ jobs:
           dependency-versions: highest
           composer-options: ${{ matrix.php == '8.0' && '--ignore-platform-reqs' || '' }}
 
-      - name: Run PHPUnit tests
+      - name: Run tests
         if: ${{ matrix.php != '8.1' || matrix.redis != '7' }}
         run: vendor/bin/phpunit --verbose --exclude-group realm-stack
 
-      - name: Run PHPUnit tests with coverage
+      - name: Run tests with coverage
         if: ${{ matrix.php == '8.1' && matrix.redis == '7' }}
         run: vendor/bin/phpunit --verbose --exclude-group realm-stack --coverage-clover build/logs/clover.xml --coverage-filter ./src
+
+      - name: Run tests using Relay
+        if: ${{ matrix.redis >= '6' }}
+        run: vendor/bin/phpunit --verbose -c phpunit.relay.xml
 
       - name: Send coverage to Coveralls
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## Unreleased
 
 ### Added
-- Added support for `ACL SETUSER, GETUSER, DRYRUN` commands
+- Added support for [Relay](https://github.com/predis/predis/wiki/Using-Relay) (#1263)
 - Added support for `FCALL_RO` command
 - Added support for `Redis JSON` module
 - Added support for `Redis Bloom` module
 - Added support for `Redis Search` module
 - Added support for `Redis TimeSeries` module
+- Added support for `ACL SETUSER, GETUSER, DRYRUN` commands
 
 ### Fixed
 - Fixed prefixes for `XTRIM` and `XREVRANGE` commands

--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ $response = $client->lpushrand('random_values', $seed = mt_rand());
 
 ### Customizable connection backends ###
 
+Predis can use different connection backends to connect to Redis. The builtin Relay integration
+leverages the [Relay](https://github.com/cachewerk/relay) extension for PHP for major performance
+gains, by caching a partial replica of the Redis dataset in PHP shared runtime memory.
+
+```php
+$client = new Predis\Client('tcp://127.0.0.1', [
+    'connections' => 'relay',
+]);
+```
+
 Developers can create their own connection classes to support whole new network backends, extend
 existing classes or provide completely different implementations. Connection classes must implement
 `Predis\Connection\NodeConnectionInterface` or extend `Predis\Connection\AbstractConnection`:
@@ -438,23 +448,6 @@ be disabled. See [the tests README](tests/README.md) for more details about test
 
 Predis uses GitHub Actions for continuous integration and the history for past and current builds can be
 found [on its actions page](https://github.com/predis/predis/actions).
-
-
-## Other ##
-
-
-### Project related links ###
-
-- [Source code](https://github.com/predis/predis)
-- [Wiki](https://github.com/predis/predis/wiki)
-- [Issue tracker](https://github.com/predis/predis/issues)
-
-
-### Author ###
-
-- [Till Krüss](https://till.im) ([Twitter](http://twitter.com/tillkruss))
-- [Daniele Alessandri](mailto:suppakilla@gmail.com) ([twitter](http://twitter.com/JoL1hAHN))
-
 
 ### License ###
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^8.0 || ~9.4.4"
     },
+    "suggest": {
+        "ext-relay": "Faster connection with in-memory caching (>=0.6.2)"
+    },
     "scripts": {
         "phpstan": "phpstan analyse",
         "style": "php-cs-fixer fix --diff --dry-run",

--- a/examples/relay_compression.php
+++ b/examples/relay_compression.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__ . '/shared.php';
+
+// Enable igbinary serializer as well as LZ4 compression
+$options = [
+    'serializer' => 'igbinary',
+    'compression' => 'lz4',
+];
+
+$client = new Predis\Client($single_server + $options, [
+    'connections' => 'relay',
+]);
+
+$quote = (object) [
+    'author' => 'Jean-Luc Picard',
+    'text' => 'I look forward to your report Mr. Broccoli.',
+];
+
+// Serialize object and apply LZ4 compression, then write key to Redis
+$client->set('quote', $client->pack($quote));
+
+// NOTE: In Predis v3.x serialization and compression will happen
+// automatically without the need to call `pack()` and `unpack()`
+
+// Retrieve raw binary value from Redis
+$raw = $client->get('quote');
+
+// Decompress and unserialize binary value
+$data = $client->unpack($raw);
+
+var_dump($quote == $data); // true
+
+var_dump($data);
+
+/*
+object(stdClass)#11 (2) {
+  ["author"]=>
+  string(15) "Jean-Luc Picard"
+  ["text"]=>
+  string(43) "I look forward to your report Mr. Broccoli."
+}
+*/

--- a/examples/relay_compression.php
+++ b/examples/relay_compression.php
@@ -45,9 +45,7 @@ var_dump($data);
 
 /*
 object(stdClass)#11 (2) {
-  ["author"]=>
-  string(15) "Jean-Luc Picard"
-  ["text"]=>
-  string(43) "I look forward to your report Mr. Broccoli."
+    ["author"]=>string(15) "Jean-Luc Picard"
+    ["text"]=>string(43) "I look forward to your report Mr. Broccoli."
 }
 */

--- a/examples/relay_connection.php
+++ b/examples/relay_connection.php
@@ -18,8 +18,8 @@ $options = [
 
     // Relay specific options
     'cache' => true,
-    'compression' => 'lz4',
-    'serializer' => 'igbinary',
+    // 'compression' => 'lz4',
+    // 'serializer' => 'igbinary',
 ];
 
 $client = new Predis\Client($single_server + $options, [
@@ -27,14 +27,14 @@ $client = new Predis\Client($single_server + $options, [
 ]);
 
 // Write key to Redis
-$client->set('library', 'relay');
+$client->set('torpedo', mt_rand());
 
 // Retrieve key from Redis
-$client->get('library');
+$client->get('torpedo');
 
-// Retrieve key from Relay (without socket/network communication)
-// This key is no available to all PHP workers in this FPM pool
-$client->get('library');
+// Retrieve key from Relay (without talking to Redis)
+// This key is now available to all PHP workers in this FPM pool
+$client->get('torpedo');
 
 // For debugging only:
 var_export(
@@ -43,12 +43,12 @@ var_export(
 
 /*
 array (
-    'library' => array (
+    'torpedo' => array (
         0 => array (
             'type' => 'string',
-            'local-len' => 5,
-            'remote-len' => 5,
-            'size' => 5,
+            'local-len' => 10,
+            'remote-len' => 10,
+            'size' => 10,
         ),
     ),
 )

--- a/examples/relay_connection.php
+++ b/examples/relay_connection.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__ . '/shared.php';
+
+$options = [
+    'timeout' => 1.0,
+    'read_write_timeout' => 1.0,
+
+    // Relay specific options
+    'cache' => true,
+    'compression' => 'lz4',
+    'serializer' => 'igbinary',
+];
+
+$client = new Predis\Client($single_server + $options, [
+    'connections' => 'relay',
+]);
+
+// Write key to Redis
+$client->set('library', 'relay');
+
+// Retrieve key from Redis
+$client->get('library');
+
+// Retrieve key from Relay (without socket/network communication)
+// This key is no available to all PHP workers in this FPM pool
+$client->get('library');
+
+// For debugging only:
+var_export(
+    $client->getConnection()->getClient()->_getKeys()
+);
+
+/*
+array (
+    'library' => array (
+        0 => array (
+            'type' => 'string',
+            'local-len' => 5,
+            'remote-len' => 5,
+            'size' => 5,
+        ),
+    ),
+)
+*/

--- a/examples/relay_events.php
+++ b/examples/relay_events.php
@@ -52,9 +52,9 @@ while (true) {
     echo '$key is: ' . var_export($key, true) . PHP_EOL;
 
     // To trigger our event callbacks, we need to either interact with Relay:
-    $relay->get(mt_rand());
+    $client->get(mt_rand());
 
-    // ... or alternatively simply dispatch events:
+    // ... or alternatively dispatch events directly on Relay:
     $relay->dispatchEvents();
 
     sleep(1);

--- a/examples/relay_events.php
+++ b/examples/relay_events.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require __DIR__ . '/shared.php';
+
+$key = null;
+
+$client = new Predis\Client($single_server, [
+    'connections' => 'relay',
+]);
+
+$relay = $client->getConnection()->getClient();
+
+// establish connection
+$client->ping();
+
+// register FLUSH callback
+$relay->onFlushed(
+    static function (Relay\Event $event) use (&$key) {
+        echo 'Redis was flushed, unsetting $key...' . PHP_EOL;
+        $key = null;
+    }
+);
+
+// register INVALIDATE callback
+$relay->onInvalidated(
+    static function (Relay\Event $event) use (&$key) {
+        if ($event->key === 'library') {
+            echo "The `{$event->key}` key was invalidated, unsetting \$key..." . PHP_EOL;
+            $key = null;
+        }
+    }
+);
+
+// Write key to Redis
+$client->set('library', 'relay');
+
+// Retrieve key from Redis (cached in Relay and $key)
+$key = $client->get('library');
+
+while (true) {
+    // $relay->dispatchEvents();
+    echo '$key is: ' . var_export($key, true) . PHP_EOL;
+
+    sleep(1);
+}

--- a/examples/relay_events.php
+++ b/examples/relay_events.php
@@ -18,7 +18,8 @@ $client = new Predis\Client($single_server, [
     'connections' => 'relay',
 ]);
 
-$relay = $client->getConnection()->getClient();
+/** @var Predis\Connection\RelayConnection $relay */
+$relay = $client->getConnection();
 
 // establish connection
 $client->ping();

--- a/examples/relay_events.php
+++ b/examples/relay_events.php
@@ -23,7 +23,7 @@ $relay = $client->getConnection()->getClient();
 // establish connection
 $client->ping();
 
-// register FLUSH callback
+// register `FLUSH*` callback
 $relay->onFlushed(
     static function (Relay\Event $event) use (&$key) {
         echo 'Redis was flushed, unsetting $key...' . PHP_EOL;
@@ -31,7 +31,7 @@ $relay->onFlushed(
     }
 );
 
-// register INVALIDATE callback
+// register `INVALIDATE` callback
 $relay->onInvalidated(
     static function (Relay\Event $event) use (&$key) {
         if ($event->key === 'library') {
@@ -42,14 +42,19 @@ $relay->onInvalidated(
 );
 
 // Write key to Redis
-$client->set('library', 'relay');
+$client->set('library', mt_rand());
 
-// Retrieve key from Redis (cached in Relay and $key)
+// Retrieve key once from Redis, then cached in Relay and $key
 $key = $client->get('library');
 
 while (true) {
-    // $relay->dispatchEvents();
     echo '$key is: ' . var_export($key, true) . PHP_EOL;
+
+    // To trigger our event callbacks, we need to either interact with Relay:
+    $relay->get(mt_rand());
+
+    // ... or alternatively simply dispatch events:
+    $relay->dispatchEvents();
 
     sleep(1);
 }

--- a/examples/relay_pubsub_consumer.php
+++ b/examples/relay_pubsub_consumer.php
@@ -12,8 +12,11 @@
 
 require __DIR__ . '/shared.php';
 
-// Create a Relay client, unlike Predis r/w timeout does not need to be disabled
-$client = new Predis\Client($single_server, ['connections' => 'relay']);
+// Create a Relay client and disable r/w timeout on the connection
+$client = new Predis\Client(
+    $single_server + ['read_write_timeout' => 0],
+    ['connections' => 'relay']
+);
 
 // Initialize a new pubsub consumer.
 $pubsub = $client->pubSubLoop();

--- a/phpunit.relay.xml
+++ b/phpunit.relay.xml
@@ -13,26 +13,13 @@
 
     <testsuites>
         <testsuite name="Predis Test Suite">
-            <directory>tests/Predis/</directory>
+            <directory phpVersion="7.4">tests/Predis/</directory>
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-
     <groups>
         <exclude>
-            <group>ext-relay</group>
-            <!-- <group>connected</group> -->
-            <!-- <group>disconnected</group> -->
-            <!-- <group>commands</group> -->
-            <!-- <group>slow</group> -->
+            <group>relay-incompatible</group>
         </exclude>
     </groups>
 
@@ -46,6 +33,6 @@
         <const name="REDIS_SERVER_HOST" value="127.0.0.1" />
         <const name="REDIS_SERVER_PORT" value="6379" />
         <const name="REDIS_SERVER_DBNUM" value="0" />
-        <env name="USE_RELAY" value="false" />
+        <env name="USE_RELAY" value="true" />
     </php>
 </phpunit>

--- a/phpunit.relay.xml
+++ b/phpunit.relay.xml
@@ -20,6 +20,10 @@
     <groups>
         <exclude>
             <group>relay-incompatible</group>
+            <group>realm-webdis</group>
+            <group>realm-stack</group>
+            <group>ext-curl</group>
+            <group>ext-phpiredis</group>
         </exclude>
     </groups>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,10 +28,11 @@
 
     <groups>
         <exclude>
-            <group>ext-phpiredis</group>
-            <group>ext-curl</group>
             <group>realm-webdis</group>
+            <group>realm-stack</group>
             <group>ext-relay</group>
+            <group>ext-curl</group>
+            <group>ext-phpiredis</group>
             <!-- <group>connected</group> -->
             <!-- <group>disconnected</group> -->
             <!-- <group>commands</group> -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,9 @@
 
     <groups>
         <exclude>
+            <group>ext-phpiredis</group>
+            <group>ext-curl</group>
+            <group>realm-webdis</group>
             <group>ext-relay</group>
             <!-- <group>connected</group> -->
             <!-- <group>disconnected</group> -->

--- a/src/Client.php
+++ b/src/Client.php
@@ -269,6 +269,32 @@ class Client implements ClientInterface, IteratorAggregate
     }
 
     /**
+     * Applies the configured serializer and compression to given value.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function pack($value)
+    {
+        return $this->connection instanceof RelayConnection
+            ? $this->connection->pack($value)
+            : $value;
+    }
+
+    /**
+     * Deserializes and decompresses to given value.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function unpack($value)
+    {
+        return $this->connection instanceof RelayConnection
+            ? $this->connection->unpack($value)
+            : $value;
+    }
+
+    /**
      * Executes a command without filtering its arguments, parsing the response,
      * applying any prefix to keys or throwing exceptions on Redis errors even
      * regardless of client options.

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ use Predis\Pipeline\Pipeline;
 use Predis\Pipeline\RelayAtomic;
 use Predis\Pipeline\RelayPipeline;
 use Predis\PubSub\Consumer as PubSubConsumer;
+use Predis\PubSub\RelayConsumer as RelayPubSubConsumer;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ResponseInterface;
 use Predis\Response\ServerException;
@@ -532,7 +533,11 @@ class Client implements ClientInterface, IteratorAggregate
      */
     protected function createPubSub(array $options = null, $callable = null)
     {
-        $pubsub = new PubSubConsumer($this, $options);
+        if ($this->connection instanceof RelayConnection) {
+            $pubsub = new RelayPubSubConsumer($this, $options);
+        } else {
+            $pubsub = new PubSubConsumer($this, $options);
+        }
 
         if (!isset($callable)) {
             return $pubsub;

--- a/src/Client.php
+++ b/src/Client.php
@@ -271,7 +271,7 @@ class Client implements ClientInterface, IteratorAggregate
     /**
      * Applies the configured serializer and compression to given value.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return string
      */
     public function pack($value)
@@ -284,7 +284,7 @@ class Client implements ClientInterface, IteratorAggregate
     /**
      * Deserializes and decompresses to given value.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return string
      */
     public function unpack($value)

--- a/src/Command/Redis/ACL.php
+++ b/src/Command/Redis/ACL.php
@@ -26,4 +26,28 @@ class ACL extends RedisCommand
     {
         return 'ACL';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        if ($data === array_values($data)) {
+            return $data;
+        }
+
+        // flatten Relay (RESP3) maps
+        $return = [];
+
+        array_walk($data, function ($value, $key) use (&$return) {
+            $return[] = $key;
+            $return[] = $value;
+        });
+
+        return $return;
+    }
 }

--- a/src/Command/Redis/COMMAND.php
+++ b/src/Command/Redis/COMMAND.php
@@ -26,4 +26,15 @@ class COMMAND extends BaseCommand
     {
         return 'COMMAND';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        // Relay (RESP3) uses maps and it might be good
+        // to make the return value a breaking change
+
+        return $data;
+    }
 }

--- a/src/Command/Redis/CONFIG.php
+++ b/src/Command/Redis/CONFIG.php
@@ -36,6 +36,10 @@ class CONFIG extends RedisCommand
     public function parseResponse($data)
     {
         if (is_array($data)) {
+            if ($data !== array_values($data)) {
+                return $data; // Relay
+            }
+
             $result = [];
 
             for ($i = 0; $i < count($data); ++$i) {

--- a/src/Command/Redis/HGETALL.php
+++ b/src/Command/Redis/HGETALL.php
@@ -32,6 +32,10 @@ class HGETALL extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if ($data !== array_values($data)) {
+            return $data; // Relay
+        }
+
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {

--- a/src/Command/Redis/HRANDFIELD.php
+++ b/src/Command/Redis/HRANDFIELD.php
@@ -31,4 +31,23 @@ class HRANDFIELD extends RedisCommand
     {
         return 'HRANDFIELD';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        // flatten Relay (RESP3) maps
+        $return = [];
+
+        array_walk_recursive($data, function ($value) use (&$return) {
+            $return[] = $value;
+        });
+
+        return $return;
+    }
 }

--- a/src/Command/Redis/LCS.php
+++ b/src/Command/Redis/LCS.php
@@ -57,6 +57,10 @@ class LCS extends RedisCommand
     public function parseResponse($data)
     {
         if (is_array($data)) {
+            if ($data !== array_values($data)) {
+                return $data; // Relay
+            }
+
             return [$data[0] => $data[1], $data[2] => $data[3]];
         }
 

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -37,7 +37,11 @@ class TDIGESTBYRANK extends RedisCommand
 
         // convert Relay (RESP3) infinite constant to string
         return array_map(function ($value) {
-            return $value === INF ? 'inf' : $value;
+            switch ($value) {
+                case INF: return 'inf';
+                case -INF: return '-inf';
+                default: return $value;
+            }
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -37,12 +37,17 @@ class TDIGESTBYRANK extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
+            if (is_string($value) || ! is_float($value)) {
+                return $value;
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_float($value) && is_nan($value): return 'nan';
-                default: return $value;
+                case is_nan($value): return 'nan';
             }
+
+            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -41,13 +41,15 @@ class TDIGESTBYRANK extends RedisCommand
                 return $value;
             }
 
+            if (is_nan($value)) {
+                return 'nan';
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                default: return $value;
             }
-
-            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -38,9 +38,9 @@ class TDIGESTBYRANK extends RedisCommand
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
             switch ($value) {
-                case NAN: return 'nan';
                 case INF: return 'inf';
                 case -INF: return '-inf';
+                case is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -25,4 +25,19 @@ class TDIGESTBYRANK extends RedisCommand
     {
         return 'TDIGEST.BYRANK';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        // convert Relay (RESP3) infinite constant to string
+        return array_map(function ($value) {
+            return $value === INF ? 'inf' : $value;
+        }, $data);
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -37,7 +37,7 @@ class TDIGESTBYRANK extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
-            if (is_string($value) || ! is_float($value)) {
+            if (is_string($value) || !is_float($value)) {
                 return $value;
             }
 

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -40,7 +40,7 @@ class TDIGESTBYRANK extends RedisCommand
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                case is_float($value) && is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -35,9 +35,10 @@ class TDIGESTBYRANK extends RedisCommand
             return $data;
         }
 
-        // convert Relay (RESP3) infinite constant to string
+        // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
             switch ($value) {
+                case NAN: return 'nan';
                 case INF: return 'inf';
                 case -INF: return '-inf';
                 default: return $value;

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -41,13 +41,15 @@ class TDIGESTBYREVRANK extends RedisCommand
                 return $value;
             }
 
+            if (is_nan($value)) {
+                return 'nan';
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                default: return $value;
             }
-
-            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -25,4 +25,23 @@ class TDIGESTBYREVRANK extends RedisCommand
     {
         return 'TDIGEST.BYREVRANK';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        // convert Relay (RESP3) infinite constant to string
+        return array_map(function ($value) {
+            switch ($value) {
+                case INF: return 'inf';
+                case -INF: return '-inf';
+                default: return $value;
+            }
+        }, $data);
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -38,9 +38,9 @@ class TDIGESTBYREVRANK extends RedisCommand
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
             switch ($value) {
-                case NAN: return 'nan';
                 case INF: return 'inf';
                 case -INF: return '-inf';
+                case is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -40,7 +40,7 @@ class TDIGESTBYREVRANK extends RedisCommand
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                case is_float($value) && is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -37,12 +37,17 @@ class TDIGESTBYREVRANK extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
+            if (is_string($value) || ! is_float($value)) {
+                return $value;
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_float($value) && is_nan($value): return 'nan';
-                default: return $value;
+                case is_nan($value): return 'nan';
             }
+
+            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -35,9 +35,10 @@ class TDIGESTBYREVRANK extends RedisCommand
             return $data;
         }
 
-        // convert Relay (RESP3) infinite constant to string
+        // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
             switch ($value) {
+                case NAN: return 'nan';
                 case INF: return 'inf';
                 case -INF: return '-inf';
                 default: return $value;

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -37,7 +37,7 @@ class TDIGESTBYREVRANK extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
-            if (is_string($value) || ! is_float($value)) {
+            if (is_string($value) || !is_float($value)) {
                 return $value;
             }
 

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -43,13 +43,15 @@ class TDIGESTCDF extends RedisCommand
                 return $value;
             }
 
+            if (is_nan($value)) {
+                return 'nan';
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                default: return $value;
             }
-
-            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -42,7 +42,7 @@ class TDIGESTCDF extends RedisCommand
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                case is_float($value) && is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -27,4 +27,24 @@ class TDIGESTCDF extends RedisCommand
     {
         return 'TDIGEST.CDF';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        // convert Relay (RESP3) constants to strings
+        return array_map(function ($value) {
+            switch ($value) {
+                case NAN: return 'nan';
+                case INF: return 'inf';
+                case -INF: return '-inf';
+                default: return $value;
+            }
+        }, $data);
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -39,12 +39,17 @@ class TDIGESTCDF extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
+            if (is_string($value) || ! is_float($value)) {
+                return $value;
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_float($value) && is_nan($value): return 'nan';
-                default: return $value;
+                case is_nan($value): return 'nan';
             }
+
+            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -39,7 +39,7 @@ class TDIGESTCDF extends RedisCommand
 
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
-            if (is_string($value) || ! is_float($value)) {
+            if (is_string($value) || !is_float($value)) {
                 return $value;
             }
 

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -40,9 +40,9 @@ class TDIGESTCDF extends RedisCommand
         // convert Relay (RESP3) constants to strings
         return array_map(function ($value) {
             switch ($value) {
-                case NAN: return 'nan';
                 case INF: return 'inf';
                 case -INF: return '-inf';
+                case is_nan($value): return 'nan';
                 default: return $value;
             }
         }, $data);

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -25,4 +25,18 @@ class TDIGESTMAX extends RedisCommand
     {
         return 'TDIGEST.MAX';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        // convert Relay (RESP3) constants to strings
+        switch ($data) {
+            case NAN: return 'nan';
+            case INF: return 'inf';
+            case -INF: return '-inf';
+            default: return $data;
+        }
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -31,12 +31,17 @@ class TDIGESTMAX extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if (is_string($data) || ! is_float($data)) {
+            return $data;
+        }
+
         // convert Relay (RESP3) constants to strings
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_float($data) && is_nan($data): return 'nan';
-            default: return $data;
+            case is_nan($data): return 'nan';
         }
+
+        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -31,7 +31,7 @@ class TDIGESTMAX extends RedisCommand
      */
     public function parseResponse($data)
     {
-        if (is_string($data) || ! is_float($data)) {
+        if (is_string($data) || !is_float($data)) {
             return $data;
         }
 

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -36,12 +36,14 @@ class TDIGESTMAX extends RedisCommand
         }
 
         // convert Relay (RESP3) constants to strings
+        if (is_nan($data)) {
+            return 'nan';
+        }
+
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            default: return $data;
         }
-
-        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -35,7 +35,7 @@ class TDIGESTMAX extends RedisCommand
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            case is_float($data) && is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -33,9 +33,9 @@ class TDIGESTMAX extends RedisCommand
     {
         // convert Relay (RESP3) constants to strings
         switch ($data) {
-            case NAN: return 'nan';
             case INF: return 'inf';
             case -INF: return '-inf';
+            case is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -35,7 +35,7 @@ class TDIGESTMIN extends RedisCommand
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            case is_float($data) && is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -31,7 +31,7 @@ class TDIGESTMIN extends RedisCommand
      */
     public function parseResponse($data)
     {
-        if (is_string($data) || ! is_float($data)) {
+        if (is_string($data) || !is_float($data)) {
             return $data;
         }
 

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -36,12 +36,14 @@ class TDIGESTMIN extends RedisCommand
         }
 
         // convert Relay (RESP3) constants to strings
+        if (is_nan($data)) {
+            return 'nan';
+        }
+
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            default: return $data;
         }
-
-        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -33,9 +33,9 @@ class TDIGESTMIN extends RedisCommand
     {
         // convert Relay (RESP3) constants to strings
         switch ($data) {
-            case NAN: return 'nan';
             case INF: return 'inf';
             case -INF: return '-inf';
+            case is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -31,12 +31,17 @@ class TDIGESTMIN extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if (is_string($data) || ! is_float($data)) {
+            return $data;
+        }
+
         // convert Relay (RESP3) constants to strings
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_float($data) && is_nan($data): return 'nan';
-            default: return $data;
+            case is_nan($data): return 'nan';
         }
+
+        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -25,4 +25,18 @@ class TDIGESTMIN extends RedisCommand
     {
         return 'TDIGEST.MIN';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        // convert Relay (RESP3) constants to strings
+        switch ($data) {
+            case NAN: return 'nan';
+            case INF: return 'inf';
+            case -INF: return '-inf';
+            default: return $data;
+        }
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -31,12 +31,17 @@ class TDIGESTQUANTILE extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if (is_string($data) || ! is_float($data)) {
+            return $data;
+        }
+
         // convert Relay (RESP3) constants to strings
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_float($data) && is_nan($data): return 'nan';
-            default: return $data;
+            case is_nan($data): return 'nan';
         }
+
+        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -41,13 +41,15 @@ class TDIGESTQUANTILE extends RedisCommand
                 return $value;
             }
 
+            if (is_nan($value)) {
+                return 'nan';
+            }
+
             switch ($value) {
                 case INF: return 'inf';
                 case -INF: return '-inf';
-                case is_nan($value): return 'nan';
+                default: return $value;
             }
-
-            return $value;
         }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -35,7 +35,7 @@ class TDIGESTQUANTILE extends RedisCommand
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            case is_float($data) && is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -31,7 +31,7 @@ class TDIGESTQUANTILE extends RedisCommand
      */
     public function parseResponse($data)
     {
-        if (is_string($data) || ! is_float($data)) {
+        if (is_string($data) || !is_float($data)) {
             return $data;
         }
 

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -31,17 +31,23 @@ class TDIGESTQUANTILE extends RedisCommand
      */
     public function parseResponse($data)
     {
-        if (is_string($data) || !is_float($data)) {
+        if (!is_array($data)) {
             return $data;
         }
 
         // convert Relay (RESP3) constants to strings
-        switch ($data) {
-            case INF: return 'inf';
-            case -INF: return '-inf';
-            case is_nan($data): return 'nan';
-        }
+        return array_map(function ($value) {
+            if (is_string($value) || !is_float($value)) {
+                return $value;
+            }
 
-        return $data;
+            switch ($value) {
+                case INF: return 'inf';
+                case -INF: return '-inf';
+                case is_nan($value): return 'nan';
+            }
+
+            return $value;
+        }, $data);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -25,4 +25,18 @@ class TDIGESTQUANTILE extends RedisCommand
     {
         return 'TDIGEST.QUANTILE';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        // convert Relay (RESP3) constants to strings
+        switch ($data) {
+            case NAN: return 'nan';
+            case INF: return 'inf';
+            case -INF: return '-inf';
+            default: return $data;
+        }
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -33,9 +33,9 @@ class TDIGESTQUANTILE extends RedisCommand
     {
         // convert Relay (RESP3) constants to strings
         switch ($data) {
-            case NAN: return 'nan';
             case INF: return 'inf';
             case -INF: return '-inf';
+            case is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -32,7 +32,7 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
      */
     public function parseResponse($data)
     {
-        if (is_string($data) || ! is_float($data)) {
+        if (is_string($data) || !is_float($data)) {
             return $data;
         }
 

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -37,12 +37,14 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
         }
 
         // convert Relay (RESP3) constants to strings
+        if (is_nan($data)) {
+            return 'nan';
+        }
+
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            default: return $data;
         }
-
-        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -34,9 +34,9 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
     {
         // convert Relay (RESP3) constants to strings
         switch ($data) {
-            case NAN: return 'nan';
             case INF: return 'inf';
             case -INF: return '-inf';
+            case is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -26,4 +26,18 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
     {
         return 'TDIGEST.TRIMMED_MEAN';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        // convert Relay (RESP3) constants to strings
+        switch ($data) {
+            case NAN: return 'nan';
+            case INF: return 'inf';
+            case -INF: return '-inf';
+            default: return $data;
+        }
+    }
 }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -32,12 +32,17 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
      */
     public function parseResponse($data)
     {
+        if (is_string($data) || ! is_float($data)) {
+            return $data;
+        }
+
         // convert Relay (RESP3) constants to strings
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_float($data) && is_nan($data): return 'nan';
-            default: return $data;
+            case is_nan($data): return 'nan';
         }
+
+        return $data;
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -36,7 +36,7 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
         switch ($data) {
             case INF: return 'inf';
             case -INF: return '-inf';
-            case is_nan($data): return 'nan';
+            case is_float($data) && is_nan($data): return 'nan';
             default: return $data;
         }
     }

--- a/src/Command/Redis/TYPE.php
+++ b/src/Command/Redis/TYPE.php
@@ -26,4 +26,26 @@ class TYPE extends RedisCommand
     {
         return 'TYPE';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        if (is_string($data)) {
+            return $data;
+        }
+
+        // Relay types
+        switch ($data) {
+            case 0: return 'none';
+            case 1: return 'string';
+            case 2: return 'set';
+            case 3: return 'list';
+            case 4: return 'zset';
+            case 5: return 'hash';
+            case 6: return 'stream';
+            default: return $data;
+        }
+    }
 }

--- a/src/Command/Redis/ZPOPMAX.php
+++ b/src/Command/Redis/ZPOPMAX.php
@@ -35,7 +35,11 @@ class ZPOPMAX extends RedisCommand
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            $result[$data[$i]] = $data[++$i];
+            if (is_array($data[$i])) {
+                $result[$data[$i][0]] = $data[$i][1]; // Relay
+            } else {
+                $result[$data[$i]] = $data[++$i];
+            }
         }
 
         return $result;

--- a/src/Command/Redis/ZPOPMIN.php
+++ b/src/Command/Redis/ZPOPMIN.php
@@ -35,7 +35,11 @@ class ZPOPMIN extends RedisCommand
         $result = [];
 
         for ($i = 0; $i < count($data); ++$i) {
-            $result[$data[$i]] = $data[++$i];
+            if (is_array($data[$i])) {
+                $result[$data[$i][0]] = $data[$i][1]; // Relay
+            } else {
+                $result[$data[$i]] = $data[++$i];
+            }
         }
 
         return $result;

--- a/src/Command/Redis/ZRANGE.php
+++ b/src/Command/Redis/ZRANGE.php
@@ -94,7 +94,11 @@ class ZRANGE extends RedisCommand
             $result = [];
 
             for ($i = 0; $i < count($data); ++$i) {
-                $result[$data[$i]] = $data[++$i];
+                if (is_array($data[$i])) {
+                    $result[$data[$i][0]] = $data[$i][1]; // Relay
+                } else {
+                    $result[$data[$i]] = $data[++$i];
+                }
             }
 
             return $result;

--- a/src/Command/Traits/With/WithScores.php
+++ b/src/Command/Traits/With/WithScores.php
@@ -53,7 +53,9 @@ trait WithScores
             $result = [];
 
             for ($i = 0, $iMax = count($data); $i < $iMax; ++$i) {
-                if ($data[$i + 1] ?? false) {
+                if (is_array($data[$i])) {
+                    $result[$data[$i][0]] = $data[$i][1]; // Relay
+                } elseif (array_key_exists($i + 1, $data)) {
                     $result[$data[$i]] = $data[++$i];
                 }
             }

--- a/src/Configuration/Option/Connections.php
+++ b/src/Configuration/Option/Connections.php
@@ -19,6 +19,7 @@ use Predis\Connection\Factory;
 use Predis\Connection\FactoryInterface;
 use Predis\Connection\PhpiredisSocketConnection;
 use Predis\Connection\PhpiredisStreamConnection;
+use Predis\Connection\RelayConnection;
 
 /**
  * Configures a new connection factory instance.
@@ -89,6 +90,7 @@ class Connections implements OptionInterface
      * - "phpiredis-stream" maps tcp, redis, unix to PhpiredisStreamConnection
      * - "phpiredis-socket" maps tcp, redis, unix to PhpiredisSocketConnection
      * - "phpiredis" is an alias of "phpiredis-stream"
+     * - "relay" maps tcp, redis, unix, tls, rediss to RelayConnection
      *
      * @param OptionsInterface $options Client options
      * @param string           $value   Descriptive string identifying the desired configuration
@@ -114,6 +116,11 @@ class Connections implements OptionInterface
                 $factory->define('tcp', PhpiredisSocketConnection::class);
                 $factory->define('redis', PhpiredisSocketConnection::class);
                 $factory->define('unix', PhpiredisSocketConnection::class);
+
+            case 'relay':
+                $factory->define('tcp', RelayConnection::class);
+                $factory->define('redis', RelayConnection::class);
+                $factory->define('unix', RelayConnection::class);
                 break;
 
             case 'default':

--- a/src/Configuration/Option/Connections.php
+++ b/src/Configuration/Option/Connections.php
@@ -116,6 +116,7 @@ class Connections implements OptionInterface
                 $factory->define('tcp', PhpiredisSocketConnection::class);
                 $factory->define('redis', PhpiredisSocketConnection::class);
                 $factory->define('unix', PhpiredisSocketConnection::class);
+                break;
 
             case 'relay':
                 $factory->define('tcp', RelayConnection::class);

--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -26,11 +26,14 @@ namespace Predis\Connection;
  * @property string $alias              Alias for the connection.
  * @property float  $timeout            Timeout for the connect() operation.
  * @property float  $read_write_timeout Timeout for read() and write() operations.
- * @property bool   $async_connect      Performs the connect() operation asynchronously.
- * @property bool   $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
  * @property bool   $persistent         Leaves the connection open after a GC collection.
  * @property string $password           Password to access Redis (see the AUTH command).
  * @property string $database           Database index (see the SELECT command).
+ * @property bool   $async_connect      Performs the connect() operation asynchronously.
+ * @property bool   $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
+ * @property bool   $cache              (Relay only) Whether to use in-memory caching.
+ * @property string $serializer         (Relay only) Serializer used for data serialization.
+ * @property string $compression        (Relay only) Algorithm used for data compression.
  */
 interface ParametersInterface
 {

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -75,6 +75,9 @@ class RelayConnection extends StreamConnection
         'EXEC',
         'DISCARD',
 
+        'WATCH',
+        'UNWATCH',
+
         'SUBSCRIBE',
         'UNSUBSCRIBE',
         'PSUBSCRIBE',
@@ -258,14 +261,14 @@ class RelayConnection extends StreamConnection
                 ? $this->client->{$name}(...$command->getArguments())
                 : $this->client->rawCommand($name, ...$command->getArguments());
         } catch (RelayException $ex) {
-            throw $this->onCommandError($ex);
+            throw $this->onCommandError($ex, $command);
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onCommandError(RelayException $exception)
+    public function onCommandError(RelayException $exception, CommandInterface $command)
     {
         $code = $exception->getCode();
         $message = $exception->getMessage();

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -68,10 +68,19 @@ class RelayConnection extends StreamConnection
     public $atypicalCommands = [
         'AUTH',
         'SELECT',
+
         'TYPE',
+
         'MULTI',
         'EXEC',
         'DISCARD',
+
+        'SUBSCRIBE',
+        'UNSUBSCRIBE',
+        'PSUBSCRIBE',
+        'PUNSUBSCRIBE',
+        'SSUBSCRIBE',
+        'SUNSUBSCRIBE',
     ];
 
     /**

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -223,7 +223,7 @@ class RelayConnection extends StreamConnection
         try {
             $name = $command->getId();
 
-            // When using compression or a serializer, we need a dedicated
+            // When using compression or a serializer, we'll need a dedicated
             // handler for `Predis\Command\RawCommand` calls
             return in_array($name, $this->atypicalCommands)
                 ? $this->client->{$name}(...$command->getArguments())

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -1,0 +1,294 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Connection;
+
+use InvalidArgumentException;
+use Predis\ClientException;
+use Predis\Command\CommandInterface;
+use Predis\NotSupportedException;
+use Predis\Response\ServerException;
+use Relay\Exception as RelayException;
+use Relay\Relay;
+
+/**
+ * This class provides the implementation of a Predis connection that
+ * uses Relay for network communication and in-memory caching.
+ *
+ * Using Relay allows for:
+ * 1) significantly faster reads thanks to in-memory caching
+ * 2) fast data serialization using igbinary
+ * 3) fast data compression using lzf, lz4 or zstd
+ *
+ * Usage of igbinary serialization and zstd compresses reduces
+ * network traffic and Redis memory usage by ~75%.
+ *
+ * For instructions on how to install the Relay extension, please consult
+ * the repository of the project: https://relay.so/docs/installation
+ *
+ * The connection parameters supported by this class are:
+ *
+ *  - scheme: it can be either 'tcp', 'tls' or 'unix'.
+ *  - host: hostname or IP address of the server.
+ *  - port: TCP port of the server.
+ *  - path: path of a UNIX domain socket when scheme is 'unix'.
+ *  - timeout: timeout to perform the connection.
+ *  - read_write_timeout: timeout of read / write operations.
+ *  - cache: whether to use in-memory caching
+ *  - serializer: data serializer
+ *  - compression: data compression algorithm
+ *
+ * @see https://github.com/cachewerk/relay
+ */
+class RelayConnection extends StreamConnection
+{
+    /**
+     * The Relay instance.
+     *
+     * @var \Relay\Relay
+     */
+    private $client;
+
+    /**
+     * These commands must be called on the client, not using `Relay::rawCommand()`.
+     *
+     * @var string[]
+     */
+    public $atypicalCommands = [
+        'AUTH',
+        'SELECT',
+        'TYPE',
+        'MULTI',
+        'EXEC',
+        'DISCARD',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(ParametersInterface $parameters)
+    {
+        $this->assertExtensions();
+
+        $this->parameters = $this->assertParameters($parameters);
+        $this->client = $this->createClient();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isConnected()
+    {
+        return $this->client->isConnected();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disconnect()
+    {
+        if ($this->client->isConnected()) {
+            $this->client->close();
+        }
+    }
+
+    /**
+     * Checks if the Relay extension is loaded in PHP.
+     */
+    private function assertExtensions()
+    {
+        if (!extension_loaded('relay')) {
+            throw new NotSupportedException(
+                'The "relay" extension is required by this connection backend.'
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function assertParameters(ParametersInterface $parameters)
+    {
+        if (!in_array($parameters->scheme, ['tcp', 'tls', 'unix', 'redis', 'rediss'])) {
+            throw new InvalidArgumentException("Invalid scheme: '{$parameters->scheme}'.");
+        }
+
+        if (!in_array($parameters->serializer, [null, 'php', 'igbinary', 'msgpack', 'json'])) {
+            throw new InvalidArgumentException("Invalid serializer: '{$parameters->serializer}'.");
+        }
+
+        if (!in_array($parameters->compression, [null, 'lzf', 'lz4', 'zstd'])) {
+            throw new InvalidArgumentException("Invalid compression algorithm: '{$parameters->compression}'.");
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Creates a new instance of the client.
+     *
+     * @return \Relay\Relay
+     */
+    private function createClient()
+    {
+        $client = new Relay();
+
+        // throw when errors occur and return `null` for non-existent keys
+        $client->setOption(Relay::OPT_PHPREDIS_COMPATIBILITY, false);
+
+        // disable Relay reconnect feature
+        $client->setOption(Relay::OPT_MAX_RETRIES, 0);
+
+        // whether to use in-memory caching
+        $client->setOption(Relay::OPT_USE_CACHE, $this->parameters->cache ?? true);
+
+        $client->setOption(Relay::OPT_SERIALIZER, constant(sprintf(
+            '%s::SERIALIZER_%s',
+            Relay::class,
+            strtoupper($this->parameters->serializer ?? 'none')
+        )));
+
+        $client->setOption(Relay::OPT_COMPRESSION, constant(sprintf(
+            '%s::COMPRESSION_%s',
+            Relay::class,
+            strtoupper($this->parameters->compression ?? 'none')
+        )));
+
+        return $client;
+    }
+
+    /**
+     * Returns the underlying client.
+     *
+     * @return \Relay\Relay
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getIdentifier()
+    {
+        return $this->client->endpointId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createStreamSocket(ParametersInterface $parameters, $address, $flags)
+    {
+        $timeout = isset($parameters->timeout) ? (float) $parameters->timeout : 5.0;
+
+        $read_timeout = 5.0;
+
+        if (isset($parameters->read_write_timeout)) {
+            $read_timeout = (float) $parameters->read_write_timeout;
+            $read_timeout = $read_timeout > 0 ? $read_timeout : 0;
+        }
+
+        try {
+            $this->client->connect(
+                $parameters->path ?? $parameters->host,
+                isset($parameters->path) ? 0 : $parameters->port,
+                $timeout,
+                null,
+                $retry_interval = 0,
+                $read_timeout
+            );
+        } catch (RelayException $ex) {
+            $this->onConnectionError($ex->getMessage(), $ex->getCode());
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function executeCommand(CommandInterface $command)
+    {
+        if (!$this->client->isConnected()) {
+            $this->getResource();
+        }
+
+        try {
+            $name = $command->getId();
+
+            // When using compression or a serializer, we need a dedicated
+            // handler for `Predis\Command\RawCommand` calls
+            return in_array($name, $this->atypicalCommands)
+                ? $this->client->{$name}(...$command->getArguments())
+                : $this->client->rawCommand($name, ...$command->getArguments());
+        } catch (RelayException $ex) {
+            throw $this->onCommandError($ex);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onCommandError(RelayException $exception)
+    {
+        $code = $exception->getCode();
+        $message = $exception->getMessage();
+
+        if (strpos($message, 'RELAY_ERR_IO')) {
+            return new ConnectionException($this, $message, $code, $exception);
+        }
+
+        if (strpos($message, 'RELAY_ERR_REDIS')) {
+            return new ServerException($message, $code, $exception);
+        }
+
+        if (strpos($message, 'RELAY_ERR_WRONGTYPE') && strpos($message, "Got reply-type 'status'")) {
+            $message = 'Operation against a key holding the wrong kind of value';
+        }
+
+        return new ClientException($message, $code, $exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeRequest(CommandInterface $command)
+    {
+        throw new NotSupportedException('The "relay" extension does not support writing requests.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readResponse(CommandInterface $command)
+    {
+        throw new NotSupportedException('The "relay" extension does not support reading responses.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __destruct()
+    {
+        $this->disconnect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __wakeup()
+    {
+        $this->assertExtensions();
+        $this->client = $this->createClient();
+    }
+}

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -146,7 +146,7 @@ class RelayConnection extends StreamConnection
         $client->setOption(Relay::OPT_PHPREDIS_COMPATIBILITY, false);
 
         // disable Relay reconnect feature
-        $client->setOption(Relay::OPT_MAX_RETRIES, 0);
+        // $client->setOption(Relay::OPT_MAX_RETRIES, 0);
 
         // whether to use in-memory caching
         $client->setOption(Relay::OPT_USE_CACHE, $this->parameters->cache ?? true);

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -141,11 +141,8 @@ class RelayConnection extends StreamConnection
     private function createClient()
     {
         $client = new Relay();
-
-        // throw when errors occur and return `null` for non-existent keys
+        $client->setOption(Relay::OPT_REPLY_LITERAL, true);
         $client->setOption(Relay::OPT_PHPREDIS_COMPATIBILITY, false);
-
-        // disable Relay reconnect feature
         // $client->setOption(Relay::OPT_MAX_RETRIES, 0);
 
         // whether to use in-memory caching

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -283,7 +283,7 @@ class RelayConnection extends StreamConnection
     /**
      * Applies the configured serializer and compression to given value.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return string
      */
     public function pack($value)
@@ -294,7 +294,7 @@ class RelayConnection extends StreamConnection
     /**
      * Deserializes and decompresses to given value.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return string
      */
     public function unpack($value)

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -144,14 +144,6 @@ class RelayConnection extends StreamConnection
             throw new InvalidArgumentException("Invalid compression algorithm: '{$parameters->compression}'.");
         }
 
-        if (isset($parameters->serializer)) {
-            throw new NotSupportedException('The serializer parameter is currently unsupported.');
-        }
-
-        if (isset($parameters->compression)) {
-            throw new NotSupportedException('The compression parameter is currently unsupported.');
-        }
-
         return $parameters;
     }
 
@@ -286,6 +278,28 @@ class RelayConnection extends StreamConnection
         }
 
         return new ClientException($message, $code, $exception);
+    }
+
+    /**
+     * Applies the configured serializer and compression to given value.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function pack($value)
+    {
+        return $this->client->_pack($value);
+    }
+
+    /**
+     * Deserializes and decompresses to given value.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    public function unpack($value)
+    {
+        return $this->client->_unpack($value);
     }
 
     /**

--- a/src/Connection/RelayConnection.php
+++ b/src/Connection/RelayConnection.php
@@ -51,12 +51,14 @@ use Relay\Relay;
  */
 class RelayConnection extends StreamConnection
 {
+    use RelayMethods;
+
     /**
      * The Relay instance.
      *
      * @var \Relay\Relay
      */
-    private $client;
+    protected $client;
 
     /**
      * These commands must be called on the client, not using `Relay::rawCommand()`.

--- a/src/Connection/RelayMethods.php
+++ b/src/Connection/RelayMethods.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Connection;
+
+trait RelayMethods
+{
+    /**
+     * Registers a new `flushed` event listener.
+     *
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function onFlushed(?callable $callback)
+    {
+        return $this->client->onFlushed($callback);
+    }
+
+    /**
+     * Registers a new `invalidated` event listener.
+     *
+     * @param  callable  $callback
+     * @param  string  $pattern
+     * @return bool
+     */
+    public function onInvalidated(?callable $callback, ?string $pattern = null)
+    {
+        return $this->client->onInvalidated($callback, $pattern);
+    }
+
+    /**
+     * Dispatches all pending events.
+     *
+     * @return int|false
+     */
+    public function dispatchEvents()
+    {
+        return $this->client->dispatchEvents();
+    }
+
+    /**
+     * Adds ignore pattern(s). Matching keys will not be cached in memory.
+     *
+     * @param  string  $pattern,...
+     * @return int
+     */
+    public function addIgnorePatterns(string ...$pattern)
+    {
+        return $this->client->addIgnorePatterns(...$pattern);
+    }
+
+    /**
+     * Adds allow pattern(s). Only matching keys will be cached in memory.
+     *
+     * @param  string  $pattern,...
+     * @return int
+     */
+    public function addAllowPatterns(string ...$pattern)
+    {
+        return $this->client->addAllowPatterns(...$pattern);
+    }
+
+    /**
+     * Returns the connection's endpoint identifier.
+     *
+     * @return string|false
+     */
+    public function endpointId()
+    {
+        return $this->client->endpointId();
+    }
+
+    /**
+     * Returns a unique representation of the underlying socket connection identifier.
+     *
+     * @return string|false
+     */
+    public function socketId()
+    {
+        return $this->client->socketId();
+    }
+
+    /**
+     * Returns information about the license.
+     *
+     * @return array<string, mixed>
+     */
+    public function license()
+    {
+        return $this->client->license();
+    }
+
+    /**
+     * Returns statistics about Relay.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function stats()
+    {
+        return $this->client->stats();
+    }
+
+    /**
+     * Returns the number of bytes allocated, or `0` in client-only mode.
+     *
+     * @return int
+     */
+    public function maxMemory()
+    {
+        return $this->client->maxMemory();
+    }
+
+    /**
+     * Flushes Relay's in-memory cache of all databases.
+     * When given an endpoint, only that connection will be flushed.
+     * When given an endpoint and database index, only that database
+     * for that connection will be flushed.
+     *
+     * @param  ?string  $endpointId
+     * @param  ?int  $db
+     * @return bool
+     */
+    public function flushMemory(?string $endpointId = null, int $db = null)
+    {
+        return $this->client->flushMemory($endpointId, $db);
+    }
+}

--- a/src/Connection/RelayMethods.php
+++ b/src/Connection/RelayMethods.php
@@ -17,7 +17,7 @@ trait RelayMethods
     /**
      * Registers a new `flushed` event listener.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return bool
      */
     public function onFlushed(?callable $callback)
@@ -28,8 +28,8 @@ trait RelayMethods
     /**
      * Registers a new `invalidated` event listener.
      *
-     * @param  callable  $callback
-     * @param  string  $pattern
+     * @param  callable $callback
+     * @param  string   $pattern
      * @return bool
      */
     public function onInvalidated(?callable $callback, ?string $pattern = null)
@@ -50,7 +50,7 @@ trait RelayMethods
     /**
      * Adds ignore pattern(s). Matching keys will not be cached in memory.
      *
-     * @param  string  $pattern,...
+     * @param  string $pattern,...
      * @return int
      */
     public function addIgnorePatterns(string ...$pattern)
@@ -61,7 +61,7 @@ trait RelayMethods
     /**
      * Adds allow pattern(s). Only matching keys will be cached in memory.
      *
-     * @param  string  $pattern,...
+     * @param  string $pattern,...
      * @return int
      */
     public function addAllowPatterns(string ...$pattern)
@@ -125,8 +125,8 @@ trait RelayMethods
      * When given an endpoint and database index, only that database
      * for that connection will be flushed.
      *
-     * @param  ?string  $endpointId
-     * @param  ?int  $db
+     * @param  ?string $endpointId
+     * @param  ?int    $db
      * @return bool
      */
     public function flushMemory(?string $endpointId = null, int $db = null)

--- a/src/Pipeline/Pipeline.php
+++ b/src/Pipeline/Pipeline.php
@@ -33,7 +33,7 @@ use SplQueue;
  */
 class Pipeline implements ClientContextInterface
 {
-    private $client;
+    protected $client;
     private $pipeline;
 
     private $responses = [];

--- a/src/Pipeline/RelayAtomic.php
+++ b/src/Pipeline/RelayAtomic.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Pipeline;
+
+use Predis\Connection\ConnectionInterface;
+use Predis\Response\Error;
+use Predis\Response\ServerException;
+use Relay\Exception as RelayException;
+use SplQueue;
+
+class RelayAtomic extends Atomic
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function executePipeline(ConnectionInterface $connection, SplQueue $commands)
+    {
+        /** @var \Predis\Connection\RelayConnection $connection */
+        $client = $connection->getClient();
+
+        $throw = $this->client->getOptions()->exceptions;
+
+        try {
+            $transaction = $client->multi();
+
+            foreach ($commands as $command) {
+                $name = $command->getId();
+
+                in_array($name, $connection->atypicalCommands)
+                    ? $transaction->{$name}(...$command->getArguments())
+                    : $transaction->rawCommand($name, ...$command->getArguments());
+            }
+
+            $responses = $transaction->exec();
+
+            if (!is_array($responses)) {
+                return $responses;
+            }
+
+            foreach ($responses as $key => $response) {
+                if ($response instanceof RelayException) {
+                    if ($throw) {
+                        throw $response;
+                    }
+
+                    $responses[$key] = new Error($response->getMessage());
+                }
+            }
+
+            return $responses;
+        } catch (RelayException $ex) {
+            if ($client->getMode() !== $client::ATOMIC) {
+                $client->discard();
+            }
+
+            throw new ServerException($ex->getMessage(), $ex->getCode(), $ex);
+        }
+    }
+}

--- a/src/Pipeline/RelayPipeline.php
+++ b/src/Pipeline/RelayPipeline.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Pipeline;
+
+use Predis\Connection\ConnectionInterface;
+use Predis\Connection\RelayConnection;
+use Predis\Response\Error;
+use Predis\Response\ServerException;
+use Relay\Exception as RelayException;
+use SplQueue;
+
+class RelayPipeline extends Pipeline
+{
+    /**
+     * Implements the logic to flush the queued commands and read the responses
+     * from the current connection.
+     *
+     * @param  RelayConnection $connection Current connection instance.
+     * @param  SplQueue        $commands   Queued commands.
+     * @return array
+     */
+    protected function executePipeline(ConnectionInterface $connection, SplQueue $commands)
+    {
+        /** @var \Predis\Connection\RelayConnection $connection */
+        $client = $connection->getClient();
+
+        $throw = $this->client->getOptions()->exceptions;
+
+        try {
+            $pipeline = $client->pipeline();
+
+            foreach ($commands as $command) {
+                $name = $command->getId();
+
+                in_array($name, $connection->atypicalCommands)
+                    ? $pipeline->{$name}(...$command->getArguments())
+                    : $pipeline->rawCommand($name, ...$command->getArguments());
+            }
+
+            $responses = $pipeline->exec();
+
+            if (!is_array($responses)) {
+                return $responses;
+            }
+
+            foreach ($responses as $key => $response) {
+                if ($response instanceof RelayException) {
+                    if ($throw) {
+                        throw $response;
+                    }
+
+                    $responses[$key] = new Error($response->getMessage());
+                }
+            }
+
+            return $responses;
+        } catch (RelayException $ex) {
+            if ($client->getMode() !== $client::ATOMIC) {
+                $client->discard();
+            }
+
+            throw new ServerException($ex->getMessage(), $ex->getCode(), $ex);
+        }
+    }
+}

--- a/src/PubSub/AbstractConsumer.php
+++ b/src/PubSub/AbstractConsumer.php
@@ -32,8 +32,8 @@ abstract class AbstractConsumer implements Iterator
     public const STATUS_SUBSCRIBED = 2;  // 0b0010
     public const STATUS_PSUBSCRIBED = 4; // 0b0100
 
-    private $position = null;
-    private $statusFlags = self::STATUS_VALID;
+    protected $position = null;
+    protected $statusFlags = self::STATUS_VALID;
 
     /**
      * Automatically stops the consumer when the garbage collector kicks in.

--- a/src/PubSub/Consumer.php
+++ b/src/PubSub/Consumer.php
@@ -19,12 +19,12 @@ use Predis\Connection\Cluster\ClusterInterface;
 use Predis\NotSupportedException;
 
 /**
- * PUB/SUB consumer abstraction.
+ * PUB/SUB consumer.
  */
 class Consumer extends AbstractConsumer
 {
-    private $client;
-    private $options;
+    protected $client;
+    protected $options;
 
     /**
      * @param ClientInterface $client  Client instance used by the consumer.
@@ -59,7 +59,7 @@ class Consumer extends AbstractConsumer
      *
      * @throws NotSupportedException
      */
-    private function checkCapabilities(ClientInterface $client)
+    protected function checkCapabilities(ClientInterface $client)
     {
         if ($client->getConnection() instanceof ClusterInterface) {
             throw new NotSupportedException(
@@ -81,7 +81,7 @@ class Consumer extends AbstractConsumer
      *
      * @param string $subscribeAction Type of subscription.
      */
-    private function genericSubscribeInit($subscribeAction)
+    protected function genericSubscribeInit($subscribeAction)
     {
         if (isset($this->options[$subscribeAction])) {
             $this->$subscribeAction($this->options[$subscribeAction]);

--- a/src/PubSub/RelayConsumer.php
+++ b/src/PubSub/RelayConsumer.php
@@ -22,8 +22,8 @@ class RelayConsumer extends Consumer
     /**
      * Subscribes to the specified channels.
      *
-     * @param string ...$channel One or more channel names.
-     * @param callable $callback The message callback.
+     * @param string   ...$channel One or more channel names.
+     * @param callable $callback   The message callback.
      */
     public function subscribe($channel) // @phpstan-ignore-line
     {
@@ -40,7 +40,7 @@ class RelayConsumer extends Consumer
                     'channel' => $channel,
                     'payload' => $message,
                 ], $relay);
-            }
+            },
         ]);
 
         $this->client->getConnection()->executeCommand($command);
@@ -51,8 +51,8 @@ class RelayConsumer extends Consumer
     /**
      * Subscribes to the specified channels using a pattern.
      *
-     * @param string ...$pattern One or more channel name patterns.
-     * @param callable $callback The message callback.
+     * @param string   ...$pattern One or more channel name patterns.
+     * @param callable $callback   The message callback.
      */
     public function psubscribe(...$pattern) // @phpstan-ignore-line
     {
@@ -70,7 +70,7 @@ class RelayConsumer extends Consumer
                     'channel' => $channel,
                     'payload' => $message,
                 ], $relay);
-            }
+            },
         ]);
 
         $this->client->getConnection()->executeCommand($command);

--- a/src/PubSub/RelayConsumer.php
+++ b/src/PubSub/RelayConsumer.php
@@ -25,7 +25,7 @@ class RelayConsumer extends Consumer
      * @param string ...$channel One or more channel names.
      * @param callable $callback The message callback.
      */
-    public function subscribe($channel)
+    public function subscribe($channel) // @phpstan-ignore-line
     {
         $channels = func_get_args();
         $callback = array_pop($channels);
@@ -54,7 +54,7 @@ class RelayConsumer extends Consumer
      * @param string ...$pattern One or more channel name patterns.
      * @param callable $callback The message callback.
      */
-    public function psubscribe(...$pattern)
+    public function psubscribe(...$pattern) // @phpstan-ignore-line
     {
         $patterns = func_get_args();
         $callback = array_pop($patterns);

--- a/src/PubSub/RelayConsumer.php
+++ b/src/PubSub/RelayConsumer.php
@@ -36,10 +36,10 @@ class RelayConsumer extends Consumer
             $channels,
             function ($relay, $channel, $message) use ($callback) {
                 $callback((object) [
-                    'kind' => self::MESSAGE,
+                    'kind' => is_null($message) ? self::SUBSCRIBE : self::MESSAGE,
                     'channel' => $channel,
                     'payload' => $message,
-                ]);
+                ], $relay);
             }
         ]);
 
@@ -65,11 +65,11 @@ class RelayConsumer extends Consumer
             $patterns,
             function ($relay, $pattern, $channel, $message) use ($callback) {
                 $callback((object) [
-                    'kind' => self::PMESSAGE,
+                    'kind' => is_null($message) ? self::PSUBSCRIBE : self::PMESSAGE,
                     'pattern' => $pattern,
                     'channel' => $channel,
                     'payload' => $message,
-                ]);
+                ], $relay);
             }
         ]);
 

--- a/src/PubSub/RelayConsumer.php
+++ b/src/PubSub/RelayConsumer.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\PubSub;
+
+use Predis\NotSupportedException;
+
+/**
+ * Relay PUB/SUB consumer.
+ */
+class RelayConsumer extends Consumer
+{
+    /**
+     * Subscribes to the specified channels.
+     *
+     * @param string ...$channel One or more channel names.
+     * @param callable $callback The message callback.
+     */
+    public function subscribe($channel)
+    {
+        $channels = func_get_args();
+        $callback = array_pop($channels);
+
+        $this->statusFlags |= self::STATUS_SUBSCRIBED;
+
+        $command = $this->client->createCommand('subscribe', [
+            $channels,
+            function ($relay, $channel, $message) use ($callback) {
+                $callback((object) [
+                    'kind' => self::MESSAGE,
+                    'channel' => $channel,
+                    'payload' => $message,
+                ]);
+            }
+        ]);
+
+        $this->client->getConnection()->executeCommand($command);
+
+        $this->invalidate();
+    }
+
+    /**
+     * Subscribes to the specified channels using a pattern.
+     *
+     * @param string ...$pattern One or more channel name patterns.
+     * @param callable $callback The message callback.
+     */
+    public function psubscribe(...$pattern)
+    {
+        $patterns = func_get_args();
+        $callback = array_pop($patterns);
+
+        $this->statusFlags |= self::STATUS_PSUBSCRIBED;
+
+        $command = $this->client->createCommand('psubscribe', [
+            $patterns,
+            function ($relay, $pattern, $channel, $message) use ($callback) {
+                $callback((object) [
+                    'kind' => self::PMESSAGE,
+                    'pattern' => $pattern,
+                    'channel' => $channel,
+                    'payload' => $message,
+                ]);
+            }
+        ]);
+
+        $this->client->getConnection()->executeCommand($command);
+
+        $this->invalidate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function genericSubscribeInit($subscribeAction)
+    {
+        if (isset($this->options[$subscribeAction])) {
+            throw new NotSupportedException('Relay does not support Pub/Sub constructor options.');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function ping($payload = null)
+    {
+        throw new NotSupportedException('Relay does not support PING in Pub/Sub.');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function stop($drop = false)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __destruct()
+    {
+        // NOOP
+    }
+}

--- a/src/Transaction/MultiExec.php
+++ b/src/Transaction/MultiExec.php
@@ -184,15 +184,15 @@ class MultiExec implements ClientContextInterface
                 $this->client->createCommand($commandID, $arguments)
             );
         } catch (ServerException $exception) {
-            if (! $this->client->getConnection() instanceof RelayConnection) {
+            if (!$this->client->getConnection() instanceof RelayConnection) {
                 throw $exception;
             }
 
-            if (strcasecmp($commandID, 'EXEC') <> 0) {
+            if (strcasecmp($commandID, 'EXEC') != 0) {
                 throw $exception;
             }
 
-            if (! strpos($exception->getMessage(), 'RELAY_ERR_REDIS')) {
+            if (!strpos($exception->getMessage(), 'RELAY_ERR_REDIS')) {
                 throw $exception;
             }
 

--- a/src/Transaction/MultiExec.php
+++ b/src/Transaction/MultiExec.php
@@ -22,9 +22,12 @@ use Predis\CommunicationException;
 use Predis\Connection\Cluster\ClusterInterface;
 use Predis\NotSupportedException;
 use Predis\Protocol\ProtocolException;
+use Predis\Response\Error;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
 use Predis\Response\Status as StatusResponse;
+use Relay\Exception as RelayException;
+use Relay\Relay;
 use SplQueue;
 
 /**
@@ -207,6 +210,8 @@ class MultiExec implements ClientContextInterface
 
         if ($response instanceof StatusResponse && $response == 'QUEUED') {
             $this->commands->enqueue($command);
+        } elseif ($response instanceof Relay) {
+            $this->commands->enqueue($command);
         } elseif ($response instanceof ErrorResponseInterface) {
             throw new AbortedMultiExecException($this, $response->getMessage());
         } else {
@@ -375,7 +380,9 @@ class MultiExec implements ClientContextInterface
 
             $execResponse = $this->call('EXEC');
 
-            if ($execResponse === null) {
+            // The additional `false` check is needed for Relay,
+            // let's hope it won't break anything
+            if ($execResponse === null || $execResponse === false) {
                 if ($attempts === 0) {
                     throw new AbortedMultiExecException(
                         $this, 'The current transaction has been aborted by the server.'
@@ -401,8 +408,18 @@ class MultiExec implements ClientContextInterface
         for ($i = 0; $i < $size; ++$i) {
             $cmdResponse = $execResponse[$i];
 
-            if ($cmdResponse instanceof ErrorResponseInterface && $this->exceptions) {
+            if ($this->exceptions && $cmdResponse instanceof ErrorResponseInterface) {
                 throw new ServerException($cmdResponse->getMessage());
+            }
+
+            if ($cmdResponse instanceof RelayException) {
+                if ($this->exceptions) {
+                    throw new ServerException($cmdResponse->getMessage(), $cmdResponse->getCode(), $cmdResponse);
+                }
+
+                $commands->dequeue();
+                $response[$i] = new Error($cmdResponse->getMessage());
+                continue;
             }
 
             $response[$i] = $commands->dequeue()->parseResponse($cmdResponse);

--- a/tests/PHPUnit/PredisConnectionTestCase.php
+++ b/tests/PHPUnit/PredisConnectionTestCase.php
@@ -167,6 +167,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testDisconnectForcesDisconnection(): void
     {
@@ -193,6 +194,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testGetResourceForcesConnection(): void
     {
@@ -273,6 +275,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testWritesCommandToServer(): void
     {
@@ -294,6 +297,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsCommandFromServer(): void
     {
@@ -316,6 +320,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testIsAbleToWriteMultipleCommandsAndReadThemBackForPipelining(): void
     {
@@ -382,6 +387,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsStatusResponses(): void
     {
@@ -402,6 +408,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsBulkResponses(): void
     {
@@ -419,6 +426,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsIntegerResponses(): void
     {
@@ -433,6 +441,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsErrorResponsesAsResponseErrorObjects(): void
     {
@@ -450,6 +459,7 @@ abstract class PredisConnectionTestCase extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReadsMultibulkResponsesAsArrays(): void
     {

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -232,10 +232,9 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
         );
 
         $options = array_merge(
-            [
-                'commands' => $this->getCommandFactory(),
-            ],
-            $options ?: []
+            ['commands' => $this->getCommandFactory()],
+            $options ?: [],
+            getenv('USE_RELAY') ? ['connections' => 'relay'] : []
         );
 
         $client = new Client($parameters, $options);

--- a/tests/Predis/Command/Redis/BZMPOP_Test.php
+++ b/tests/Predis/Command/Redis/BZMPOP_Test.php
@@ -81,7 +81,7 @@ class BZMPOP_Test extends PredisCommandTestCase
         $redis->zadd($key, ...$sortedSetDictionary);
         $actualResponse = $redis->bzmpop($timeout, [$key], $modifier, $count);
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
         $this->assertSame($expectedModifiedSortedSet, $redis->zrange($key, 0, -1));
     }
 

--- a/tests/Predis/Command/Redis/BZPOPMAX_Test.php
+++ b/tests/Predis/Command/Redis/BZPOPMAX_Test.php
@@ -47,7 +47,7 @@ class BZPOPMAX_Test extends PredisCommandTestCase
 
         $redis->zadd('test-bzpopmax', ...$sortedSetDictionary);
 
-        $this->assertSame($expectedResponse, $redis->bzpopmax(['empty sorted set', 'test-bzpopmax'], 0));
+        $this->assertEquals($expectedResponse, $redis->bzpopmax(['empty sorted set', 'test-bzpopmax'], 0));
         $this->assertSame($expectedModifiedSortedSet, $redis->zrange('test-bzpopmax', 0, -1));
     }
 

--- a/tests/Predis/Command/Redis/BZPOPMIN_Test.php
+++ b/tests/Predis/Command/Redis/BZPOPMIN_Test.php
@@ -47,7 +47,7 @@ class BZPOPMIN_Test extends PredisCommandTestCase
 
         $redis->zadd('test-bzpopmin', ...$sortedSetDictionary);
 
-        $this->assertSame($expectedResponse, $redis->bzpopmin(['empty sorted set', 'test-bzpopmin'], 0));
+        $this->assertEquals($expectedResponse, $redis->bzpopmin(['empty sorted set', 'test-bzpopmin'], 0));
         $this->assertSame($expectedModifiedSortedSet, $redis->zrange('test-bzpopmin', 0, -1));
     }
 

--- a/tests/Predis/Command/Redis/CLIENT_Test.php
+++ b/tests/Predis/Command/Redis/CLIENT_Test.php
@@ -146,6 +146,7 @@ BUFFER;
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      * @requiresRedisVersion >= 2.6.9
      */
     public function testGetsNameOfConnection(): void

--- a/tests/Predis/Command/Redis/CLIENT_Test.php
+++ b/tests/Predis/Command/Redis/CLIENT_Test.php
@@ -146,7 +146,6 @@ BUFFER;
     /**
      * @group connected
      * @group relay-incompatible
-     * @group relay-fixme
      * @requiresRedisVersion >= 2.6.9
      */
     public function testGetsNameOfConnection(): void

--- a/tests/Predis/Command/Redis/CLIENT_Test.php
+++ b/tests/Predis/Command/Redis/CLIENT_Test.php
@@ -145,6 +145,7 @@ BUFFER;
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @requiresRedisVersion >= 2.6.9
      */
     public function testGetsNameOfConnection(): void

--- a/tests/Predis/Command/Redis/COMMAND_Test.php
+++ b/tests/Predis/Command/Redis/COMMAND_Test.php
@@ -97,6 +97,8 @@ class COMMAND_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
+     * @group relay-fixme
      * @requiresRedisVersion >= 2.8.13
      */
     public function testReturnsCommandInfoOnExistingCommand(): void

--- a/tests/Predis/Command/Redis/COMMAND_Test.php
+++ b/tests/Predis/Command/Redis/COMMAND_Test.php
@@ -100,6 +100,8 @@ class COMMAND_Test extends PredisCommandTestCase
      * @group relay-incompatible
      * @group relay-fixme
      * @requiresRedisVersion >= 2.8.13
+     *
+     * Relay uses RESP3 maps, the `Predis\Command\Redis\COMMAND` needs a converter.
      */
     public function testReturnsCommandInfoOnExistingCommand(): void
     {

--- a/tests/Predis/Command/Redis/DISCARD_Test.php
+++ b/tests/Predis/Command/Redis/DISCARD_Test.php
@@ -55,6 +55,7 @@ class DISCARD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @requiresRedisVersion >= 2.0.0
      */
     public function testAbortsTransactionAndRestoresNormalFlow(): void
@@ -70,12 +71,28 @@ class DISCARD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group ext-relay
+     */
+    public function testAbortsTransactionAndRestoresNormalFlowUsingRelay(): void
+    {
+        $redis = $this->getClient();
+        $relay = $redis->getConnection()->getClient();
+
+        $redis->multi();
+
+        $this->assertSame($relay, $redis->set('foo', 'bar'));
+        $this->assertTrue($redis->discard());
+        $this->assertSame(0, $redis->exists('foo'));
+    }
+
+    /**
+     * @group connected
      * @requiresRedisVersion >= 2.0.0
      */
     public function testThrowsExceptionWhenCallingOutsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR DISCARD without MULTI');
+        $this->expectExceptionMessage('DISCARD without MULTI');
 
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/EXEC_Test.php
+++ b/tests/Predis/Command/Redis/EXEC_Test.php
@@ -105,7 +105,7 @@ class EXEC_Test extends PredisCommandTestCase
     public function testThrowsExceptionWhenCallingOutsideTransaction(): void
     {
         $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR EXEC without MULTI');
+        $this->expectExceptionMessage('EXEC without MULTI');
 
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/EXPIREAT_Test.php
+++ b/tests/Predis/Command/Redis/EXPIREAT_Test.php
@@ -93,8 +93,8 @@ class EXPIREAT_Test extends PredisCommandTestCase
     /**
      * @medium
      * @group connected
-     * @dataProvider keysProvider
      * @group slow
+     * @dataProvider keysProvider
      * @param  array $firstKeyArguments
      * @param  array $secondKeyArguments
      * @param  array $positivePathArguments

--- a/tests/Predis/Command/Redis/EXPIRE_Test.php
+++ b/tests/Predis/Command/Redis/EXPIRE_Test.php
@@ -90,8 +90,8 @@ class EXPIRE_Test extends PredisCommandTestCase
     /**
      * @medium
      * @group connected
-     * @dataProvider keysProvider
      * @group slow
+     * @dataProvider keysProvider
      * @param  array $firstKeyArguments
      * @param  array $secondKeyArguments
      * @param  array $positivePathArguments

--- a/tests/Predis/Command/Redis/FCALL_Test.php
+++ b/tests/Predis/Command/Redis/FCALL_Test.php
@@ -17,6 +17,7 @@ use Predis\Response\ServerException;
 /**
  * @group commands
  * @group realm-scripting
+ * @requiresRedisVersion >= 7.0.0
  */
 class FCALL_Test extends PredisCommandTestCase
 {
@@ -71,6 +72,7 @@ class FCALL_Test extends PredisCommandTestCase
         $expectedResponse
     ): void {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $this->assertSame('mylib', $redis->function->load($function));
 
@@ -87,6 +89,7 @@ class FCALL_Test extends PredisCommandTestCase
     public function testThrowsExceptionOnNonExistingFunctionGiven(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $this->expectException(ServerException::class);
         $this->expectExceptionMessage('ERR Function not found');

--- a/tests/Predis/Command/Redis/FUNCTIONS_Test.php
+++ b/tests/Predis/Command/Redis/FUNCTIONS_Test.php
@@ -17,6 +17,7 @@ use Predis\Response\ServerException;
 /**
  * @group commands
  * @group realm-scripting
+ * @requiresRedisVersion >= 7.0.0
  */
 class FUNCTIONS_Test extends PredisCommandTestCase
 {
@@ -85,6 +86,7 @@ class FUNCTIONS_Test extends PredisCommandTestCase
     public function testLoadFunctionAddFunctionIntoGivenLibrary(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $actualResponse = $redis->function->load(
             "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
@@ -103,6 +105,7 @@ class FUNCTIONS_Test extends PredisCommandTestCase
     public function testLoadFunctionOverridesExistingFunctionWithReplaceArgumentGiven(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $actualResponse = $redis->function->load(
             "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
@@ -129,6 +132,7 @@ class FUNCTIONS_Test extends PredisCommandTestCase
     public function testLoadFunctionThrowsErrorOnAlreadyExistingLibraryGiven(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $actualResponse = $redis->function->load(
             "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
@@ -156,6 +160,7 @@ class FUNCTIONS_Test extends PredisCommandTestCase
     public function testDeleteFunctionRemovesAlreadyExistingLibrary(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $actualResponse = $redis->function->load(
             "#!lua name={$this->libName} \n redis.register_function('myfunc', function(keys, args) return args[1] end)"
@@ -173,6 +178,7 @@ class FUNCTIONS_Test extends PredisCommandTestCase
     public function testDeleteFunctionThrowsErrorOnNonExistingLibrary(): void
     {
         $redis = $this->getClient();
+        $redis->executeRaw(['FUNCTION', 'FLUSH']);
 
         $this->expectException(ServerException::class);
         $this->expectExceptionMessage('ERR Library not found');

--- a/tests/Predis/Command/Redis/GEOADD_Test.php
+++ b/tests/Predis/Command/Redis/GEOADD_Test.php
@@ -88,7 +88,7 @@ class GEOADD_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->geoadd('Sicily', '13.361389', '38.115556', 'Palermo');
-        $this->assertSame(['Palermo' => '3479099956230698'], $redis->zrange('Sicily', 0, -1, 'WITHSCORES'));
+        $this->assertEquals(['Palermo' => '3479099956230698'], $redis->zrange('Sicily', 0, -1, 'WITHSCORES'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/GETBIT_Test.php
+++ b/tests/Predis/Command/Redis/GETBIT_Test.php
@@ -80,8 +80,7 @@ class GETBIT_Test extends PredisCommandTestCase
      */
     public function testThrowsExceptionOnNegativeOffset(): void
     {
-        $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
+        $this->expectExceptionMessage('bit offset is not an integer or out of range');
 
         $redis = $this->getClient();
 
@@ -95,8 +94,7 @@ class GETBIT_Test extends PredisCommandTestCase
      */
     public function testThrowsExceptionOnInvalidOffset(): void
     {
-        $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR bit offset is not an integer or out of range');
+        $this->expectExceptionMessage('bit offset is not an integer or out of range');
 
         $redis = $this->getClient();
 

--- a/tests/Predis/Command/Redis/HMGET_Test.php
+++ b/tests/Predis/Command/Redis/HMGET_Test.php
@@ -86,7 +86,31 @@ class HMGET_Test extends PredisCommandTestCase
         $redis->hmset('metavars', 'foo', 'bar', 'hoge', 'piyo', 'lol', 'wut');
 
         $this->assertSame(['bar', 'piyo', null], $redis->hmget('metavars', 'foo', 'hoge', 'unknown'));
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 2.0.0
+     */
+    public function testReturnsDuplicateValues(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->hmset('metavars', 'foo', 'bar', 'hoge', 'piyo', 'lol', 'wut');
+
         $this->assertSame(['bar', 'bar'], $redis->hmget('metavars', 'foo', 'foo'));
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 2.0.0
+     */
+    public function testReturnsNullValues(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->hmset('metavars', 'foo', 'bar', 'hoge', 'piyo', 'lol', 'wut');
+
         $this->assertSame([null, null], $redis->hmget('metavars', 'unknown', 'unknown'));
         $this->assertSame([null, null], $redis->hmget('unknown', 'foo', 'hoge'));
     }

--- a/tests/Predis/Command/Redis/MIGRATE_Test.php
+++ b/tests/Predis/Command/Redis/MIGRATE_Test.php
@@ -88,6 +88,7 @@ class MIGRATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @requiresRedisVersion >= 2.6.0
      */
     public function testReturnsStatusNOKEYOnNonExistingKey(): void

--- a/tests/Predis/Command/Redis/MIGRATE_Test.php
+++ b/tests/Predis/Command/Redis/MIGRATE_Test.php
@@ -89,7 +89,6 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
-     * @group relay-fixme
      * @requiresRedisVersion >= 2.6.0
      */
     public function testReturnsStatusNOKEYOnNonExistingKey(): void
@@ -98,6 +97,18 @@ class MIGRATE_Test extends PredisCommandTestCase
 
         $this->assertEquals('NOKEY', $response = $redis->migrate('169.254.10.10', 16379, 'foo', 15, 1));
         $this->assertInstanceOf('Predis\Response\Status', $response);
+    }
+
+    /**
+     * @group connected
+     * @group ext-relay
+     * @requiresRedisVersion >= 2.6.0
+     */
+    public function testReturnsStatusNOKEYOnNonExistingKeyUsingRelay(): void
+    {
+        $redis = $this->getClient();
+
+        $this->assertEquals('NOKEY', $redis->migrate('169.254.10.10', 16379, 'foo', 15, 1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/MIGRATE_Test.php
+++ b/tests/Predis/Command/Redis/MIGRATE_Test.php
@@ -89,6 +89,7 @@ class MIGRATE_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      * @requiresRedisVersion >= 2.6.0
      */
     public function testReturnsStatusNOKEYOnNonExistingKey(): void

--- a/tests/Predis/Command/Redis/MONITOR_Test.php
+++ b/tests/Predis/Command/Redis/MONITOR_Test.php
@@ -56,6 +56,7 @@ class MONITOR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReturnsStatusResponseAndReadsEventsFromTheConnection(): void
     {

--- a/tests/Predis/Command/Redis/MOVE_Test.php
+++ b/tests/Predis/Command/Redis/MOVE_Test.php
@@ -61,7 +61,6 @@ class MOVE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     *
      * @todo Should be improved, this test fails when REDIS_SERVER_DBNUM is 0.
      */
     public function testMovesKeysToDifferentDatabases(): void

--- a/tests/Predis/Command/Redis/MULTI_Test.php
+++ b/tests/Predis/Command/Redis/MULTI_Test.php
@@ -55,6 +55,7 @@ class MULTI_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testInitializesNewTransaction(): void
     {
@@ -67,6 +68,23 @@ class MULTI_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group ext-relay
+     */
+    public function testInitializesNewTransactionUsingRelay(): void
+    {
+        $redis = $this->getClient();
+        $relay = $redis->getConnection()->getClient();
+
+        $this->assertSame($relay, $redis->multi());
+        $this->assertSame($relay, $redis->echo('tx1'));
+        $this->assertSame($relay, $redis->echo('tx2'));
+
+        $relay->discard();
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
      */
     public function testActuallyReturnsResponseObjectAbstraction(): void
     {
@@ -79,6 +97,7 @@ class MULTI_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testThrowsExceptionWhenCallingMultiInsideTransaction(): void
     {

--- a/tests/Predis/Command/Redis/MULTI_Test.php
+++ b/tests/Predis/Command/Redis/MULTI_Test.php
@@ -85,6 +85,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      */
     public function testActuallyReturnsResponseObjectAbstraction(): void
     {
@@ -98,6 +99,7 @@ class MULTI_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      */
     public function testThrowsExceptionWhenCallingMultiInsideTransaction(): void
     {

--- a/tests/Predis/Command/Redis/PING_Test.php
+++ b/tests/Predis/Command/Redis/PING_Test.php
@@ -58,6 +58,7 @@ class PING_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testAlwaysReturnsStatusResponse(): void
     {
@@ -66,5 +67,21 @@ class PING_Test extends PredisCommandTestCase
 
         $this->assertInstanceOf('Predis\Response\Status', $response);
         $this->assertEquals('PONG', $response);
+    }
+
+    /**
+     * @group connected
+     * @group ext-relay
+     */
+    public function testAlwaysReturnsResponseUsingRelay(): void
+    {
+        $redis = $this->getClient();
+
+        $response = $redis->ping();
+        $this->assertTrue($response);
+        $this->assertEquals('PONG', $response);
+
+        $response = $redis->ping('PONG');
+        $this->assertSame('PONG', $response);
     }
 }

--- a/tests/Predis/Command/Redis/PING_Test.php
+++ b/tests/Predis/Command/Redis/PING_Test.php
@@ -78,10 +78,9 @@ class PING_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $response = $redis->ping();
-        $this->assertTrue($response);
         $this->assertEquals('PONG', $response);
 
-        $response = $redis->ping('PONG');
-        $this->assertSame('PONG', $response);
+        $response = $redis->ping('HELLO');
+        $this->assertSame('HELLO', $response);
     }
 }

--- a/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
+ *
+ * Waiting for `PSUBSCRIBE` support in Relay.
  */
 class PSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-pubsub
+ * @group relay-incompatible
  */
 class PSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PSUBSCRIBE_Test.php
@@ -16,8 +16,6 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
- *
- * Waiting for `PSUBSCRIBE` support in Relay.
  */
 class PSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/PUBLISH_Test.php
+++ b/tests/Predis/Command/Redis/PUBLISH_Test.php
@@ -59,9 +59,8 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      * @requiresRedisVersion >= 2.0.0
-     *
-     * Waiting for `PUBLISH` support in Relay.
      */
     public function testPublishesMessagesToChannel(): void
     {

--- a/tests/Predis/Command/Redis/PUBLISH_Test.php
+++ b/tests/Predis/Command/Redis/PUBLISH_Test.php
@@ -58,6 +58,7 @@ class PUBLISH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @requiresRedisVersion >= 2.0.0
      */
     public function testPublishesMessagesToChannel(): void

--- a/tests/Predis/Command/Redis/PUBLISH_Test.php
+++ b/tests/Predis/Command/Redis/PUBLISH_Test.php
@@ -60,6 +60,8 @@ class PUBLISH_Test extends PredisCommandTestCase
      * @group connected
      * @group relay-incompatible
      * @requiresRedisVersion >= 2.0.0
+     *
+     * Waiting for `PUBLISH` support in Relay.
      */
     public function testPublishesMessagesToChannel(): void
     {

--- a/tests/Predis/Command/Redis/PUBLISH_Test.php
+++ b/tests/Predis/Command/Redis/PUBLISH_Test.php
@@ -59,7 +59,6 @@ class PUBLISH_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
-     * @group relay-fixme
      * @requiresRedisVersion >= 2.0.0
      */
     public function testPublishesMessagesToChannel(): void

--- a/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
+ *
+ * Waiting for `PUNSUBSCRIBE` support in Relay.
  */
 class PUNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
@@ -16,8 +16,6 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
- *
- * Waiting for `PUNSUBSCRIBE` support in Relay.
  */
 class PUNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/PUNSUBSCRIBE_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-pubsub
+ * @group relay-incompatible
  */
 class PUNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/QUIT_Test.php
+++ b/tests/Predis/Command/Redis/QUIT_Test.php
@@ -59,6 +59,7 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
+     * @group relay-fixme
      */
     public function testReturnsStatusResponseWhenClosingConnection(): void
     {

--- a/tests/Predis/Command/Redis/QUIT_Test.php
+++ b/tests/Predis/Command/Redis/QUIT_Test.php
@@ -58,6 +58,7 @@ class QUIT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testReturnsStatusResponseWhenClosingConnection(): void
     {

--- a/tests/Predis/Command/Redis/QUIT_Test.php
+++ b/tests/Predis/Command/Redis/QUIT_Test.php
@@ -59,7 +59,6 @@ class QUIT_Test extends PredisCommandTestCase
     /**
      * @group connected
      * @group relay-incompatible
-     * @group relay-fixme
      */
     public function testReturnsStatusResponseWhenClosingConnection(): void
     {

--- a/tests/Predis/Command/Redis/SELECT_Test.php
+++ b/tests/Predis/Command/Redis/SELECT_Test.php
@@ -84,6 +84,7 @@ class SELECT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testThrowsExceptionOnUnexpectedDatabaseName(): void
     {

--- a/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
+ *
+ * Waiting for `SUBSCRIBE` support in Relay.
  */
 class SUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-pubsub
+ * @group relay-incompatible
  */
 class SUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/SUBSCRIBE_Test.php
@@ -16,8 +16,6 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
- *
- * Waiting for `SUBSCRIBE` support in Relay.
  */
 class SUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
@@ -20,6 +20,10 @@ use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class FTAGGREGATE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
@@ -21,6 +21,10 @@ use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class FTCURSOR_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class FTEXPLAIN_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/Search/FTINFO_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTINFO_Test.php
@@ -63,8 +63,11 @@ class FTINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
+     *
+     * Prior to Redis 7.2 `-nan` is messing with Relay/hiredis.
      */
     public function testInfoReturnsInformationAboutGivenIndex(): void
     {

--- a/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
@@ -83,7 +83,7 @@ class FTSPELLCHECK_Test extends PredisCommandTestCase
             (new SpellcheckArguments())->distance(2)->terms('dict')
         );
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
@@ -78,7 +78,7 @@ class FTSUGGET_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->ftsugget(...$getArguments);
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\Search\SugAddArguments;
 use Predis\Command\Argument\Search\SugGetArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class FTSUGGET_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/Search/FTSUGLEN_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGLEN_Test.php
@@ -14,6 +14,10 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class FTSUGLEN_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
@@ -76,8 +76,8 @@ class TDIGESTBYRANK_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5, 6);
 
-        $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertSame(['nan', 'nan'], $redis->tdigestbyrank('empty_key', 0, 1));
+        $this->assertEquals($expectedResponse, $actualResponse);
+        $this->assertEquals(['nan', 'nan'], $redis->tdigestbyrank('empty_key', 0, 1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
@@ -76,8 +76,8 @@ class TDIGESTBYREVRANK_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestbyrevrank('key', 0, 1, 2, 3, 4, 5, 6);
 
-        $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertSame(['nan', 'nan'], $redis->tdigestbyrevrank('empty_key', 0, 1));
+        $this->assertEquals($expectedResponse, $actualResponse);
+        $this->assertEquals(['nan', 'nan'], $redis->tdigestbyrevrank('empty_key', 0, 1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
@@ -76,8 +76,8 @@ class TDIGESTCDF_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestcdf('key', 0, 1, 2, 3, 4);
 
-        $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertSame(['nan', 'nan'], $redis->tdigestcdf('empty_key', 0, 1));
+        $this->assertEquals($expectedResponse, $actualResponse);
+        $this->assertEquals(['nan', 'nan'], $redis->tdigestcdf('empty_key', 0, 1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
@@ -75,8 +75,8 @@ class TDIGESTMAX_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestmax('key');
 
-        $this->assertSame('5', $actualResponse);
-        $this->assertSame('nan', $redis->tdigestmax('empty_key'));
+        $this->assertEquals('5', $actualResponse);
+        $this->assertEquals('nan', $redis->tdigestmax('empty_key'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -148,7 +148,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame(100, $info['Compression']);
-        $this->assertSame(
+        $this->assertEquals(
             ['1', '2', '3', '4', 'inf'],
             $redis->tdigestbyrank('destination-key', 0, 1, 2, 3, 4)
         );

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -84,7 +84,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame($expectedCompression, $info['Compression']);
-        $this->assertSame(
+        $this->assertEquals(
             $expectedMergedSketchValues,
             $redis->tdigestbyrank('destination-key', 0, 1, 2, 3, 4)
         );
@@ -110,7 +110,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame(1000, $info['Compression']);
-        $this->assertSame(
+        $this->assertEquals(
             ['1', '2', '3', '4', 'inf'],
             $redis->tdigestbyrank('destination-key', 0, 1, 2, 3, 4)
         );
@@ -133,7 +133,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
         $redis->tdigestadd('source-key2', 3, 4);
         $redis->tdigestadd('destination-key', 5, 6, 7, 8);
 
-        $this->assertSame(
+        $this->assertEquals(
             ['5', '6', '7', '8', 'inf'],
             $redis->tdigestbyrank('destination-key', 0, 1, 2, 3, 4)
         );
@@ -176,7 +176,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame(100, $info['Compression']);
-        $this->assertSame(
+        $this->assertEquals(
             ['1', '2', '3', '4', '5', '6', '7', '8', 'inf'],
             $redis->tdigestbyrank('destination-key', 0, 1, 2, 3, 4, 5, 6, 7, 8)
         );

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
@@ -75,8 +75,8 @@ class TDIGESTMIN_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestmin('key');
 
-        $this->assertSame('1', $actualResponse);
-        $this->assertSame('nan', $redis->tdigestmin('empty_key'));
+        $this->assertEquals('1', $actualResponse);
+        $this->assertEquals('nan', $redis->tdigestmin('empty_key'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
@@ -74,10 +74,10 @@ class TDIGESTQUANTILE_Test extends PredisCommandTestCase
         $quantileResponse = $redis->tdigestquantile('key', 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0);
 
         $this->assertEquals('OK', $addResponse);
-        $this->assertSame(['1', '2', '3', '3', '4', '4', '4', '5', '5', '5', '5'], $quantileResponse);
+        $this->assertEquals(['1', '2', '3', '3', '4', '4', '4', '5', '5', '5', '5'], $quantileResponse);
 
         $redis->tdigestcreate('empty_key');
-        $this->assertSame(['nan', 'nan'], $redis->tdigestquantile('empty_key', 0.0, 0.1));
+        $this->assertEquals(['nan', 'nan'], $redis->tdigestquantile('empty_key', 0.0, 0.1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
@@ -71,7 +71,7 @@ class TDIGESTRESET_Test extends PredisCommandTestCase
         $redis->tdigestcreate('key', 500);
         $redis->tdigestadd('key', 1, 2, 2, 3, 3, 3);
 
-        $this->assertSame(
+        $this->assertEquals(
             ['1', '2', '2', '3', '3', '3'],
             $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5)
         );

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
@@ -81,7 +81,7 @@ class TDIGESTRESET_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame(500, $info['Compression']);
-        $this->assertSame(
+        $this->assertEquals(
             ['nan', 'nan', 'nan', 'nan', 'nan', 'nan'],
             $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5)
         );

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
@@ -82,7 +82,7 @@ class TDIGESTTRIMMED_MEAN_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigesttrimmed_mean(...$trimmedMeanArguments);
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 
     /**
@@ -97,7 +97,7 @@ class TDIGESTTRIMMED_MEAN_Test extends PredisCommandTestCase
         $redis->tdigestcreate('key');
 
         $actualResponse = $redis->tdigesttrimmed_mean('key', 0, 1);
-        $this->assertSame('nan', $actualResponse);
+        $this->assertEquals('nan', $actualResponse);
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSADD_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
@@ -18,6 +18,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSALTER_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSCREATERULE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSCREATE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
@@ -19,6 +19,10 @@ use Predis\Command\Argument\TimeSeries\DecrByArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSDECRBY_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSDELETERULE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSDEL_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
@@ -18,6 +18,10 @@ use Predis\Command\Argument\TimeSeries\GetArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSGET_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
@@ -19,6 +19,10 @@ use Predis\Command\Argument\TimeSeries\IncrByArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSINCRBY_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\InfoArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSINFO_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSMADD_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSMGET_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMGET_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\MGetArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSMGET_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\MRangeArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSMRANGE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\MRangeArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSMREVRANGE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSQUERYINDEX_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSQUERYINDEX_Test.php
@@ -16,6 +16,10 @@ use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSQUERYINDEX_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\RangeArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSRANGE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
@@ -17,6 +17,10 @@ use Predis\Command\Argument\TimeSeries\RangeArguments;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
+/**
+ * @group commands
+ * @group realm-stack
+ */
 class TSREVRANGE_Test extends PredisCommandTestCase
 {
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
@@ -73,7 +73,7 @@ class TOPKINFO_Test extends PredisCommandTestCase
 
         $redis->topkreserve('key', 50);
 
-        $this->assertSame(
+        $this->assertEquals(
             ['k' => 50, 'width' => 8, 'depth' => 7, 'decay' => '0.90000000000000002'],
             $redis->topkinfo('key')
         );

--- a/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
@@ -77,7 +77,7 @@ class TOPKRESERVE_Test extends PredisCommandTestCase
         $actualInfoResponse = $redis->topkinfo($key);
 
         $this->assertEquals('OK', $actualResponse);
-        $this->assertSame($expectedInfoResponse, $actualInfoResponse);
+        $this->assertEquals($expectedInfoResponse, $actualInfoResponse);
     }
 
     /**

--- a/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
@@ -16,8 +16,6 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
- *
- * Waiting for `UNSUBSCRIBE` support in Relay.
  */
 class UNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-pubsub
  * @group relay-incompatible
+ *
+ * Waiting for `UNSUBSCRIBE` support in Relay.
  */
 class UNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
+++ b/tests/Predis/Command/Redis/UNSUBSCRIBE_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-pubsub
+ * @group relay-incompatible
  */
 class UNSUBSCRIBE_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -88,8 +88,6 @@ class UNWATCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-broken
      * @requiresRedisVersion >= 2.2.0
      */
     public function testCanBeCalledInsideTransactionUsingRelay(): void

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-transaction
+ * @group relay-incompatible
  */
 class UNWATCH_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -95,6 +95,6 @@ class UNWATCH_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $redis->multi();
-        $this->assertInstanceOf('Relay\\Relay', $redis->unwatch());
+        $this->assertInstanceOf('Relay\Relay', $redis->unwatch());
     }
 }

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -88,6 +88,8 @@ class UNWATCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
+     * @group relay-broken
      * @requiresRedisVersion >= 2.2.0
      */
     public function testCanBeCalledInsideTransactionUsingRelay(): void

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -88,6 +88,7 @@ class UNWATCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group ext-relay
      * @requiresRedisVersion >= 2.2.0
      */
     public function testCanBeCalledInsideTransactionUsingRelay(): void

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-transaction
  * @group relay-incompatible
+ *
+ * Waiting for `UNWATCH` support in Relay.
  */
 class UNWATCH_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/UNWATCH_Test.php
+++ b/tests/Predis/Command/Redis/UNWATCH_Test.php
@@ -15,9 +15,6 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-transaction
- * @group relay-incompatible
- *
- * Waiting for `UNWATCH` support in Relay.
  */
 class UNWATCH_Test extends PredisCommandTestCase
 {
@@ -78,6 +75,7 @@ class UNWATCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      * @requiresRedisVersion >= 2.2.0
      */
     public function testCanBeCalledInsideTransaction(): void
@@ -86,5 +84,17 @@ class UNWATCH_Test extends PredisCommandTestCase
 
         $redis->multi();
         $this->assertInstanceOf('Predis\Response\Status', $redis->unwatch());
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 2.2.0
+     */
+    public function testCanBeCalledInsideTransactionUsingRelay(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->multi();
+        $this->assertInstanceOf('Relay\\Relay', $redis->unwatch());
     }
 }

--- a/tests/Predis/Command/Redis/WATCH_Test.php
+++ b/tests/Predis/Command/Redis/WATCH_Test.php
@@ -15,9 +15,6 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-transaction
- * @group relay-incompatible
- *
- * Waiting for `UNWATCH` support in Relay.
  */
 class WATCH_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/WATCH_Test.php
+++ b/tests/Predis/Command/Redis/WATCH_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis;
 /**
  * @group commands
  * @group realm-transaction
+ * @group relay-incompatible
  */
 class WATCH_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/WATCH_Test.php
+++ b/tests/Predis/Command/Redis/WATCH_Test.php
@@ -16,6 +16,8 @@ namespace Predis\Command\Redis;
  * @group commands
  * @group realm-transaction
  * @group relay-incompatible
+ *
+ * Waiting for `UNWATCH` support in Relay.
  */
 class WATCH_Test extends PredisCommandTestCase
 {

--- a/tests/Predis/Command/Redis/ZADD_Test.php
+++ b/tests/Predis/Command/Redis/ZADD_Test.php
@@ -154,10 +154,10 @@ class ZADD_Test extends PredisCommandTestCase
     {
         $redis = $this->getClient();
 
-        $this->assertSame('1', $redis->zadd('letters', 'INCR', 1, 'a'));
-        $this->assertSame('0', $redis->zadd('letters', 'INCR', -1, 'a'));
-        $this->assertSame('0.5', $redis->zadd('letters', 'INCR', 0.5, 'a'));
-        $this->assertSame('-10', $redis->zadd('letters', 'INCR', -10.5, 'a'));
+        $this->assertEquals('1', $redis->zadd('letters', 'INCR', 1, 'a'));
+        $this->assertEquals('0', $redis->zadd('letters', 'INCR', -1, 'a'));
+        $this->assertEquals('0.5', $redis->zadd('letters', 'INCR', 0.5, 'a'));
+        $this->assertEquals('-10', $redis->zadd('letters', 'INCR', -10.5, 'a'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/ZINCRBY_Test.php
@@ -63,10 +63,10 @@ class ZINCRBY_Test extends PredisCommandTestCase
     {
         $redis = $this->getClient();
 
-        $this->assertSame('1', $redis->zincrby('letters', 1, 'member'));
-        $this->assertSame('0', $redis->zincrby('letters', -1, 'member'));
-        $this->assertSame('0.5', $redis->zincrby('letters', 0.5, 'member'));
-        $this->assertSame('-10', $redis->zincrby('letters', -10.5, 'member'));
+        $this->assertEquals('1', $redis->zincrby('letters', 1, 'member'));
+        $this->assertEquals('0', $redis->zincrby('letters', -1, 'member'));
+        $this->assertEquals('0.5', $redis->zincrby('letters', 0.5, 'member'));
+        $this->assertEquals('-10', $redis->zincrby('letters', -10.5, 'member'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZINTERSTORE_Test.php
@@ -92,7 +92,7 @@ class ZINTERSTORE_Test extends PredisCommandTestCase
         );
 
         $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertSame(
+        $this->assertEquals(
             $expectedResultSortedSet,
             $redis->zrange($destination, 0, -1, ['withscores' => true])
         );

--- a/tests/Predis/Command/Redis/ZINTER_Test.php
+++ b/tests/Predis/Command/Redis/ZINTER_Test.php
@@ -107,7 +107,7 @@ class ZINTER_Test extends PredisCommandTestCase
             $withScores
         );
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZMPOP_Test.php
+++ b/tests/Predis/Command/Redis/ZMPOP_Test.php
@@ -79,7 +79,7 @@ class ZMPOP_Test extends PredisCommandTestCase
         $redis->zadd($key, ...$sortedSetDictionary);
         $actualResponse = $redis->zmpop([$key], $modifier, $count);
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
         $this->assertSame($expectedModifiedSortedSet, $redis->zrange($key, 0, -1));
     }
 

--- a/tests/Predis/Command/Redis/ZMSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZMSCORE_Test.php
@@ -78,7 +78,7 @@ class ZMSCORE_Test extends PredisCommandTestCase
 
         $redis->zadd($key, ...$membersDictionary);
 
-        $this->assertSame($expectedResponse, $redis->zmscore($key, ...$members));
+        $this->assertEquals($expectedResponse, $redis->zmscore($key, ...$members));
         $this->assertNull($redis->zmscore($key, $notExpectedMember)[0]);
     }
 

--- a/tests/Predis/Command/Redis/ZPOPMAX_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMAX_Test.php
@@ -66,9 +66,8 @@ class ZPOPMAX_Test extends PredisCommandTestCase
     }
 
     /**
-     * @requiresRedisVersion >= 5.0.0
-     *
      * @group connected
+     * @requiresRedisVersion >= 5.0.0
      */
     public function testReturnsElements(): void
     {
@@ -79,9 +78,9 @@ class ZPOPMAX_Test extends PredisCommandTestCase
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
-        $this->assertSame(['f' => '30'], $redis->zpopmax('letters'));
-        $this->assertSame(['e' => '20', 'd' => '20', 'c' => '10'], $redis->zpopmax('letters', 3));
-        $this->assertSame(['b' => '0', 'a' => '-10'], $redis->zpopmax('letters', 3));
+        $this->assertEquals(['f' => '30'], $redis->zpopmax('letters'));
+        $this->assertEquals(['e' => '20', 'd' => '20', 'c' => '10'], $redis->zpopmax('letters', 3));
+        $this->assertEquals(['b' => '0', 'a' => '-10'], $redis->zpopmax('letters', 3));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZPOPMIN_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMIN_Test.php
@@ -66,9 +66,8 @@ class ZPOPMIN_Test extends PredisCommandTestCase
     }
 
     /**
-     * @requiresRedisVersion >= 5.0.0
-     *
      * @group connected
+     * @requiresRedisVersion >= 5.0.0
      */
     public function testReturnsElements(): void
     {
@@ -79,9 +78,9 @@ class ZPOPMIN_Test extends PredisCommandTestCase
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
-        $this->assertSame(['a' => '-10'], $redis->zpopmin('letters'));
-        $this->assertSame(['b' => '0', 'c' => '10', 'd' => '20'], $redis->zpopmin('letters', 3));
-        $this->assertSame(['e' => '20', 'f' => '30'], $redis->zpopmin('letters', 3));
+        $this->assertEquals(['a' => '-10'], $redis->zpopmin('letters'));
+        $this->assertEquals(['b' => '0', 'c' => '10', 'd' => '20'], $redis->zpopmin('letters', 3));
+        $this->assertEquals(['e' => '20', 'f' => '30'], $redis->zpopmin('letters', 3));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZRANGEBYSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGEBYSCORE_Test.php
@@ -180,8 +180,8 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
         $expected = ['c' => '10', 'd' => '20', 'e' => '20'];
 
-        $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, 'withscores'));
-        $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, ['withscores' => true]));
+        $this->assertEquals($expected, $redis->zrangebyscore('letters', 10, 20, 'withscores'));
+        $this->assertEquals($expected, $redis->zrangebyscore('letters', 10, 20, ['withscores' => true]));
     }
 
     /**
@@ -210,7 +210,7 @@ class ZRANGEBYSCORE_Test extends PredisCommandTestCase
         $options = ['limit' => [1, 2], 'withscores' => true];
         $expected = ['d' => '20', 'e' => '20'];
 
-        $this->assertSame($expected, $redis->zrangebyscore('letters', 10, 20, $options));
+        $this->assertEquals($expected, $redis->zrangebyscore('letters', 10, 20, $options));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZRANGE_Test.php
+++ b/tests/Predis/Command/Redis/ZRANGE_Test.php
@@ -137,8 +137,8 @@ class ZRANGE_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
         $expected = ['c' => '10', 'd' => '20', 'e' => '20'];
 
-        $this->assertSame($expected, $redis->zrange('letters', 2, 4, 'withscores'));
-        $this->assertSame($expected, $redis->zrange('letters', 2, 4, ['withscores' => true]));
+        $this->assertEquals($expected, $redis->zrange('letters', 2, 4, 'withscores'));
+        $this->assertEquals($expected, $redis->zrange('letters', 2, 4, ['withscores' => true]));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZREVRANGEBYSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANGEBYSCORE_Test.php
@@ -184,8 +184,8 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
         $expected = ['e' => '20', 'd' => '20', 'c' => '10'];
 
-        $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, 'withscores'));
-        $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, ['withscores' => true]));
+        $this->assertEquals($expected, $redis->zrevrangebyscore('letters', 20, 10, 'withscores'));
+        $this->assertEquals($expected, $redis->zrevrangebyscore('letters', 20, 10, ['withscores' => true]));
     }
 
     /**
@@ -216,7 +216,7 @@ class ZREVRANGEBYSCORE_Test extends PredisCommandTestCase
         $options = ['limit' => [1, 2], 'withscores' => true];
         $expected = ['d' => '20', 'c' => '10'];
 
-        $this->assertSame($expected, $redis->zrevrangebyscore('letters', 20, 10, $options));
+        $this->assertEquals($expected, $redis->zrevrangebyscore('letters', 20, 10, $options));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/ZREVRANGE_Test.php
@@ -137,8 +137,8 @@ class ZREVRANGE_Test extends PredisCommandTestCase
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
         $expected = ['d' => '20', 'c' => '10', 'b' => '0'];
 
-        $this->assertSame($expected, $redis->zrevrange('letters', 2, 4, 'withscores'));
-        $this->assertSame($expected, $redis->zrevrange('letters', 2, 4, ['withscores' => true]));
+        $this->assertEquals($expected, $redis->zrevrange('letters', 2, 4, 'withscores'));
+        $this->assertEquals($expected, $redis->zrevrange('letters', 2, 4, ['withscores' => true]));
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZSCORE_Test.php
+++ b/tests/Predis/Command/Redis/ZSCORE_Test.php
@@ -65,9 +65,9 @@ class ZSCORE_Test extends PredisCommandTestCase
 
         $redis->zadd('letters', -10, 'a', 0, 'b', 10, 'c', 20, 'd', 20, 'e', 30, 'f');
 
-        $this->assertSame('-10', $redis->zscore('letters', 'a'));
-        $this->assertSame('0', $redis->zscore('letters', 'b'));
-        $this->assertSame('20', $redis->zscore('letters', 'e'));
+        $this->assertEquals('-10', $redis->zscore('letters', 'a'));
+        $this->assertEquals('0', $redis->zscore('letters', 'b'));
+        $this->assertEquals('20', $redis->zscore('letters', 'e'));
 
         $this->assertNull($redis->zscore('unknown', 'a'));
     }

--- a/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
+++ b/tests/Predis/Command/Redis/ZUNIONSTORE_Test.php
@@ -92,7 +92,7 @@ class ZUNIONSTORE_Test extends PredisCommandTestCase
         );
 
         $this->assertSame($expectedResponse, $actualResponse);
-        $this->assertSame(
+        $this->assertEquals(
             $expectedResultSortedSet,
             $redis->zrange($destination, 0, -1, ['withscores' => true])
         );

--- a/tests/Predis/Command/Redis/ZUNION_Test.php
+++ b/tests/Predis/Command/Redis/ZUNION_Test.php
@@ -81,7 +81,7 @@ class ZUNION_Test extends PredisCommandTestCase
             $withScores
         );
 
-        $this->assertSame($expectedResponse, $actualResponse);
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 
     /**

--- a/tests/Predis/Configuration/Option/ConnectionsTest.php
+++ b/tests/Predis/Configuration/Option/ConnectionsTest.php
@@ -66,7 +66,7 @@ class ConnectionsTest extends PredisTestCase
      * @group disconnected
      * @dataProvider provideSupportedStringValuesForOption
      */
-    public function testAcceptsStringToConfigurePhpiredisStreamBackend($value, $classFQCN)
+    public function testAcceptsStringToConfigureRelayBackend($value, $classFQCN)
     {
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
@@ -232,6 +232,7 @@ class ConnectionsTest extends PredisTestCase
             ['phpiredis-stream', 'Predis\Connection\PhpiredisStreamConnection'],
             ['phpiredis-socket', 'Predis\Connection\PhpiredisSocketConnection'],
             ['phpiredis', 'Predis\Connection\PhpiredisStreamConnection'],
+            ['relay', \Predis\Connection\RelayConnection::class],
         ];
     }
 }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -737,6 +737,7 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * @group disconnected
+     * @group slow
      */
     public function testThrowsClientExceptionWhenExecutingCommandWithEmptyPool(): void
     {

--- a/tests/Predis/Connection/ParametersTest.php
+++ b/tests/Predis/Connection/ParametersTest.php
@@ -386,6 +386,23 @@ class ParametersTest extends PredisTestCase
         $this->assertSame($uri, (string) $parameters);
     }
 
+    /**
+     * @group disconnected
+     */
+    public function testSettingRelayOptions(): void
+    {
+        $uri = 'tcp://10.10.10.10?serializer=igbinary&compression=lz4';
+
+        $expected = [
+            'scheme' => 'tcp',
+            'host' => '10.10.10.10',
+            'serializer' => 'igbinary',
+            'compression' => 'lz4',
+        ];
+
+        $this->assertSame($expected, Parameters::parse($uri));
+    }
+
     // ******************************************************************** //
     // ---- HELPER METHODS ------------------------------------------------ //
     // ******************************************************************** //

--- a/tests/Predis/Connection/RelayConnectionTest.php
+++ b/tests/Predis/Connection/RelayConnectionTest.php
@@ -78,11 +78,7 @@ class RelayConnectionTest extends PredisConnectionTestCase
     /**
      * @group connected
      * @group slow
-     * @group relay-incompatible
-     * @group relay-fixme
      * @requires PHP 5.4
-     *
-     * This is a bug in Relay v0.6.3 and earlier.
      */
     public function testThrowsExceptionOnReadWriteTimeout(): void
     {

--- a/tests/Predis/Connection/RelayConnectionTest.php
+++ b/tests/Predis/Connection/RelayConnectionTest.php
@@ -78,7 +78,11 @@ class RelayConnectionTest extends PredisConnectionTestCase
     /**
      * @group connected
      * @group slow
+     * @group relay-incompatible
+     * @group relay-fixme
      * @requires PHP 5.4
+     *
+     * This is a bug in Relay v0.6.3 and earlier.
      */
     public function testThrowsExceptionOnReadWriteTimeout(): void
     {

--- a/tests/Predis/Connection/RelayConnectionTest.php
+++ b/tests/Predis/Connection/RelayConnectionTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Connection;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\RawCommand;
+use Predis\Response\Error as ErrorResponse;
+
+/**
+ * @group ext-relay
+ * @requires extension relay
+ */
+class RelayConnectionTest extends PredisConnectionTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConnectionClass(): string
+    {
+        return RelayConnection::class;
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testThrowsExceptionOnInitializationCommandFailure(): void
+    {
+        $this->expectException('Predis\Connection\ConnectionException');
+        $this->expectExceptionMessage('`SELECT` failed: ERR invalid DB index [tcp://127.0.0.1:6379]');
+
+        $cmdSelect = RawCommand::create('SELECT', '1000');
+
+        /** @var NodeConnectionInterface|MockObject */
+        $connection = $this
+            ->getMockBuilder($this->getConnectionClass())
+            ->onlyMethods(['executeCommand', 'createResource'])
+            ->setConstructorArgs([new Parameters()])
+            ->getMock();
+        $connection
+            ->method('executeCommand')
+            ->with($cmdSelect)
+            ->willReturn(
+                new ErrorResponse('ERR invalid DB index')
+            );
+
+        $connection->method('createResource');
+
+        $connection->addConnectCommand($cmdSelect);
+        $connection->connect();
+    }
+
+    // ******************************************************************** //
+    // ---- INTEGRATION TESTS --------------------------------------------- //
+    // ******************************************************************** //
+
+    /**
+     * @group connected
+     */
+    public function testGetResourceForcesConnection(): void
+    {
+        $connection = $this->createConnection();
+
+        $this->assertFalse($connection->isConnected());
+        $connection->getResource();
+        $this->assertTrue($connection->isConnected());
+    }
+
+    /**
+     * @group connected
+     * @group slow
+     * @requires PHP 5.4
+     */
+    public function testThrowsExceptionOnReadWriteTimeout(): void
+    {
+        $this->expectException('Predis\Connection\ConnectionException');
+
+        $connection = $this->createConnectionWithParams([
+            'read_write_timeout' => 0.5,
+        ], true);
+
+        $connection->executeCommand(
+            $this->getCommandFactory()->create('brpop', ['foo', 3])
+        );
+    }
+
+    /**
+     * @medium
+     * @group connected
+     * @group relay-incompatible
+     */
+    public function testThrowsExceptionOnProtocolDesynchronizationErrors(): void
+    {
+        $this->expectException('Predis\Protocol\ProtocolException');
+
+        $connection = $this->createConnection();
+        $stream = $connection->getResource();
+
+        $connection->writeRequest($this->getCommandFactory()->create('ping'));
+        stream_socket_recvfrom($stream, 1);
+
+        $connection->read();
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requires PHP 5.4
+     */
+    public function testPersistentParameterWithFalseLikeValues(): void
+    {
+        $connection1 = $this->createConnectionWithParams(['persistent' => 0]);
+        $this->assertNonPersistentConnection($connection1);
+
+        $connection2 = $this->createConnectionWithParams(['persistent' => false]);
+        $this->assertNonPersistentConnection($connection2);
+
+        $connection3 = $this->createConnectionWithParams(['persistent' => '0']);
+        $this->assertNonPersistentConnection($connection3);
+
+        $connection4 = $this->createConnectionWithParams(['persistent' => 'false']);
+        $this->assertNonPersistentConnection($connection4);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requires PHP 5.4
+     */
+    public function testPersistentParameterWithTrueLikeValues(): void
+    {
+        $connection1 = $this->createConnectionWithParams(['persistent' => 1]);
+        $this->assertPersistentConnection($connection1);
+
+        $connection2 = $this->createConnectionWithParams(['persistent' => true]);
+        $this->assertPersistentConnection($connection2);
+
+        $connection3 = $this->createConnectionWithParams(['persistent' => '1']);
+        $this->assertPersistentConnection($connection3);
+
+        $connection4 = $this->createConnectionWithParams(['persistent' => 'true']);
+        $this->assertPersistentConnection($connection4);
+
+        $connection1->disconnect();
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requires PHP 5.4
+     */
+    public function testPersistentConnectionsToSameNodeShareResource(): void
+    {
+        $connection1 = $this->createConnectionWithParams(['persistent' => true]);
+        $connection2 = $this->createConnectionWithParams(['persistent' => true]);
+
+        $this->assertPersistentConnection($connection1);
+        $this->assertPersistentConnection($connection2);
+
+        $this->assertSame($connection1->getResource(), $connection2->getResource());
+
+        $connection1->disconnect();
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requires PHP 5.4
+     */
+    public function testPersistentConnectionsToSameNodeDoNotShareResourceUsingDifferentPersistentID(): void
+    {
+        $connection1 = $this->createConnectionWithParams(['persistent' => 'conn1']);
+        $connection2 = $this->createConnectionWithParams(['persistent' => 'conn2']);
+
+        $this->assertPersistentConnection($connection1);
+        $this->assertPersistentConnection($connection2);
+
+        $this->assertNotSame($connection1->getResource(), $connection2->getResource());
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     */
+    public function testTcpNodelayParameterSetsContextFlagWhenTrue()
+    {
+        $connection = $this->createConnectionWithParams(['tcp_nodelay' => true]);
+        $options = stream_context_get_options($connection->getResource());
+
+        $this->assertIsArray($options);
+        $this->assertArrayHasKey('socket', $options);
+        $this->assertArrayHasKey('tcp_nodelay', $options['socket']);
+        $this->assertTrue($options['socket']['tcp_nodelay']);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     */
+    public function testTcpNodelayParameterDoesNotSetContextFlagWhenFalse()
+    {
+        $connection = $this->createConnectionWithParams(['tcp_nodelay' => false]);
+        $options = stream_context_get_options($connection->getResource());
+
+        $this->assertIsArray($options);
+        $this->assertArrayHasKey('socket', $options);
+        $this->assertArrayHasKey('tcp_nodelay', $options['socket']);
+        $this->assertFalse($options['socket']['tcp_nodelay']);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     */
+    public function testTcpDelayContextFlagIsNotSetByDefault()
+    {
+        $connection = $this->createConnectionWithParams([]);
+        $options = stream_context_get_options($connection->getResource());
+
+        $this->assertIsArray($options);
+        $this->assertArrayHasKey('socket', $options);
+        $this->assertArrayHasKey('tcp_nodelay', $options['socket']);
+        $this->assertFalse($options['socket']['tcp_nodelay']);
+    }
+}

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -780,7 +780,8 @@ class MultiExecTest extends PredisTestCase
 
     /**
      * @group connected
-     * @group relay-risky
+     * @group relay-incompatible
+     * @group relay-broken
      * @requiresRedisVersion >= 2.2.0
      */
     public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -910,8 +910,7 @@ class MultiExecTest extends PredisTestCase
         ?array $expected = [],
         ?array &$commands = [],
         ?array &$cas = []
-    ): callable
-    {
+    ): callable {
         $multi = $watch = $abort = false;
 
         return function (CommandInterface $command) use (&$expected, &$commands, &$cas, &$multi, &$watch, &$abort) {

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -910,7 +910,8 @@ class MultiExecTest extends PredisTestCase
         ?array $expected = [],
         ?array &$commands = [],
         ?array &$cas = []
-    ): callable {
+    ): callable
+    {
         $multi = $watch = $abort = false;
 
         return function (CommandInterface $command) use (&$expected, &$commands, &$cas, &$multi, &$watch, &$abort) {

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -783,6 +783,8 @@ class MultiExecTest extends PredisTestCase
      * @group relay-incompatible
      * @group relay-fixme
      * @requiresRedisVersion >= 2.2.0
+     *
+     * Waiting for `WATCH` support in Relay.
      */
     public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void
     {

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -780,11 +780,8 @@ class MultiExecTest extends PredisTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
+     * @group relay-risky
      * @requiresRedisVersion >= 2.2.0
-     *
-     * Waiting for `WATCH` support in Relay.
      */
     public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void
     {

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -780,8 +780,6 @@ class MultiExecTest extends PredisTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-broken
      * @requiresRedisVersion >= 2.2.0
      */
     public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -754,7 +754,7 @@ class MultiExecTest extends PredisTestCase
             $tx->echo('foobar');
         });
 
-        $this->assertTrue($responses[0]);
+        $this->assertSame('OK', $responses[0]);
         $this->assertInstanceOf('Predis\Response\Error', $responses[1]);
         $this->assertSame('foobar', $responses[2]);
     }

--- a/tests/Predis/Transaction/MultiExecTest.php
+++ b/tests/Predis/Transaction/MultiExecTest.php
@@ -723,6 +723,7 @@ class MultiExecTest extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
      */
     public function testIntegrationReturnsErrorObjectOnRedisErrorInBlock(): void
     {
@@ -735,6 +736,25 @@ class MultiExecTest extends PredisTestCase
         });
 
         $this->assertInstanceOf('Predis\Response\Status', $responses[0]);
+        $this->assertInstanceOf('Predis\Response\Error', $responses[1]);
+        $this->assertSame('foobar', $responses[2]);
+    }
+
+    /**
+     * @group connected
+     * @group ext-relay
+     */
+    public function testIntegrationReturnsErrorObjectOnRedisErrorInBlockWhenUsingRelay(): void
+    {
+        $client = $this->getClient([], ['exceptions' => false]);
+
+        $responses = $client->transaction(function (MultiExec $tx) {
+            $tx->set('foo', 'bar');
+            $tx->lpush('foo', 'bar');
+            $tx->echo('foobar');
+        });
+
+        $this->assertTrue($responses[0]);
         $this->assertInstanceOf('Predis\Response\Error', $responses[1]);
         $this->assertSame('foobar', $responses[2]);
     }
@@ -760,6 +780,8 @@ class MultiExecTest extends PredisTestCase
 
     /**
      * @group connected
+     * @group relay-incompatible
+     * @group relay-fixme
      * @requiresRedisVersion >= 2.2.0
      */
     public function testIntegrationWritesOnWatchedKeysAbortTransaction(): void

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,7 @@ line test runner. Please note that due to a bug in PHPUnit, older versions ignor
 option when the group is excluded in the XML configuration file. More details about this issue are
 available on [PHPUnit's bug tracker](http://github.com/sebastianbergmann/phpunit/issues/320).
 
-Certain groups of tests requiring native extensions, such as `ext-curl` or `ext-phpiredis`, are
+Certain groups of tests requiring native extensions, such as `ext-relay`, are
 disabled by default in the configuration file. To enable these groups of tests you should remove
 them from the exclusion list in `phpunit.xml`.
 


### PR DESCRIPTION
Backport #1084. This is a work in progress. Currently waiting for v0.6.4 release.

## TODOs

- [x] Deprecate phpiredis + webdis now
- [x] Pass most Redis Stack tests
- [x] Replace `phpiredis` instructions with Relay instructions
- [x] Pass most tests (except `relay-incompatible` group)
- [x] Remove all `relay-*` groups except `relay-incompatible`
- [x] Add `examples/relay_events.php` 
- [x] Make `onInvalidated()` and other methods easier to access
- [x] Finish [Wiki page](https://github.com/predis/predis/wiki/Using-Relay)
- [x] Support `compression` and `serializer` options
- [x] Support `pack()` and `unpack()`

## 3.x followup
- Merge into `main`
- Remove Webdis and Phpiredis from `main` after merging
- Auto-mutate data
- Review `relay-fixme` test group
- Handle `Predis\Command\RawCommand()` calls
- Do we need a `dispatcher_loop.php` example?
