### PR TITLE
Add missing `@return` annotations

### DIFF
--- a/src/Cluster/SlotMap.php
+++ b/src/Cluster/SlotMap.php
@@ -19,6 +19,7 @@ use IteratorAggregate;
 use OutOfBoundsException;
 use Predis\Connection\NodeConnectionInterface;
 use ReturnTypeWillChange;
+use Traversable;
 
 /**
  * Slot map for redis-cluster.
@@ -198,7 +199,7 @@ class SlotMap implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns an iterator over the slot map.
      *
-     * @return ArrayIterator
+     * @return Traversable<int, string>
      */
     #[ReturnTypeWillChange]
     public function getIterator()

--- a/src/Collection/Iterator/CursorBasedIterator.php
+++ b/src/Collection/Iterator/CursorBasedIterator.php
@@ -138,7 +138,7 @@ abstract class CursorBasedIterator implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
@@ -148,7 +148,7 @@ abstract class CursorBasedIterator implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function current()
@@ -157,7 +157,7 @@ abstract class CursorBasedIterator implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -166,7 +166,7 @@ abstract class CursorBasedIterator implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function next()
@@ -186,7 +186,7 @@ abstract class CursorBasedIterator implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function valid()

--- a/src/Collection/Iterator/ListKey.php
+++ b/src/Collection/Iterator/ListKey.php
@@ -128,7 +128,7 @@ class ListKey implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
@@ -138,7 +138,7 @@ class ListKey implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function current()
@@ -147,7 +147,7 @@ class ListKey implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -156,7 +156,7 @@ class ListKey implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function next()
@@ -173,7 +173,7 @@ class ListKey implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function valid()

--- a/src/Command/Processor/ProcessorChain.php
+++ b/src/Command/Processor/ProcessorChain.php
@@ -93,7 +93,9 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $index
+     *
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function offsetExists($index)
@@ -102,7 +104,9 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $index
+     *
+     * @return ProcessorInterface
      */
     #[ReturnTypeWillChange]
     public function offsetGet($index)
@@ -111,7 +115,10 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int                $index
+     * @param ProcessorInterface $processor
+     *
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function offsetSet($index, $processor)
@@ -126,7 +133,9 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $index
+     *
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function offsetUnset($index)

--- a/src/Command/Processor/ProcessorChain.php
+++ b/src/Command/Processor/ProcessorChain.php
@@ -117,7 +117,6 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     /**
      * @param int                $index
      * @param ProcessorInterface $processor
-     *
      * @return void
      */
     #[ReturnTypeWillChange]
@@ -134,7 +133,6 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
 
     /**
      * @param int $index
-     *
      * @return void
      */
     #[ReturnTypeWillChange]

--- a/src/Command/Processor/ProcessorChain.php
+++ b/src/Command/Processor/ProcessorChain.php
@@ -93,8 +93,7 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * @param int $index
-     *
+     * @param  int $index
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -104,8 +103,7 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * @param int $index
-     *
+     * @param  int $index
      * @return ProcessorInterface
      */
     #[ReturnTypeWillChange]
@@ -115,8 +113,8 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * @param int                $index
-     * @param ProcessorInterface $processor
+     * @param  int $index
+     * @param  ProcessorInterface $processor
      * @return void
      */
     #[ReturnTypeWillChange]
@@ -132,7 +130,7 @@ class ProcessorChain implements ArrayAccess, ProcessorInterface
     }
 
     /**
-     * @param int $index
+     * @param  int $index
      * @return void
      */
     #[ReturnTypeWillChange]

--- a/src/Connection/Cluster/PredisCluster.php
+++ b/src/Connection/Cluster/PredisCluster.php
@@ -21,6 +21,7 @@ use Predis\Command\CommandInterface;
 use Predis\Connection\NodeConnectionInterface;
 use Predis\NotSupportedException;
 use ReturnTypeWillChange;
+use Traversable;
 
 /**
  * Abstraction for a cluster of aggregate connections to various Redis servers
@@ -200,7 +201,7 @@ class PredisCluster implements ClusterInterface, IteratorAggregate, Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     #[ReturnTypeWillChange]
     public function count()
@@ -209,7 +210,7 @@ class PredisCluster implements ClusterInterface, IteratorAggregate, Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable<string, NodeConnectionInterface>
      */
     #[ReturnTypeWillChange]
     public function getIterator()

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -31,6 +31,7 @@ use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
 use ReturnTypeWillChange;
 use Throwable;
+use Traversable;
 
 /**
  * Abstraction for a Redis-backed cluster of nodes (Redis >= 3.0.0).
@@ -589,7 +590,7 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     #[ReturnTypeWillChange]
     public function count()
@@ -598,7 +599,7 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable<string, NodeConnectionInterface>
      */
     #[ReturnTypeWillChange]
     public function getIterator()

