### PR TITLE
Limit version of php-cs-fixer >= 3.52.1 <= 3.53.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "~3.52.1",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^8.0 || ~9.4.4",
         "phpunit/phpcov": "^6.0 || ^8.0"

--- a/examples/sharded_dispatcher_loop.php
+++ b/examples/sharded_dispatcher_loop.php
@@ -35,8 +35,8 @@ $client = new Client(
         'tcp://127.0.0.1:6373?read_write_timeout=0',
         'tcp://127.0.0.1:6374?read_write_timeout=0',
     ], [
-    'cluster' => 'redis',
-]);
+        'cluster' => 'redis',
+    ]);
 
 // 2. Run pub/sub loop.
 $pubSub = $client->pubSubLoop();

--- a/examples/sharded_pubsub_consumer.php
+++ b/examples/sharded_pubsub_consumer.php
@@ -21,8 +21,8 @@ $client = new Client(
         'tcp://127.0.0.1:6373?read_write_timeout=0',
         'tcp://127.0.0.1:6374?read_write_timeout=0',
     ], [
-    'cluster' => 'redis',
-]);
+        'cluster' => 'redis',
+    ]);
 
 // 2. Run pub/sub loop. Sharded channels belongs to different shards.
 $pubSub = $client->pubSubLoop();

--- a/examples/transaction_using_cas.php
+++ b/examples/transaction_using_cas.php
@@ -32,7 +32,7 @@ function zpop($client, $key)
         'cas' => true,      // Initialize with support for CAS operations
         'watch' => $key,    // Key that needs to be WATCHed to detect changes
         'retry' => 3,       // Number of retries on aborted transactions, after
-                            // which the client bails out with an exception.
+        // which the client bails out with an exception.
     ];
 
     $client->transaction($options, function ($tx) use ($key, &$element) {

--- a/tests/Predis/Collection/Iterator/HashKeyTest.php
+++ b/tests/Predis/Collection/Iterator/HashKeyTest.php
@@ -63,7 +63,7 @@ class HashKeyTest extends PredisTestCase
             ->with('key:hash', 0, [])
             ->willReturn(
                 [0, [],
-            ]);
+                ]);
 
         $iterator = new HashKey($client, 'key:hash');
 

--- a/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
@@ -70,7 +70,7 @@ class TSINFO_Test extends PredisCommandTestCase
         $redis = $this->getClient();
         $expectedResponse = ['totalSamples', 0, 'memoryUsage', 4239, 'firstTimestamp', 0, 'lastTimestamp', 0,
             'retentionTime', 60000, 'chunkCount', 1, 'chunkSize', 4096, 'chunkType', 'compressed', 'duplicatePolicy',
-        'max', 'labels', [['sensor_id', '2'], ['area_id', '32']], 'sourceKey', null, 'rules', []];
+            'max', 'labels', [['sensor_id', '2'], ['area_id', '32']], 'sourceKey', null, 'rules', []];
 
         $arguments = (new CreateArguments())
             ->retentionMsecs(60000)

--- a/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMRANGE_Test.php
@@ -117,17 +117,17 @@ class TSMRANGE_Test extends PredisCommandTestCase
     {
         $redis = $this->getResp3Client();
         $expectedResponse = [
-                'type=stock' => [
-                    ['type' => 'stock'],
-                    ['reducers' => ['max']],
-                    ['sources' => ['stock:A', 'stock:B']],
-                    [
-                        [1000, 120],
-                        [1010, 110],
-                        [1020, 120],
-                    ],
+            'type=stock' => [
+                ['type' => 'stock'],
+                ['reducers' => ['max']],
+                ['sources' => ['stock:A', 'stock:B']],
+                [
+                    [1000, 120],
+                    [1010, 110],
+                    [1020, 120],
                 ],
-            ];
+            ],
+        ];
 
         $this->assertEquals(
             'OK',

--- a/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMREVRANGE_Test.php
@@ -118,16 +118,16 @@ class TSMREVRANGE_Test extends PredisCommandTestCase
         $redis = $this->getResp3Client();
         $expectedResponse = [
             'type=stock' => [
-                    ['type' => 'stock'],
-                    ['reducers' => ['max']],
-                    ['sources' => ['stock:A', 'stock:B']],
-                    [
-                        [1020, 120],
-                        [1010, 110],
-                        [1000, 120],
-                    ],
+                ['type' => 'stock'],
+                ['reducers' => ['max']],
+                ['sources' => ['stock:A', 'stock:B']],
+                [
+                    [1020, 120],
+                    [1010, 110],
+                    [1000, 120],
                 ],
-            ];
+            ],
+        ];
 
         $this->assertEquals(
             'OK',


### PR DESCRIPTION
Php-cs-fixer package continue constantly updating, so are codestyle rules. This leads often to CI failures and requires separate PR so it won't be mixed with actual changes. I propose to limit to the latest minor version, to avoid this codestyle changes and lately we have to choose more stable version.