### PR TITLE
Fix prefix error if prefix equals a php command

### DIFF
--- a/src/Configuration/Option/Prefix.php
+++ b/src/Configuration/Option/Prefix.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Configuration\Option;
 
+use Closure;
 use Predis\Command\Processor\KeyPrefixProcessor;
 use Predis\Command\Processor\ProcessorInterface;
 use Predis\Configuration\OptionInterface;
@@ -28,7 +29,7 @@ class Prefix implements OptionInterface
      */
     public function filter(OptionsInterface $options, $value)
     {
-        if (is_callable($value)) {
+        if (is_callable($value) && (is_object($value) || $value instanceof Closure)) {
             $value = call_user_func($value, $options);
         }
 


### PR DESCRIPTION
Fix php error if prefix equals a php command like "chr" for example.

Replaced is_callable with instanceof Closure, which should preserve the desired behavior.

Hopefully better fix for #1339