--- a/src/Monitor/Consumer.php
+++ b/src/Monitor/Consumer.php
@@ -90,7 +90,7 @@ class Consumer implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
@@ -110,7 +110,7 @@ class Consumer implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -119,7 +119,7 @@ class Consumer implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function next()

--- a/src/PubSub/AbstractConsumer.php
+++ b/src/PubSub/AbstractConsumer.php
@@ -151,7 +151,7 @@ abstract class AbstractConsumer implements Iterator
     abstract protected function writeRequest($method, $arguments);
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
@@ -172,7 +172,7 @@ abstract class AbstractConsumer implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -181,7 +181,7 @@ abstract class AbstractConsumer implements Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function next()

--- a/src/Response/Iterator/MultiBulkIterator.php
+++ b/src/Response/Iterator/MultiBulkIterator.php
@@ -34,7 +34,7 @@ abstract class MultiBulkIterator implements Iterator, Countable, ResponseInterfa
     protected $size;
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
@@ -43,7 +43,7 @@ abstract class MultiBulkIterator implements Iterator, Countable, ResponseInterfa
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function current()
@@ -52,7 +52,7 @@ abstract class MultiBulkIterator implements Iterator, Countable, ResponseInterfa
     }
 
     /**
-     * {@inheritdoc}
+     * @return int|null
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -61,7 +61,7 @@ abstract class MultiBulkIterator implements Iterator, Countable, ResponseInterfa
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function next()
@@ -72,7 +72,7 @@ abstract class MultiBulkIterator implements Iterator, Countable, ResponseInterfa
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function valid()

--- a/src/Response/Iterator/MultiBulkTuple.php
+++ b/src/Response/Iterator/MultiBulkTuple.php
@@ -63,7 +63,7 @@ class MultiBulkTuple extends MultiBulk implements OuterIterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return MultiBulk
      */
     #[ReturnTypeWillChange]
     public function getInnerIterator()

--- a/src/Session/Handler.php
+++ b/src/Session/Handler.php
@@ -55,7 +55,6 @@ class Handler implements SessionHandlerInterface
     /**
      * @param string $save_path
      * @param string $session_id
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -77,7 +76,6 @@ class Handler implements SessionHandlerInterface
 
     /**
      * @param int $maxlifetime
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -89,7 +87,6 @@ class Handler implements SessionHandlerInterface
 
     /**
      * @param string $session_id
-     *
      * @return string
      */
     #[ReturnTypeWillChange]
@@ -105,7 +102,6 @@ class Handler implements SessionHandlerInterface
     /**
      * @param string $session_id
      * @param string $session_data
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]

--- a/src/Session/Handler.php
+++ b/src/Session/Handler.php
@@ -53,8 +53,8 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * @param string $save_path
-     * @param string $session_id
+     * @param  string $save_path
+     * @param  string $session_id
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -75,7 +75,7 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * @param int $maxlifetime
+     * @param  int $maxlifetime
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -86,7 +86,7 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * @param string $session_id
+     * @param  string $session_id
      * @return string
      */
     #[ReturnTypeWillChange]
@@ -100,8 +100,8 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * @param string $session_id
-     * @param string $session_data
+     * @param  string $session_id
+     * @param  string $session_data
      * @return bool
      */
     #[ReturnTypeWillChange]
@@ -114,7 +114,6 @@ class Handler implements SessionHandlerInterface
 
     /**
      * @param string $session_id
-     *
      * @return bool
      */
     #[ReturnTypeWillChange]

--- a/src/Session/Handler.php
+++ b/src/Session/Handler.php
@@ -53,7 +53,10 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $save_path
+     * @param string $session_id
+     *
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function open($save_path, $session_id)
@@ -63,7 +66,7 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function close()
@@ -73,7 +76,9 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $maxlifetime
+     *
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function gc($maxlifetime)
@@ -83,7 +88,9 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $session_id
+     *
+     * @return string
      */
     #[ReturnTypeWillChange]
     public function read($session_id)
@@ -96,7 +103,10 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $session_id
+     * @param string $session_data
+     *
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function write($session_id, $session_data)
@@ -107,7 +117,9 @@ class Handler implements SessionHandlerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $session_id
+     *
+     * @return bool
      */
     #[ReturnTypeWillChange]
     public function destroy($session_id)


### PR DESCRIPTION
Declaring `#[ReturnTypeWillChange]` is not precise enough, that's why they should always have their corresponding `@return`.

This change is required to enable using Predis v2 with Symfony, see https://github.com/symfony/symfony/pull/49801