### PR TITLE
Feature/client info param

### DIFF
--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -175,7 +175,7 @@ class Factory implements FactoryInterface
             );
         }
 
-        if (!$connection instanceof RelayConnection) {
+        if ($parameters->client_info ?? false && !$connection instanceof RelayConnection) {
             $connection->addConnectCommand(
                 new RawCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])
             );

--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -31,6 +31,7 @@ namespace Predis\Connection;
  * @property string $database           Database index (see the SELECT command).
  * @property bool   $async_connect      Performs the connect() operation asynchronously.
  * @property bool   $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
+ * @property bool   $client_info        Whether to set LIB-NAME and LIB-VER when connecting.
  * @property bool   $cache              (Relay only) Whether to use in-memory caching.
  * @property string $serializer         (Relay only) Serializer used for data serialization.
  * @property string $compression        (Relay only) Algorithm used for data compression.

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1258,9 +1258,24 @@ class ClientTest extends PredisTestCase
      * @group relay-incompatible
      * @requiresRedisVersion >= 7.2.0
      */
-    public function testSetClientInfoOnConnection(): void
+    public function testDoNoSetClientInfoOnConnection(): void
     {
         $client = new Client($this->getParameters());
+        $libName = $client->client('LIST')[0]['lib-name'];
+        $libVer = $client->client('LIST')[0]['lib-ver'];
+
+        $this->assertEmpty($libName);
+        $this->assertEmpty($libVer);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisVersion >= 7.2.0
+     */
+    public function testSetClientInfoOnConnectionWhenEnabled(): void
+    {
+        $client = new Client($this->getParameters(['client_info' => true]));
         $libName = $client->client('LIST')[0]['lib-name'];
         $libVer = $client->client('LIST')[0]['lib-ver'];
 

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -12,8 +12,6 @@
 
 namespace Predis\Connection;
 
-use Predis\Client;
-use Predis\Command\RawCommand;
 use PredisTestCase;
 use ReflectionObject;
 use stdClass;
@@ -304,12 +302,10 @@ class FactoryTest extends PredisTestCase
             ->method('getParameters')
             ->willReturn($parameters);
         $connection
-            ->expects($this->exactly(4))
+            ->expects($this->exactly(2))
             ->method('addConnectCommand')
             ->withConsecutive(
                 [$this->isRedisCommand('AUTH', ['foobar'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])],
                 [$this->isRedisCommand('SELECT', ['0'])]
             );
 
@@ -335,13 +331,9 @@ class FactoryTest extends PredisTestCase
         $connection->expects($this->once())
             ->method('getParameters')
             ->will($this->returnValue($parameters));
-        $connection->expects($this->exactly(3))
+        $connection->expects($this->once())
             ->method('addConnectCommand')
-            ->withConsecutive(
-                [$this->isRedisCommand('AUTH', ['foobar'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])]
-            );
+            ->with($this->isRedisCommand('AUTH', ['foobar']));
 
         $factory = new Factory();
 
@@ -366,13 +358,9 @@ class FactoryTest extends PredisTestCase
         $connection->expects($this->once())
             ->method('getParameters')
             ->will($this->returnValue($parameters));
-        $connection->expects($this->exactly(3))
+        $connection->expects($this->once())
             ->method('addConnectCommand')
-            ->withConsecutive(
-                [$this->isRedisCommand('AUTH', ['myusername', 'foobar'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])]
-            );
+            ->with($this->isRedisCommand('AUTH', ['myusername', 'foobar']));
 
         $factory = new Factory();
 
@@ -396,12 +384,8 @@ class FactoryTest extends PredisTestCase
         $connection->expects($this->once())
             ->method('getParameters')
             ->will($this->returnValue($parameters));
-        $connection->expects($this->exactly(2))
-            ->method('addConnectCommand')
-            ->withConsecutive(
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])]
-            );
+        $connection->expects($this->never())
+            ->method('addConnectCommand');
 
         $factory = new Factory();
 
@@ -426,12 +410,8 @@ class FactoryTest extends PredisTestCase
         $connection->expects($this->once())
             ->method('getParameters')
             ->will($this->returnValue($parameters));
-        $connection->expects($this->exactly(2))
-            ->method('addConnectCommand')
-            ->withConsecutive(
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])],
-                [$this->isRedisCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])]
-            );
+        $connection->expects($this->never())
+            ->method('addConnectCommand');
 
         $factory = new Factory();
 
@@ -564,7 +544,7 @@ class FactoryTest extends PredisTestCase
      */
     public function testSetClientNameAndVersionOnConnection(): void
     {
-        $parameters = [];
+        $parameters = ['client_info' => true];
 
         $factory = new Factory();
         $connection = $factory->create($parameters);

--- a/tests/Predis/Connection/FactoryTest.php
+++ b/tests/Predis/Connection/FactoryTest.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Connection;
 
+use Predis\Client;
+use Predis\Command\RawCommand;
 use PredisTestCase;
 use ReflectionObject;
 use stdClass;


### PR DESCRIPTION
Quick fix for #1370 and #1347.

According to the `CLIENT SETINFO` docs:
>Client libraries are expected to pipeline this command after authentication on all connections and ignore failures since they could be connected to an older version that doesn't support them.

We don't do that.