### PR TITLE
Fix Redis 7 test compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,14 +62,20 @@ jobs:
       - name: Run tests
         if: ${{ matrix.php != '8.1' || matrix.redis != '7' }}
         run: vendor/bin/phpunit
+        env:
+          REDIS_VERSION: ${{ matrix.redis }}
 
       - name: Run tests with coverage
         if: ${{ matrix.php == '8.1' && matrix.redis == '7' }}
         run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-filter ./src
+        env:
+          REDIS_VERSION: ${{ matrix.redis }}
 
       - name: Run tests using Relay
         if: ${{ matrix.redis >= '6' }}
         run: vendor/bin/phpunit -c phpunit.relay.xml
+        env:
+          REDIS_VERSION: ${{ matrix.redis }}
 
       - name: Send coverage to Coveralls
         env:
@@ -121,3 +127,5 @@ jobs:
         run: |
           sleep 5 # Timeout to make sure that docker image is setup
           vendor/bin/phpunit --group cluster
+        env:
+          REDIS_VERSION: cluster

--- a/tests/Predis/Command/Redis/ACL_Test.php
+++ b/tests/Predis/Command/Redis/ACL_Test.php
@@ -93,6 +93,11 @@ class ACL_Test extends PredisCommandTestCase
      */
     public function testDryRunSimulateExecutionOfGivenCommandByUser(): void
     {
+        $version = (int) getenv('REDIS_VERSION');
+        $message = $version < 7
+            ? "This user has no permissions to run the 'get' command"
+            : "User Test has no permissions to run the 'get' command";
+
         $redis = $this->getClient();
 
         $this->assertEquals('OK', $redis->acl->setUser('Test', '+SET', '~*'));
@@ -101,7 +106,7 @@ class ACL_Test extends PredisCommandTestCase
             $redis->acl->dryRun('Test', 'SET', 'foo', 'bar')
         );
         $this->assertEquals(
-            "This user has no permissions to run the 'get' command",
+            $message,
             $redis->acl->dryRun('Test', 'GET', 'foo')
         );
     }

--- a/tests/Predis/Command/Redis/OBJECT_Test.php
+++ b/tests/Predis/Command/Redis/OBJECT_Test.php
@@ -86,10 +86,16 @@ class OBJECT_Test extends PredisCommandTestCase
      */
     public function testObjectEncoding(): void
     {
+        $version = (int) getenv('REDIS_VERSION');
+        $type = $version < 7
+            ? 'quicklist'
+            : 'listpack';
+
         $redis = $this->getClient();
 
         $redis->lpush('list:metavars', 'foo', 'bar');
-        $this->assertMatchesRegularExpression('/[zip|quick]list/', $redis->object('ENCODING', 'list:metavars'));
+
+        $this->assertSame($type, $redis->object('ENCODING', 'list:metavars'));
     }
 
     /**


### PR DESCRIPTION
`testObjectEncoding`
Make expected type explicitly depending on Redis version.

`testDryRunSimulateExecutionOfGivenCommandByUser`
Align message with new format on Redis 7.