### PR TITLE
Add TOPK.COUNT command

### DIFF
--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -243,6 +243,7 @@ use Predis\Command\Redis\Container\Search\FTCURSOR;
  * @method $this tdigestrevrank(string $key, float ...$value)
  * @method $this tdigesttrimmed_mean(string $key, float $lowCutQuantile, float $highCutQuantile)
  * @method $this topkadd(string $key, ...$items)
+ * @method $this topkcount(string $key, ...$items)
  * @method $this topkincrby(string $key, ...$itemIncrement)
  * @method $this topkinfo(string $key)
  * @method $this topklist(string $key, bool $withCount = false)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -253,6 +253,7 @@ use Predis\Response\Status;
  * @method array             tdigestrevrank(string $key, float ...$value)
  * @method string            tdigesttrimmed_mean(string $key, float $lowCutQuantile, float $highCutQuantile)
  * @method array             topkadd(string $key, ...$items)
+ * @method array             topkcount(string $key, ...$items)
  * @method array             topkincrby(string $key, ...$itemIncrement)
  * @method array             topkinfo(string $key)
  * @method array             topklist(string $key, bool $withCount = false)

--- a/src/Command/Redis/TopK/TOPKCOUNT.php
+++ b/src/Command/Redis/TopK/TOPKCOUNT.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2023 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Predis\Command\Redis\TopK;
+use Predis\Command\Command as RedisCommand;
+/**
+ * @see https://redis.io/commands/topk.count/
+ *
+ * Fetches counts for passed list of items if they are in the Top-K list.
+ * Multiple items can be queried at once.
+ */
+class TOPKCOUNT extends RedisCommand
+{
+    public function getId()
+    {
+        return 'TOPK.COUNT';
+    }
+}


### PR DESCRIPTION
I'm starting to use TOPK for some work in our application and noticed that TOPK.COUNT was missing. It'll be handy for us to check some thresholds so I figured I could add it.

If this could be baked into a 2.x release soonish I would love it, otherwise we'll have to use my fork for a while.