### PR TITLE
Removed NULL assignement for username parameter

### DIFF
--- a/examples/dispatcher_loop.php
+++ b/examples/dispatcher_loop.php
@@ -30,7 +30,7 @@ $client = new Predis\Client($single_server + ['read_write_timeout' => 0]);
 $pubsub = $client->pubSubLoop();
 
 // Create a dispatcher loop instance and attach a bunch of callbacks.
-$dispatcher = new \Predis\Consumer\PubSub\DispatcherLoop($pubsub);
+$dispatcher = new Predis\Consumer\PubSub\DispatcherLoop($pubsub);
 
 // Demonstrate how to use a callable class as a callback for the dispatcher loop.
 class EventsListener implements Countable

--- a/examples/sharded_dispatcher_loop.php
+++ b/examples/sharded_dispatcher_loop.php
@@ -42,7 +42,7 @@ $client = new Client(
 $pubSub = $client->pubSubLoop();
 
 // 3. Create a dispatcher loop instance and attach a bunch of callbacks.
-$dispatcher = new \Predis\Consumer\PubSub\DispatcherLoop($pubSub);
+$dispatcher = new Predis\Consumer\PubSub\DispatcherLoop($pubSub);
 
 // 4. Demonstrate how to use a callable class as a callback for the dispatcher loop.
 class EventsListener implements Countable

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -265,14 +265,10 @@ class SentinelReplication implements ReplicationInterface
         }
 
         if (is_array($parameters)) {
-            // NOTE: sentinels do not accept AUTH and SELECT commands so we must
-            // explicitly set them to NULL to avoid problems when using default
-            // parameters set via client options. Actually AUTH is supported for
-            // sentinels starting with Redis 5 but we have to differentiate from
-            // sentinels passwords and nodes passwords, this will be implemented
-            // in a later release.
+            // NOTE: sentinels do not accept SELECT command so we must
+            // explicitly set it to NULL to avoid problems when using default
+            // parameters set via client options.
             $parameters['database'] = null;
-            $parameters['username'] = null;
 
             // don't leak password from between configurations
             // https://github.com/predis/predis/pull/807/#discussion_r985764770

--- a/tests/PHPUnit/ArrayHasSameValuesConstraint.php
+++ b/tests/PHPUnit/ArrayHasSameValuesConstraint.php
@@ -13,7 +13,7 @@
 /**
  * PHPUnit constraint matching arrays with same elements even in different order.
  */
-class ArrayHasSameValuesConstraint extends \PHPUnit\Framework\Constraint\Constraint
+class ArrayHasSameValuesConstraint extends PHPUnit\Framework\Constraint\Constraint
 {
     protected $array;
 

--- a/tests/PHPUnit/PredisTestCase.php
+++ b/tests/PHPUnit/PredisTestCase.php
@@ -21,7 +21,7 @@ use Predis\Connection;
 /**
  * Base test case class for the Predis test suite.
  */
-abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
+abstract class PredisTestCase extends PHPUnit\Framework\TestCase
 {
     protected $redisServerVersion;
     protected $redisJsonVersion;
@@ -296,7 +296,7 @@ abstract class PredisTestCase extends \PHPUnit\Framework\TestCase
         if (!is_a($interface, '\Predis\Connection\NodeConnectionInterface', true)) {
             $method = __METHOD__;
 
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Argument `\$interface` for $method() expects a type implementing Predis\Connection\NodeConnectionInterface"
             );
         }

--- a/tests/PHPUnit/RedisCommandConstraint.php
+++ b/tests/PHPUnit/RedisCommandConstraint.php
@@ -16,7 +16,7 @@ use SebastianBergmann\Exporter\Exporter;
 /**
  * PHPUnit constraint to verify that a Redis command matches certain conditions.
  */
-class RedisCommandConstraint extends \PHPUnit\Framework\Constraint\Constraint
+class RedisCommandConstraint extends PHPUnit\Framework\Constraint\Constraint
 {
     protected $commandID;
     protected $arguments;

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1264,7 +1264,7 @@ class ClientTest extends PredisTestCase
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6382');
         $connection3 = $this->getMockConnection('tcp://127.0.0.1:6383');
 
-        $aggregate = new \Predis\Connection\Cluster\PredisCluster(new Parameters());
+        $aggregate = new Connection\Cluster\PredisCluster(new Parameters());
 
         $aggregate->add($connection1);
         $aggregate->add($connection2);

--- a/tests/Predis/Connection/RelayConnectionTest.php
+++ b/tests/Predis/Connection/RelayConnectionTest.php
@@ -267,7 +267,7 @@ class RelayConnectionTest extends PredisTestCase
      */
     public function testGetResourceForcesConnection(): void
     {
-        $connection = new RelayConnection(new Parameters(), new \Relay\Relay());
+        $connection = new RelayConnection(new Parameters(), new Relay());
 
         $this->assertFalse($connection->isConnected());
         $connection->getResource();
@@ -279,7 +279,7 @@ class RelayConnectionTest extends PredisTestCase
      */
     public function testExecutesCommand(): void
     {
-        $connection = new RelayConnection(new Parameters(), new \Relay\Relay());
+        $connection = new RelayConnection(new Parameters(), new Relay());
 
         $this->assertEquals(
             'OK',
@@ -298,7 +298,7 @@ class RelayConnectionTest extends PredisTestCase
      */
     public function testConnectWithOnConnectionCommands(): void
     {
-        $connection = new RelayConnection(new Parameters(), new \Relay\Relay());
+        $connection = new RelayConnection(new Parameters(), new Relay());
         $connection->addConnectCommand(new RawCommand('CLIENT', ['SETNAME', 'predis']));
 
         $connection->connect();

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -51,17 +51,17 @@ class SentinelReplicationTest extends PredisTestCase
     /**
      * @group disconnected
      */
-    public function testParametersForSentinelConnectionShouldIgnoreDatabaseAndPassword(): void
+    public function testParametersForSentinelConnectionShouldIgnoreDatabase(): void
     {
         $replication = $this->getReplicationConnection('svc', [
-            'tcp://127.0.0.1:5381?role=sentinel&database=1&username=myusername',
+            'tcp://127.0.0.1:5381?role=sentinel&database=1&username=myusername&password=password',
         ]);
 
         $parameters = $replication->getSentinelConnection()->getParameters()->toArray();
 
         $this->assertArrayNotHasKey('database', $parameters, 'Parameter `database` was expected to not exist in connection parameters');
-        $this->assertArrayNotHasKey('username', $parameters, 'Parameter `username` was expected to not exist in connection parameters');
-        $this->assertArrayNotHasKey('password', $parameters, 'Parameter `password` was expected to not exist in connection parameters');
+        $this->assertArrayHasKey('username', $parameters, 'Parameter `username` was expected to not exist in connection parameters');
+        $this->assertArrayHasKey('password', $parameters, 'Parameter `password` was expected to not exist in connection parameters');
     }
 
     /**


### PR DESCRIPTION
Since, Redis 6.2 sentinels supports ACL authentication and AUTH command with both username and password. So for now we don't need to override username on Sentinel connections

Closes https://github.com/predis/predis/issues/1427