### PR TITLE
Fix prefix for GEOSEARCH

### DIFF
--- a/src/Command/Processor/KeyPrefixProcessor.php
+++ b/src/Command/Processor/KeyPrefixProcessor.php
@@ -198,6 +198,7 @@ class KeyPrefixProcessor implements ProcessorInterface
             /* ---------------- Redis 6.2 ---------------- */
             'GETDEL' => $prefixFirst,
             'ZMSCORE' => $prefixFirst,
+            'GEOSEARCH' => $prefixFirst,
 
             /* ---------------- Redis 7.0 ---------------- */
             'EXPIRETIME' => $prefixFirst,


### PR DESCRIPTION
closes  [#1286](https://github.com/predis/predis/issues/1286)