### PR TITLE
Mark GEOSEARCH as read-only to ensure execution on replica instead of…

### DIFF
--- a/src/Replication/ReplicationStrategy.php
+++ b/src/Replication/ReplicationStrategy.php
@@ -274,6 +274,7 @@ class ReplicationStrategy
             'GEODIST' => true,
             'GEORADIUS' => [$this, 'isGeoradiusReadOnly'],
             'GEORADIUSBYMEMBER' => [$this, 'isGeoradiusReadOnly'],
+            'GEOSEARCH' => true,
         ];
     }
 

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -217,7 +217,6 @@ class ReplicationStrategyTest extends PredisTestCase
         );
     }
 
-
     /**
      * @group disconnected
      */

--- a/tests/Predis/Replication/ReplicationStrategyTest.php
+++ b/tests/Predis/Replication/ReplicationStrategyTest.php
@@ -13,6 +13,8 @@
 namespace Predis\Replication;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Predis\Command\Argument\Geospatial\ByRadius;
+use Predis\Command\Argument\Geospatial\FromLonLat;
 use Predis\Command\CommandInterface;
 use PredisTestCase;
 
@@ -212,6 +214,22 @@ class ReplicationStrategyTest extends PredisTestCase
         $this->assertFalse(
             $strategy->isReadOperation($command),
             'GEORADIUSBYMEMBER with STOREDIST is expected to be a write operation.'
+        );
+    }
+
+
+    /**
+     * @group disconnected
+     */
+    public function testGeosearchCommand(): void
+    {
+        $commands = $this->getCommandFactory();
+        $strategy = new ReplicationStrategy();
+        $geoSearchArgs = ['key', new FromLonLat(1.1, 2.2), new ByRadius(1, 'km')];
+        $command = $commands->create('GEOSEARCH', $geoSearchArgs);
+        $this->assertTrue(
+            $strategy->isReadOperation($command),
+            'GEOSEARCH is expected to be a read operation.'
         );
     }
 


### PR DESCRIPTION
This update modifies the behavior of the GEOSEARCH command by marking it as a read-only operation. This ensures that the command is routed to and executed on a replica node rather than the master, improving load distribution and preventing unnecessary commands on the master. The change is designed to enhance performance in environments using Redis replication.