### PR TITLE
added if condition befor fclose

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -273,7 +273,10 @@ class StreamConnection extends AbstractConnection
     public function disconnect()
     {
         if ($this->isConnected()) {
-            fclose($this->getResource());
+            $resource = $this->getResource();
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
             parent::disconnect();
         }
     }


### PR DESCRIPTION
fixes fclose(): supplied resource is not a valid stream resource which (as per my understanding) may occur since PHP 8.1 if the resource was already closed (or is otherwise invalid).

- Added if condition to fclose when the resource is available. 
- This is for v1.x releases.

Fix in v2.x - https://github.com/predis/predis/pull/1199