### PR TITLE
keep key and value when filtering SET arguments

### DIFF
--- a/src/Command/Redis/SET.php
+++ b/src/Command/Redis/SET.php
@@ -29,7 +29,16 @@ class SET extends RedisCommand
 
     public function setArguments(array $arguments)
     {
+        foreach ($arguments as $index => $value) {
+            if ($index < 2) {
+                continue;
+            }
+
+            if (false === $value || null === $value) {
+                unset($arguments[$index]);
+            }
+        }
+
         parent::setArguments($arguments);
-        $this->filterArguments();
     }
 }

--- a/tests/Predis/Command/Redis/SET_Test.php
+++ b/tests/Predis/Command/Redis/SET_Test.php
@@ -190,6 +190,32 @@ class SET_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @requiresRedisVersion >= 2.6.12
+     */
+    public function testSetNull(): void
+    {
+        $redis = $this->getClient();
+
+        $this->assertEquals(
+            'OK', $redis->set('foo', null)
+        );
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 2.6.12
+     */
+    public function testSetFalse(): void
+    {
+        $redis = $this->getClient();
+
+        $this->assertEquals(
+            'OK', $redis->set('foo', false)
+        );
+    }
+
+    /**
+     * @group connected
      * @group cluster
      * @requiresRedisVersion >= 6.0.0
      */


### PR DESCRIPTION
With the changes done in #1470 the value that is going to be set is also filtered which prevents setting a key to `false` or `null`.