### PR TITLE
Changes related to Redis 7.2 image update

### DIFF
--- a/docker/unstable_cluster/redis.conf
+++ b/docker/unstable_cluster/redis.conf
@@ -3,7 +3,6 @@
 # port, cluster-enabled, daemonize, logfile, dir
 protected-mode no
 loadmodule /opt/redis-stack/lib/redisearch.so
-loadmodule /opt/redis-stack/lib/redisgraph.so
 loadmodule /opt/redis-stack/lib/redistimeseries.so
 loadmodule /opt/redis-stack/lib/rejson.so
 loadmodule /opt/redis-stack/lib/redisbloom.so

--- a/phpunit.relay.xml
+++ b/phpunit.relay.xml
@@ -20,6 +20,7 @@
     <groups>
         <exclude>
             <group>relay-incompatible</group>
+            <group>relay-resp3</group>
             <group>realm-webdis</group>
             <group>realm-stack</group>
             <group>ext-curl</group>

--- a/tests/PHPUnit/AssertSameWithPrecisionConstraint.php
+++ b/tests/PHPUnit/AssertSameWithPrecisionConstraint.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+class AssertSameWithPrecisionConstraint extends Constraint
+{
+    /**
+     * @var mixed
+     */
+    private $expectedValue;
+
+    /**
+     * @var int
+     */
+    private $precision;
+
+    public function __construct($expectedValue, int $precision)
+    {
+        $this->expectedValue = $expectedValue;
+        $this->precision = $precision;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches($other): bool
+    {
+        if (gettype($this->expectedValue) !== gettype($other)) {
+            return false;
+        }
+
+        if (is_array($other)) {
+            $other = array_map([$this, 'roundToPrecision'], $other);
+            $this->expectedValue = array_map([$this, 'roundToPrecision'], $this->expectedValue);
+
+            return !array_diff($this->expectedValue, $other);
+        }
+
+        $other = $this->roundToPrecision($other);
+        $this->expectedValue = $this->roundToPrecision($this->expectedValue);
+
+        return $other === $this->expectedValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toString(): string
+    {
+        return 'given value matches another value with given precision';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function failureDescription($other): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * @param  mixed $numeric
+     * @return float
+     */
+    private function roundToPrecision($numeric): float
+    {
+        return round((float) $numeric, $this->precision);
+    }
+}

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -10,6 +10,7 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\AssertSameWithPrecisionConstraint;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\OneOfConstraint;
 use PHPUnit\Util\Test as TestUtil;
@@ -129,6 +130,20 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
     public function assertOneOf(array $expected, $actual, string $message = ''): void
     {
         $this->assertThat($actual, new OneOfConstraint($expected), $message);
+    }
+
+    /**
+     * Asserts that two values (of the same type) have the same values with given precision.
+     *
+     * @param  mixed  $expected  Expected value
+     * @param  mixed  $actual    Actual value
+     * @param  int    $precision Precision value should be round to
+     * @param  string $message   Optional assertion message
+     * @return void
+     */
+    public function assertSameWithPrecision($expected, $actual, int $precision = 0, string $message = ''): void
+    {
+        $this->assertThat($actual, new AssertSameWithPrecisionConstraint($expected, $precision), $message);
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
@@ -76,20 +76,6 @@ class BFADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @return void
-     * @requiresRedisBfVersion >= 2.6.0
-     */
-    public function testAddGivenItemIntoBloomFilterResp3(): void
-    {
-        $redis = $this->getResp3Client();
-
-        $actualResponse = $redis->bfadd('key', 'item');
-        $this->assertTrue($actualResponse);
-        $this->assertTrue($redis->bfexists('key', 'item'));
-    }
-
-    /**
-     * @group connected
      * @group relay-incompatible
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
@@ -61,8 +61,9 @@ class BFADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
-     * @requiresRedisBfVersion >= 1.0
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testAddGivenItemIntoBloomFilter(): void
     {
@@ -75,7 +76,22 @@ class BFADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisBfVersion >= 1.0
+     * @return void
+     * @requiresRedisBfVersion >= 2.6.0
+     */
+    public function testAddGivenItemIntoBloomFilterResp3(): void
+    {
+        $redis = $this->getResp3Client();
+
+        $actualResponse = $redis->bfadd('key', 'item');
+        $this->assertTrue($actualResponse);
+        $this->assertTrue($redis->bfexists('key', 'item'));
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testThrowsExceptionOnWrongType(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFEXISTS_Test.php
@@ -60,8 +60,9 @@ class BFEXISTS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
-     * @requiresRedisBfVersion >= 1.0
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testExistsReturnsExistingItemWithinBloomFilter(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFINFO_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFINFO_Test.php
@@ -61,6 +61,7 @@ class BFINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array  $filter
      * @param  string $key
@@ -98,7 +99,8 @@ class BFINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisBfVersion >= 1.0
+     * @group relay-resp3
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testThrowsExceptionOnWrongType(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFINSERT_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFINSERT_Test.php
@@ -60,6 +60,7 @@ class BFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array  $arguments
      * @param  string $key
@@ -101,6 +102,7 @@ class BFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */
@@ -134,6 +136,7 @@ class BFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider unexpectedValuesProvider
      * @param  array  $arguments
      * @param  string $expectedExceptionMessage

--- a/tests/Predis/Command/Redis/BloomFilter/BFLOADCHUNK_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFLOADCHUNK_Test.php
@@ -61,6 +61,7 @@ class BFLOADCHUNK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/BloomFilter/BFMADD_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFMADD_Test.php
@@ -61,8 +61,9 @@ class BFMADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
-     * @requiresRedisBfVersion >= 1.0
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testAddGivenItemsIntoBloomFilter(): void
     {
@@ -75,7 +76,8 @@ class BFMADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisBfVersion >= 1.0
+     * @group relay-incompatible
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testThrowsExceptionOnWrongType(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFMEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFMEXISTS_Test.php
@@ -60,8 +60,9 @@ class BFMEXISTS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
-     * @requiresRedisBfVersion >= 1.0
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testExistsReturnsExistingItemsWithinBloomFilter(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFRESERVE_Test.php
@@ -60,6 +60,7 @@ class BFRESERVE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array  $filter
      * @param  string $key
@@ -98,7 +99,8 @@ class BFRESERVE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisBfVersion >= 1.0
+     * @group relay-resp3
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testThrowsExceptionOnWrongType(): void
     {

--- a/tests/Predis/Command/Redis/BloomFilter/BFSCANDUMP_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFSCANDUMP_Test.php
@@ -61,6 +61,7 @@ class BFSCANDUMP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINCRBY_Test.php
@@ -61,6 +61,7 @@ class CMSINCRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  array $incrementArguments
      * @param  array $queryArguments

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINFO_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINFO_Test.php
@@ -64,6 +64,7 @@ class CMSINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYDIM_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYDIM_Test.php
@@ -61,6 +61,7 @@ class CMSINITBYDIM_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYPROB_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYPROB_Test.php
@@ -61,6 +61,7 @@ class CMSINITBYPROB_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSMERGE_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSMERGE_Test.php
@@ -59,6 +59,7 @@ class CMSMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  array  $mergeArguments
      * @param  string $destinationKey
@@ -107,6 +108,7 @@ class CMSMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */
@@ -125,6 +127,7 @@ class CMSMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSQUERY_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSQUERY_Test.php
@@ -61,6 +61,7 @@ class CMSQUERY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  array $queryArguments
      * @param  array $expectedResponse

--- a/tests/Predis/Command/Redis/CuckooFilter/CFADDNX_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFADDNX_Test.php
@@ -61,6 +61,7 @@ class CFADDNX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFADD_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFADD_Test.php
@@ -61,6 +61,7 @@ class CFADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFCOUNT_Test.php
@@ -60,6 +60,7 @@ class CFCOUNT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFDEL_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFDEL_Test.php
@@ -61,6 +61,7 @@ class CFDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFEXISTS_Test.php
@@ -60,6 +60,7 @@ class CFEXISTS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINFO_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINFO_Test.php
@@ -62,6 +62,7 @@ class CFINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINSERTNX_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINSERTNX_Test.php
@@ -51,6 +51,7 @@ class CFINSERTNX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array  $filterArguments
      * @param  string $key
@@ -76,6 +77,7 @@ class CFINSERTNX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */
@@ -107,6 +109,7 @@ class CFINSERTNX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINSERT_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINSERT_Test.php
@@ -52,6 +52,7 @@ class CFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array  $filterArguments
      * @param  string $key
@@ -77,6 +78,7 @@ class CFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */
@@ -110,6 +112,7 @@ class CFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */
@@ -125,6 +128,7 @@ class CFINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFLOADCHUNK_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFLOADCHUNK_Test.php
@@ -61,6 +61,7 @@ class CFLOADCHUNK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/CuckooFilter/CFMEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFMEXISTS_Test.php
@@ -60,8 +60,9 @@ class CFMEXISTS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
-     * @requiresRedisBfVersion >= 1.0
+     * @requiresRedisBfVersion >= 1.0.0
      */
     public function testExistsReturnsExistingItemsWithinCuckooFilter(): void
     {

--- a/tests/Predis/Command/Redis/CuckooFilter/CFRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFRESERVE_Test.php
@@ -51,6 +51,7 @@ class CFRESERVE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider filtersProvider
      * @param  array $filterArguments
      * @param  int   $expectedCapacity

--- a/tests/Predis/Command/Redis/CuckooFilter/CFSCANDUMP_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFSCANDUMP_Test.php
@@ -61,6 +61,7 @@ class CFSCANDUMP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Json/JSONARRAPPEND_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRAPPEND_Test.php
@@ -60,6 +60,7 @@ class JSONARRAPPEND_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONARRINDEX_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRINDEX_Test.php
@@ -60,6 +60,7 @@ class JSONARRINDEX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONARRINSERT_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRINSERT_Test.php
@@ -60,6 +60,7 @@ class JSONARRINSERT_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONARRLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRLEN_Test.php
@@ -60,6 +60,7 @@ class JSONARRLEN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONARRPOP_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRPOP_Test.php
@@ -60,6 +60,7 @@ class JSONARRPOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONARRTRIM_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRTRIM_Test.php
@@ -60,6 +60,7 @@ class JSONARRTRIM_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONCLEAR_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONCLEAR_Test.php
@@ -60,6 +60,7 @@ class JSONCLEAR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONDEBUG_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONDEBUG_Test.php
@@ -56,6 +56,7 @@ class JSONDEBUG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONDEL_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONDEL_Test.php
@@ -60,6 +60,7 @@ class JSONDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONFORGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONFORGET_Test.php
@@ -60,6 +60,7 @@ class JSONFORGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONGET_Test.php
@@ -59,6 +59,7 @@ class JSONGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonData
      * @param  string $key
@@ -101,6 +102,7 @@ class JSONGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider unexpectedValuesProvider
      * @param  array  $arguments
      * @param  string $expectedExceptionMessage

--- a/tests/Predis/Command/Redis/Json/JSONMERGE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMERGE_Test.php
@@ -57,6 +57,7 @@ class JSONMERGE_Test extends PredisCommandTestCase
     /**
      * @dataProvider jsonProvider
      * @group connected
+     * @group relay-resp3
      * @param  array  $setArguments
      * @param  array  $mergeArguments
      * @param  string $expectedResponse

--- a/tests/Predis/Command/Redis/Json/JSONMGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMGET_Test.php
@@ -60,6 +60,7 @@ class JSONMGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $firstJson
      * @param  array  $secondJson

--- a/tests/Predis/Command/Redis/Json/JSONMSET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMSET_Test.php
@@ -57,6 +57,7 @@ class JSONMSET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisJsonVersion >= 2.6.0
      */
@@ -70,6 +71,7 @@ class JSONMSET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisJsonVersion >= 2.6.0
      */

--- a/tests/Predis/Command/Redis/Json/JSONNUMINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONNUMINCRBY_Test.php
@@ -60,6 +60,7 @@ class JSONNUMINCRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONOBJKEYS_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONOBJKEYS_Test.php
@@ -60,6 +60,7 @@ class JSONOBJKEYS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONOBJLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONOBJLEN_Test.php
@@ -60,6 +60,7 @@ class JSONOBJLEN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONRESP_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONRESP_Test.php
@@ -61,6 +61,7 @@ class JSONRESP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONSET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSET_Test.php
@@ -59,6 +59,7 @@ class JSONSET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  string      $key
      * @param  string      $defaultJson

--- a/tests/Predis/Command/Redis/Json/JSONSTRAPPEND_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSTRAPPEND_Test.php
@@ -60,6 +60,7 @@ class JSONSTRAPPEND_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONSTRLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSTRLEN_Test.php
@@ -60,6 +60,7 @@ class JSONSTRLEN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONTOGGLE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONTOGGLE_Test.php
@@ -60,6 +60,7 @@ class JSONTOGGLE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Json/JSONTYPE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONTYPE_Test.php
@@ -60,6 +60,7 @@ class JSONTYPE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider jsonProvider
      * @param  array  $jsonArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
@@ -64,6 +64,7 @@ class FTAGGREGATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.1.0
      */

--- a/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
@@ -63,6 +63,7 @@ class FTALIASADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */
@@ -100,6 +101,7 @@ class FTALIASADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTALIASDEL_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASDEL_Test.php
@@ -62,6 +62,7 @@ class FTALIASDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTALIASUPDATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASUPDATE_Test.php
@@ -62,6 +62,7 @@ class FTALIASUPDATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */
@@ -99,6 +100,7 @@ class FTALIASUPDATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTALTER_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALTER_Test.php
@@ -61,6 +61,7 @@ class FTALTER_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
@@ -102,7 +102,7 @@ class FTCONFIG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-rep3
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */
@@ -116,6 +116,7 @@ class FTCONFIG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
@@ -89,6 +89,7 @@ class FTCONFIG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */
@@ -136,6 +137,7 @@ class FTCONFIG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCONFIG_Test.php
@@ -102,6 +102,7 @@ class FTCONFIG_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-rep3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTCREATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCREATE_Test.php
@@ -62,6 +62,7 @@ class FTCREATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
@@ -79,6 +79,7 @@ class FTCURSOR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.1.0
      */
@@ -178,6 +179,7 @@ class FTCURSOR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.1.0
      */
@@ -193,6 +195,7 @@ class FTCURSOR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.1.0
      */

--- a/tests/Predis/Command/Redis/Search/FTDICTADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTADD_Test.php
@@ -60,6 +60,7 @@ class FTDICTADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.4.0
      */

--- a/tests/Predis/Command/Redis/Search/FTDICTDEL_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTDEL_Test.php
@@ -60,6 +60,7 @@ class FTDICTDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider dictionariesProvider
      * @param  array $addArguments
      * @param  array $deleteArguments

--- a/tests/Predis/Command/Redis/Search/FTDICTDUMP_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTDUMP_Test.php
@@ -61,6 +61,7 @@ class FTDICTDUMP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.4.0
      */

--- a/tests/Predis/Command/Redis/Search/FTDROPINDEX_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDROPINDEX_Test.php
@@ -61,6 +61,7 @@ class FTDROPINDEX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
@@ -61,6 +61,7 @@ class FTEXPLAIN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTINFO_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTINFO_Test.php
@@ -96,7 +96,6 @@ class FTINFO_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $this->expectException(ServerException::class);
-        $this->expectExceptionMessage('Unknown Index name');
 
         $redis->ftinfo('index');
     }

--- a/tests/Predis/Command/Redis/Search/FTINFO_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTINFO_Test.php
@@ -63,7 +63,7 @@ class FTINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      *

--- a/tests/Predis/Command/Redis/Search/FTPROFILE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTPROFILE_Test.php
@@ -61,6 +61,7 @@ class FTPROFILE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider queryProvider
      * @param  array $createArguments
      * @param  array $profileArguments

--- a/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
@@ -54,6 +54,7 @@ class FTSEARCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      * @requiresRedisJsonVersion >= 1.0.0
@@ -80,7 +81,7 @@ class FTSEARCH_Test extends PredisCommandTestCase
         $this->assertEquals('OK', $ftCreateResponse);
 
         // Timeout to make sure that index created before search performed.
-        usleep(2000);
+        usleep(10000);
 
         $ftSearchArguments = new SearchArguments();
         $ftSearchArguments->addReturn(2, 'arr', 'val');
@@ -91,6 +92,7 @@ class FTSEARCH_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */
@@ -114,7 +116,7 @@ class FTSEARCH_Test extends PredisCommandTestCase
         $this->assertEquals('OK', $ftCreateResponse);
 
         // Timeout to make sure that index created before search performed.
-        usleep(2000);
+        usleep(10000);
 
         $ftSearchArguments = new SearchArguments();
         $ftSearchArguments->addReturn(1, 'should_return');

--- a/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
@@ -62,6 +62,7 @@ class FTSPELLCHECK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.4.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSUGADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGADD_Test.php
@@ -59,6 +59,7 @@ class FTSUGADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSUGDEL_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGDEL_Test.php
@@ -60,6 +60,7 @@ class FTSUGDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGGET_Test.php
@@ -60,6 +60,7 @@ class FTSUGGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider suggestionProvider
      * @param  array $addArguments
      * @param  array $getArguments
@@ -83,6 +84,7 @@ class FTSUGGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSUGLEN_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSUGLEN_Test.php
@@ -60,6 +60,7 @@ class FTSUGLEN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSYNDUMP_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSYNDUMP_Test.php
@@ -62,6 +62,7 @@ class FTSYNDUMP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.2.0
      */

--- a/tests/Predis/Command/Redis/Search/FTSYNUPDATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSYNUPDATE_Test.php
@@ -61,6 +61,7 @@ class FTSYNUPDATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.2.0
      */
@@ -106,6 +107,7 @@ class FTSYNUPDATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.2.0
      */

--- a/tests/Predis/Command/Redis/Search/FTTAGVALS_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTTAGVALS_Test.php
@@ -63,6 +63,7 @@ class FTTAGVALS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRediSearchVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTADD_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTADD_Test.php
@@ -61,6 +61,7 @@ class TDIGESTADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
@@ -61,6 +61,7 @@ class TDIGESTBYRANK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
@@ -61,6 +61,7 @@ class TDIGESTBYREVRANK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
@@ -61,6 +61,7 @@ class TDIGESTCDF_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
@@ -76,8 +76,8 @@ class TDIGESTCDF_Test extends PredisCommandTestCase
 
         $actualResponse = $redis->tdigestcdf('key', 0, 1, 2, 3, 4);
 
-        $this->assertEquals($expectedResponse, $actualResponse);
-        $this->assertEquals(['nan', 'nan'], $redis->tdigestcdf('empty_key', 0, 1));
+        $this->assertSameWithPrecision($expectedResponse, $actualResponse, 5);
+        $this->assertSame(['nan', 'nan'], $redis->tdigestcdf('empty_key', 0, 1));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCREATE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCREATE_Test.php
@@ -59,6 +59,7 @@ class TDIGESTCREATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  array  $createArguments
      * @param  string $key

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTINFO_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTINFO_Test.php
@@ -77,6 +77,7 @@ class TDIGESTINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
@@ -61,6 +61,7 @@ class TDIGESTMAX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -120,7 +120,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-rep3
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -51,6 +51,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  string $sourceKey1
      * @param  string $sourceKey2
@@ -92,6 +93,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */
@@ -156,6 +158,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */
@@ -184,6 +187,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -120,6 +120,7 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-rep3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
@@ -61,6 +61,7 @@ class TDIGESTMIN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
@@ -61,6 +61,7 @@ class TDIGESTQUANTILE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRANK_Test.php
@@ -61,6 +61,7 @@ class TDIGESTRANK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
@@ -61,6 +61,7 @@ class TDIGESTRESET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTREVRANK_Test.php
@@ -61,6 +61,7 @@ class TDIGESTREVRANK_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
@@ -61,6 +61,7 @@ class TDIGESTTRIMMED_MEAN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider sketchesProvider
      * @param  array  $addArguments
      * @param  string $key
@@ -102,6 +103,7 @@ class TDIGESTTRIMMED_MEAN_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.4.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
@@ -61,6 +61,7 @@ class TSADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
@@ -62,6 +62,7 @@ class TSALTER_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
@@ -60,6 +60,7 @@ class TSCREATERULE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */
@@ -95,6 +96,7 @@ class TSCREATERULE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
@@ -61,6 +61,7 @@ class TSCREATE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
@@ -63,6 +63,7 @@ class TSDECRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */
@@ -121,6 +122,7 @@ class TSDECRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
@@ -147,7 +147,6 @@ class TSDECRBY_Test extends PredisCommandTestCase
         );
 
         $this->expectException(ServerException::class);
-        $this->expectExceptionMessage('TSDB: for incrby/decrby, timestamp should be newer than the');
 
         $redis->tsdecrby('temperature:2:32', 27, (new DecrByArguments())->timestamp(123123123122));
     }

--- a/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
@@ -62,6 +62,7 @@ class TSDELETERULE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
@@ -63,6 +63,7 @@ class TSDEL_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.6.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
@@ -62,6 +62,7 @@ class TSGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
@@ -147,7 +147,6 @@ class TSINCRBY_Test extends PredisCommandTestCase
         );
 
         $this->expectException(ServerException::class);
-        $this->expectExceptionMessage('TSDB: for incrby/decrby, timestamp should be newer than the');
 
         $redis->tsincrby('temperature:2:32', 27, (new IncrByArguments())->timestamp(123123123122));
     }

--- a/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
@@ -63,6 +63,7 @@ class TSINCRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */
@@ -121,6 +122,7 @@ class TSINCRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
@@ -61,6 +61,7 @@ class TSINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
@@ -101,7 +101,6 @@ class TSMADD_Test extends PredisCommandTestCase
         $redis = $this->getClient();
 
         $this->expectException(ServerException::class);
-        $this->expectExceptionMessage("ERR wrong number of arguments for 'TS.MADD' command");
 
         $redis->tsmadd('temperature:2:32', 123123123123, 27, 'temperature:2:33', 123123123124);
     }

--- a/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
@@ -63,6 +63,7 @@ class TSMADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSMGET_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMGET_Test.php
@@ -61,6 +61,7 @@ class TSMGET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
@@ -60,6 +60,7 @@ class TSMRANGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
@@ -60,6 +60,7 @@ class TSMREVRANGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.4.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSQUERYINDEX_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSQUERYINDEX_Test.php
@@ -54,6 +54,7 @@ class TSQUERYINDEX_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
@@ -61,6 +61,7 @@ class TSRANGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
@@ -61,6 +61,7 @@ class TSREVRANGE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisTimeSeriesVersion >= 1.0.0
      */

--- a/tests/Predis/Command/Redis/TopK/TOPKADD_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKADD_Test.php
@@ -61,6 +61,7 @@ class TOPKADD_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider structuresProvider
      * @param  array $reserveArguments
      * @param  array $addArguments

--- a/tests/Predis/Command/Redis/TopK/TOPKINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINCRBY_Test.php
@@ -61,6 +61,7 @@ class TOPKINCRBY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
@@ -73,9 +73,10 @@ class TOPKINFO_Test extends PredisCommandTestCase
 
         $redis->topkreserve('key', 50);
 
-        $this->assertEquals(
+        $this->assertSameWithPrecision(
             ['k' => 50, 'width' => 8, 'depth' => 7, 'decay' => '0.90000000000000002'],
-            $redis->topkinfo('key')
+            $redis->topkinfo('key'),
+            1
         );
     }
 

--- a/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
@@ -64,6 +64,7 @@ class TOPKINFO_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/TopK/TOPKLIST_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKLIST_Test.php
@@ -63,6 +63,7 @@ class TOPKLIST_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider structureProvider
      * @param  array $reserveArguments
      * @param  array $addArguments

--- a/tests/Predis/Command/Redis/TopK/TOPKQUERY_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKQUERY_Test.php
@@ -61,6 +61,7 @@ class TOPKQUERY_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @return void
      * @requiresRedisBfVersion >= 2.0.0
      */

--- a/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
@@ -77,7 +77,7 @@ class TOPKRESERVE_Test extends PredisCommandTestCase
         $actualInfoResponse = $redis->topkinfo($key);
 
         $this->assertEquals('OK', $actualResponse);
-        $this->assertEquals($expectedInfoResponse, $actualInfoResponse);
+        $this->assertSameWithPrecision($expectedInfoResponse, $actualInfoResponse, 1);
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
@@ -59,6 +59,7 @@ class TOPKRESERVE_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @group relay-resp3
      * @dataProvider structureProvider
      * @param  array  $topKArguments
      * @param  string $key

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,7 @@ if (file_exists(__DIR__ . '/../autoload.php')) {
 
 require __DIR__ . '/PHPUnit/ArrayHasSameValuesConstraint.php';
 require __DIR__ . '/PHPUnit/OneOfConstraint.php';
+require __DIR__ . '/PHPUnit/AssertSameWithPrecisionConstraint.php';
 require __DIR__ . '/PHPUnit/RedisCommandConstraint.php';
 require __DIR__ . '/PHPUnit/PredisTestCase.php';
 require __DIR__ . '/PHPUnit/PredisCommandTestCase.php';


### PR DESCRIPTION
This changes mostly is a cherry-pick from this commit where it's already been fixed

https://github.com/predis/predis/pull/1300/commits/21d6a5056591769dad1e9e2b87e681c5fbf47b77

RESP2 tests that shouldn't be called over Relay connection, cherry-picked here:

https://github.com/predis/predis/pull/1348/commits/dca67f2a0695708ed30115524d7d894735ecd633