### PR TITLE
ClientInterface: using set with NX flag can return null

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -155,7 +155,7 @@ use Predis\Response\Status;
  * @method mixed             mset(array $dictionary)
  * @method int               msetnx(array $dictionary)
  * @method Status            psetex(string $key, $milliseconds, $value)
- * @method Status            set(string $key, $value, $expireResolution = null, $expireTTL = null, $flag = null)
+ * @method Status|null       set(string $key, $value, $expireResolution = null, $expireTTL = null, $flag = null)
  * @method int               setbit(string $key, $offset, $value)
  * @method Status            setex(string $key, $seconds, $value)
  * @method int               setnx(string $key, $value)


### PR DESCRIPTION
Calling `$client->set('key', '1', 'EX', 7200, 'NX')` for a key that is already set will return null instead of Status