### PR TITLE
Use Replicas For Read

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ $options    = ['cluster' => 'redis'];
 $client = new Predis\Client($parameters, $options);
 ```
 
+If your redis cluster uses replicated nodes, you can also set the `loadBalancing` option to send read commands to replicas:
+
+```php
+$options    = ['cluster' => 'redis', 'loadBalancing' => true];
+```
+Note: In the case that a node has multiple replicas, each replica node will serve a subset of the primary's slots.
+
 #### Replication ####
 
 The client can be configured to operate in a single master / multiple slaves setup to provide better

--- a/src/Configuration/Option/Cluster.php
+++ b/src/Configuration/Option/Cluster.php
@@ -17,6 +17,7 @@ use Predis\Cluster\RedisStrategy;
 use Predis\Configuration\OptionsInterface;
 use Predis\Connection\Cluster\PredisCluster;
 use Predis\Connection\Cluster\RedisCluster;
+use Predis\Replication\ReplicationStrategy;
 
 /**
  * Configures an aggregate connection used for clustering
@@ -59,7 +60,12 @@ class Cluster extends Aggregate
             case 'redis':
             case 'redis-cluster':
                 return function ($parameters, $options, $option) {
-                    return new RedisCluster($options->connections, new RedisStrategy($options->crc16));
+                    $replicationStrategy = new ReplicationStrategy();
+                    if (!$options->loadBalancing) {
+                        $replicationStrategy->disableLoadBalancing();
+                    }
+
+                    return new RedisCluster($options->connections, new RedisStrategy($options->crc16), $replicationStrategy);
                 };
 
             case 'predis':

--- a/src/Connection/Cluster/RedisCluster.php
+++ b/src/Connection/Cluster/RedisCluster.php
@@ -74,14 +74,15 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
      */
     public function __construct(
         FactoryInterface $connections,
-        StrategyInterface $strategy = null
+        StrategyInterface $strategy = null,
+        ReplicationStrategy $replicationStrategy = null
     ) {
         $this->connections = $connections;
         $this->strategy = $strategy ?: new RedisClusterStrategy();
         $this->slotmap = new SlotMap();
 
         $this->replicaSlotmap = new SlotMap();
-        $this->replicaStrategy = new ReplicationStrategy();
+        $this->replicaStrategy = $replicationStrategy ?: (new ReplicationStrategy())->disableLoadBalancing();
     }
 
     /**
@@ -296,7 +297,6 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
 
         foreach ($response as $slots) {
             [$start, $end, $master] = $slots;
-            $replicas = array_slice($slots, 3);
 
             if ($master[0] === '') {
                 $this->slotmap->setSlots($start, $end, (string) $connection);
@@ -304,14 +304,28 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
                 $this->slotmap->setSlots($start, $end, "{$master[0]}:{$master[1]}");
             }
 
-            if ($replicas) {
+            if ($this->replicaStrategy->isUsingLoadBalancing()) {
+                $replicas = array_slice($slots, 3);
                 $this->initReplicaMap($replicas, $start, $end);
             }
         }
     }
 
-    private function initReplicaMap(array $replicas, int $start, int $end)
+    /**
+     * Initializes the slot maps for any replicas.
+     *
+     * @param  array                $replicas
+     * @param  int                  $start
+     * @param  int                  $end
+     * @return void
+     * @throws OutOfBoundsException
+     */
+    private function initReplicaMap(array $replicas, int $start, int $end): void
     {
+        if (!$replicas) {
+            return;
+        }
+
         // Split up slots evenly between replicas for now
         $totalSlots = $end - $start + 1;
         $slotsPerReplica = (int) ceil($totalSlots / count($replicas));
@@ -401,7 +415,17 @@ class RedisCluster implements ClusterInterface, IteratorAggregate, Countable
         }
     }
 
-    private function getReadConnection(CommandInterface $command, int $slot)
+    /**
+     * Returns a connection to a replica if possible.
+     *
+     * @param  CommandInterface             $command
+     * @param  int                          $slot
+     * @return NodeConnectionInterface|null
+     *
+     * @throws NotSupportedException
+     * @throws OutOfBoundsException
+     */
+    private function getReadConnection(CommandInterface $command, int $slot): ?NodeConnectionInterface
     {
         $isDisallowed = $this->replicaStrategy->isDisallowedOperation($command);
         if ($isDisallowed) {

--- a/src/Replication/ReplicationStrategy.php
+++ b/src/Replication/ReplicationStrategy.php
@@ -289,4 +289,14 @@ class ReplicationStrategy
 
         return $this;
     }
+
+    /**
+     * Returns the current load balancing setting.
+     *
+     * @return bool
+     */
+    public function isUsingLoadBalancing(): bool
+    {
+        return $this->loadBalancing;
+    }
 }

--- a/tests/Predis/Configuration/Option/ClusterTest.php
+++ b/tests/Predis/Configuration/Option/ClusterTest.php
@@ -285,13 +285,15 @@ class ClusterTest extends PredisTestCase
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $options
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('__get')
             ->withConsecutive(
+                ['loadBalancing'],
                 ['connections'],
                 ['crc16']
             )
             ->willReturnOnConsecutiveCalls(
+                null,
                 $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock(),
                 $this->getMockBuilder('Predis\Cluster\Hash\HashGeneratorInterface')->getMock()
             );
@@ -311,13 +313,15 @@ class ClusterTest extends PredisTestCase
         $options = $this->getMockBuilder('Predis\Configuration\OptionsInterface')->getMock();
 
         $options
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('__get')
             ->withConsecutive(
+                ['loadBalancing'],
                 ['connections'],
                 ['crc16']
             )
             ->willReturnOnConsecutiveCalls(
+                null,
                 $this->getMockBuilder('Predis\Connection\FactoryInterface')->getMock(),
                 $this->getMockBuilder('Predis\Cluster\Hash\HashGeneratorInterface')->getMock()
             );

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Cluster;
 use Predis\Command;
 use Predis\Connection;
+use Predis\Replication\ReplicationStrategy;
 use Predis\Response;
 use PredisTestCase;
 
@@ -1438,5 +1439,127 @@ class RedisClusterTest extends PredisTestCase
         $this->AssertEqualsWithDelta($expectedTime, $totalTime, 1, 'Unexpected execution time');
 
         $this->assertCount(16384, $cluster->getSlotMap());
+    }
+
+    public function testLoadBalancingReadsFromSecondaries()
+    {
+        // Setup mock cluster connections
+        $slotsmap = [
+            [0, 5460, ['127.0.0.1', 1001], ['127.0.0.1', 2001]],
+            [5461, 10922, ['127.0.0.1', 1002], ['127.0.0.1', 2002]],
+            [10923, 16383, ['127.0.0.1', 1003], ['127.0.0.1', 2003]],
+        ];
+
+        [$cluster, $returnMap, $primaryConnections] = $this->setupMocks($slotsmap, new ReplicationStrategy());
+
+        $cluster
+            ->expects($this->exactly(3))
+            ->method('createConnection')
+            ->willReturnMap($returnMap);
+
+        // Check that the right connections are returned
+        foreach ($slotsmap as $i => $mapData) {
+            // pick a slot that belongs to this shard, e.g. the start
+            $slot = $mapData[0];
+
+            $command = new Command\RawCommand('GET', ['foo']);
+            $command->setSlot($slot);
+            $commandConnection = $cluster->getConnectionByCommand($command);
+
+            $expectedConnection = $returnMap[$i][1];
+
+            $this->assertSame($expectedConnection, $commandConnection);
+        }
+    }
+
+    /**
+     * Ensure that disabled load balancing keep the previous behavior of only using primaries.
+     */
+    public function testNoLoadBalancingReadsFromPrimaries()
+    {
+        // Setup mock cluster connections
+        $slotsmap = [
+            [0, 5460, ['127.0.0.1', 1001], ['127.0.0.1', 2001]],
+            [5461, 10922, ['127.0.0.1', 1002], ['127.0.0.1', 2002]],
+            [10923, 16383, ['127.0.0.1', 1003], ['127.0.0.1', 2003]],
+        ];
+
+        $replicationStrategy = new ReplicationStrategy();
+        $replicationStrategy->disableLoadBalancing();
+        [$cluster, $returnMap, $primaryConnections] = $this->setupMocks($slotsmap, $replicationStrategy);
+
+        // Check that the right connections are returned
+        foreach ($slotsmap as $i => $mapData) {
+            // pick a slot that belongs to this shard, e.g. the start
+            $slot = $mapData[0];
+
+            $command = new Command\RawCommand('GET', ['foo']);
+            $command->setSlot($slot);
+            $commandConnection = $cluster->getConnectionByCommand($command);
+
+            $expectedConnection = $primaryConnections[$i];
+            $this->assertSame($expectedConnection, $commandConnection);
+        }
+    }
+
+    private function setupMocks(array $slotsmap, ReplicationStrategy $replicationStrategy): array
+    {
+        // Setup mock cluster connections
+        $primaryConnections = [];
+        $returnMap = [];
+        foreach ($slotsmap as $mapData) {
+            [$start, $end, $primary, $secondary] = $mapData;
+
+            $primaryIp = $primary[0];
+            $primaryPort = $primary[1];
+            $primaryConnection = $this->getMockConnection("tcp://{$primaryIp}:{$primaryPort}");
+
+            // Mock cluster slots response
+            $primaryConnection
+            ->method('executeCommand')
+            ->with($this->isRedisCommand(
+                'CLUSTER', ['SLOTS']
+            ))
+            ->willReturn($slotsmap);
+
+            $primaryConnections[] = $primaryConnection;
+
+            $secondaryIp = $secondary[0];
+            $secondaryPort = $secondary[1];
+            $connectionId = "{$secondaryIp}:{$secondaryPort}";
+
+            $secondaryConnection = $this->getMockConnection("tcp://{$connectionId}");
+
+            $returnMap[] = [$connectionId, $secondaryConnection];
+        }
+
+        // Setup mock cluster object
+        $connections = $this->getMockBuilder(Connection\FactoryInterface::class)->getMock();
+        $connections
+            ->expects($this->never())
+            ->method('create');
+        /** @var RedisCluster|MockObject */
+        $cluster = $this->getMockBuilder(RedisCluster::class)
+            ->onlyMethods([
+                'createConnection',
+                'getRandomConnection',
+            ])
+            ->setConstructorArgs([new Connection\Factory(), null, $replicationStrategy])
+            ->getMock();
+
+        // setup mock methods
+        $cluster
+            ->expects($this->once())
+            ->method('getRandomConnection')
+            ->willReturnOnConsecutiveCalls(...$primaryConnections);
+
+        foreach ($primaryConnections as $primaryConnection) {
+            $cluster->add($primaryConnection);
+        }
+
+        // Init slot map
+        $cluster->askSlotMap();
+
+        return [$cluster, $returnMap, $primaryConnections];
     }
 }

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -12,7 +12,6 @@
 
 namespace Predis\Connection\Cluster;
 
-use Iterator;
 use OutOfBoundsException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Cluster;
@@ -1480,7 +1479,7 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Ensure that disabled load balancing keep the previous behavior of only using primaries.
-     * 
+     *
      * @group disconnected
      */
     public function testNoLoadBalancingReadsFromPrimaries()
@@ -1512,7 +1511,7 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Ensure that disabled load balancing keep the previous behavior of only using primaries.
-     * 
+     *
      * @group disconnected
      */
     public function testLoadBalancingWritesToPrimaries()
@@ -1619,7 +1618,7 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Cover the guard clause in getReadConnection.
-     * 
+     *
      * @group disconnected
      */
     public function testLoadBalancingSlotRange()
@@ -1636,7 +1635,7 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Coverage test for empty replica slotmap.
-     * 
+     *
      * @group disconnected
      */
     public function testLoadBalancingEmptySlotMap()

--- a/tests/Predis/Connection/Cluster/RedisClusterTest.php
+++ b/tests/Predis/Connection/Cluster/RedisClusterTest.php
@@ -1444,6 +1444,9 @@ class RedisClusterTest extends PredisTestCase
         $this->assertCount(16384, $cluster->getSlotMap());
     }
 
+    /**
+     * @group disconnected
+     */
     public function testLoadBalancingReadsFromSecondaries()
     {
         $slotsmap = [
@@ -1477,6 +1480,8 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Ensure that disabled load balancing keep the previous behavior of only using primaries.
+     * 
+     * @group disconnected
      */
     public function testNoLoadBalancingReadsFromPrimaries()
     {
@@ -1507,6 +1512,8 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Ensure that disabled load balancing keep the previous behavior of only using primaries.
+     * 
+     * @group disconnected
      */
     public function testLoadBalancingWritesToPrimaries()
     {
@@ -1514,6 +1521,9 @@ class RedisClusterTest extends PredisTestCase
         $this->checkLoadBalancingOnPrimaryCommands($command);
     }
 
+    /**
+     * @group disconnected
+     */
     public function testLoadBalancingDisallowedCommandsToPrimaries()
     {
         $command = new Command\RawCommand('INFO', []);
@@ -1609,6 +1619,8 @@ class RedisClusterTest extends PredisTestCase
 
     /**
      * Cover the guard clause in getReadConnection.
+     * 
+     * @group disconnected
      */
     public function testLoadBalancingSlotRange()
     {
@@ -1623,7 +1635,9 @@ class RedisClusterTest extends PredisTestCase
     }
 
     /**
-     * Coverage test for empty replica slotma.
+     * Coverage test for empty replica slotmap.
+     * 
+     * @group disconnected
      */
     public function testLoadBalancingEmptySlotMap()
     {


### PR DESCRIPTION
This is a proposition on how load could be balanced for replicated clusters.

See:
#595 #392 #173 #579

* Added separate pool and slot map for cluster replicas
* Use replicas to serve read requests

This adds a dependency on the replication strategy for detecting read commands. The detection could be moved to the redis cluster strategy or to a separate class included in both strategies.

Also this doesn't allow for the user to configure how the replicas should be used. Future improvements could be:
* prefer replicas for reads, fallback to primary
* randomly select between replicas and primaries to evenly distribute

This splits up the slots of the primary between replicas. Another idea would be to share the slots between all replicas and select the replica (randomly) for each command