### PR TITLE
Added timeout to prevent search before create

### DIFF
--- a/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
@@ -79,6 +79,9 @@ class FTSEARCH_Test extends PredisCommandTestCase
         $ftCreateResponse = $redis->ftcreate('idx_json', $schema, $createArguments);
         $this->assertEquals('OK', $ftCreateResponse);
 
+        // Timeout to make sure that index created before search performed.
+        usleep(2000);
+
         $ftSearchArguments = new SearchArguments();
         $ftSearchArguments->addReturn(2, 'arr', 'val');
 


### PR DESCRIPTION
Fixes bug with randomly failing test, because search performed on index that wasn't created yet