### PR TITLE
Added RESP3 protocol option, establish RESP3 connection

### DIFF
--- a/src/Connection/AbstractConnection.php
+++ b/src/Connection/AbstractConnection.php
@@ -104,6 +104,14 @@ abstract class AbstractConnection implements NodeConnectionInterface
     /**
      * {@inheritdoc}
      */
+    public function getInitCommands(): array
+    {
+        return $this->initCommands;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function executeCommand(CommandInterface $command)
     {
         $this->writeRequest($command);

--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -174,6 +174,12 @@ class Factory implements FactoryInterface
             );
         }
 
+        if (isset($parameters->protocol) && (int) $parameters->protocol > 2) {
+            $connection->addConnectCommand(
+                new RawCommand('HELLO', [$parameters->protocol, 'SETNAME', 'predis'])
+            );
+        }
+
         if (isset($parameters->database) && strlen($parameters->database)) {
             $connection->addConnectCommand(
                 new RawCommand('SELECT', [$parameters->database])

--- a/src/Connection/NodeConnectionInterface.php
+++ b/src/Connection/NodeConnectionInterface.php
@@ -49,13 +49,6 @@ interface NodeConnectionInterface extends ConnectionInterface
     public function addConnectCommand(CommandInterface $command);
 
     /**
-     * Returns init commands array for current connection.
-     *
-     * @return CommandInterface[]
-     */
-    public function getInitCommands(): array;
-
-    /**
      * Reads a response from the server.
      *
      * @return mixed

--- a/src/Connection/NodeConnectionInterface.php
+++ b/src/Connection/NodeConnectionInterface.php
@@ -49,6 +49,13 @@ interface NodeConnectionInterface extends ConnectionInterface
     public function addConnectCommand(CommandInterface $command);
 
     /**
+     * Returns init commands array for current connection.
+     *
+     * @return CommandInterface[]
+     */
+    public function getInitCommands(): array;
+
+    /**
      * Reads a response from the server.
      *
      * @return mixed

--- a/src/Connection/Parameters.php
+++ b/src/Connection/Parameters.php
@@ -25,6 +25,7 @@ class Parameters implements ParametersInterface
         'scheme' => 'tcp',
         'host' => '127.0.0.1',
         'port' => 6379,
+        'protocol' => 2,
     ];
 
     /**

--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -22,6 +22,7 @@ namespace Predis\Connection;
  * @property string $scheme             Connection scheme, such as 'tcp' or 'unix'.
  * @property string $host               IP address or hostname of Redis.
  * @property int    $port               TCP port on which Redis is listening to.
+ * @property int    $protocol           Version of RESP protocol.
  * @property string $path               Path of a UNIX domain socket file.
  * @property string $alias              Alias for the connection.
  * @property float  $timeout            Timeout for the connect() operation.

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Connection;
 
+use Predis\Command\RawCommand;
 use PredisTestCase;
 use ReflectionObject;
 use stdClass;
@@ -536,6 +537,22 @@ class FactoryTest extends PredisTestCase
 
         $factory->undefine('test');
         $factory->create('test://127.0.0.1');
+    }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testCreatesResp3ConnectionOnProtocolParameterGiven(): void
+    {
+        $parameters = ['protocol' => 3];
+
+        $factory = new Factory();
+        $connection = $factory->create($parameters);
+        $initCommands = $connection->getInitCommands();
+
+        $this->assertInstanceOf(RawCommand::class, $initCommands[0]);
+        $this->assertSame('HELLO', $initCommands[0]->getId());
     }
 
     // ******************************************************************** //

--- a/tests/Predis/Connection/ParametersTest.php
+++ b/tests/Predis/Connection/ParametersTest.php
@@ -401,6 +401,7 @@ class ParametersTest extends PredisTestCase
             'scheme' => 'tcp',
             'host' => '127.0.0.1',
             'port' => 6379,
+            'protocol' => 2,
         ];
     }
 

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -195,4 +195,21 @@ class StreamConnectionTest extends PredisConnectionTestCase
         $this->assertArrayHasKey('tcp_nodelay', $options['socket']);
         $this->assertFalse($options['socket']['tcp_nodelay']);
     }
+
+    /**
+     * @group disconnected
+     * @return void
+     */
+    public function testGetInitCommandsReturnsGivenInitCommands(): void
+    {
+        $command = new RawCommand('HELLO', [3]);
+
+        $connection = $this->createConnection();
+        $connection->addConnectCommand($command);
+
+        $initCommands = $connection->getInitCommands();
+
+        $this->assertInstanceOf(RawCommand::class, $initCommands[0]);
+        $this->assertSame('HELLO', $initCommands[0]->getId());
+    }
 }


### PR DESCRIPTION
- Added new default option `protocol` with default value `2` (which corresponds to RESP2)
- Added possibility to establish different protocol version connection if given version `>2`