### PR TITLE
Limit version of php-cs-fixer >= 3.4.0 <= 3.5.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,7 +19,6 @@ return (new PhpCsFixer\Config)
         'phpdoc_annotation_without_dot' => false,
         'no_superfluous_phpdoc_tags' => false,
         'no_unneeded_curly_braces' => false,
-        'no_unneeded_braces' => false,
         'global_namespace_import' => true,
         'yoda_style' => false,
         'single_line_throw' => false,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "~3.4.0",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^8.0 || ^9.4"
     },

--- a/src/Collection/Iterator/CursorBasedIterator.php
+++ b/src/Collection/Iterator/CursorBasedIterator.php
@@ -176,13 +176,13 @@ abstract class CursorBasedIterator implements Iterator
                 $this->fetch();
             }
 
-            if ($this->elements) {
-                $this->extractNext();
-            } elseif ($this->cursor) {
-                goto tryFetch;
-            } else {
-                $this->valid = false;
-            }
+        if ($this->elements) {
+            $this->extractNext();
+        } elseif ($this->cursor) {
+            goto tryFetch;
+        } else {
+            $this->valid = false;
+        }
     }
 
     /**

--- a/tests/Predis/Command/Redis/GEOSEARCH_Test.php
+++ b/tests/Predis/Command/Redis/GEOSEARCH_Test.php
@@ -186,7 +186,7 @@ class GEOSEARCH_Test extends PredisCommandTestCase
                 [
                     'member1' => ['lng' => 1.1, 'lat' => 2.2],
                     'member2' => ['lng' => 2.2, 'lat' => 3.3],
-                    'member3' => ['lng' => 3.3, 'lat' => 4.4]],
+                    'member3' => ['lng' => 3.3, 'lat' => 4.4], ],
             ],
             'with WITHDIST modifier' => [
                 [['member1', '111.111'], ['member2', '222.222'], ['member3', '333.333']],

--- a/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
@@ -70,7 +70,7 @@ class TSINFO_Test extends PredisCommandTestCase
         $redis = $this->getClient();
         $expectedResponse = ['totalSamples', 0, 'memoryUsage', 4239, 'firstTimestamp', 0, 'lastTimestamp', 0,
             'retentionTime', 60000, 'chunkCount', 1, 'chunkSize', 4096, 'chunkType', 'compressed', 'duplicatePolicy',
-        'max', 'labels', [['sensor_id', '2'], ['area_id', '32']], 'sourceKey', null, 'rules', []];
+        'max', 'labels', [['sensor_id', '2'], ['area_id', '32']], 'sourceKey', null, 'rules', [], ];
 
         $arguments = (new CreateArguments())
             ->retentionMsecs(60000)


### PR DESCRIPTION
Php-cs-fixer package continue constantly updating, so are codestyle rules. This leads often to CI failures and requires separate PR so it won't be mixed with actual changes. I propose to limit to the latest minor version, to avoid this codestyle changes and lately we have to choose more stable version.