### PR TITLE
refactor: use parallel on `PHP-CS-Fixer`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 $PREDIS_HEADER = <<<EOS
 This file is part of the Predis package.
 
@@ -11,6 +13,7 @@ file that was distributed with this source code.
 EOS;
 
 return (new PhpCsFixer\Config)
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
         '@PHP71Migration' => true,
         'header_comment' => ['header' => $PREDIS_HEADER],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,7 +1,5 @@
 <?php
 
-use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
-
 $PREDIS_HEADER = <<<EOS
 This file is part of the Predis package.
 
@@ -12,24 +10,23 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOS;
 
-return (new PhpCsFixer\Config)
-    ->setParallelConfig(ParallelConfigFactory::detect())
-    ->setRules([
-        '@PHP71Migration' => true,
-        'header_comment' => ['header' => $PREDIS_HEADER],
-        '@Symfony' => true,
-        'phpdoc_separation' => false,
-        'phpdoc_annotation_without_dot' => false,
-        'no_superfluous_phpdoc_tags' => false,
-        'no_unneeded_curly_braces' => false,
-        'no_unneeded_braces' => false,
-        'global_namespace_import' => true,
-        'yoda_style' => false,
-        'single_line_throw' => false,
-        'concat_space' => ['spacing' => 'one'],
-        'increment_style' => false,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays']]
-    ])
+$fixer = new PhpCsFixer\Config;
+$fixer->setRules([
+    '@PHP71Migration' => true,
+    'header_comment' => ['header' => $PREDIS_HEADER],
+    '@Symfony' => true,
+    'phpdoc_separation' => false,
+    'phpdoc_annotation_without_dot' => false,
+    'no_superfluous_phpdoc_tags' => false,
+    'no_unneeded_curly_braces' => false,
+    'no_unneeded_braces' => false,
+    'global_namespace_import' => true,
+    'yoda_style' => false,
+    'single_line_throw' => false,
+    'concat_space' => ['spacing' => 'one'],
+    'increment_style' => false,
+    'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays']]
+])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__ . '/bin')
@@ -37,3 +34,9 @@ return (new PhpCsFixer\Config)
             ->in(__DIR__ . '/src')
             ->in(__DIR__ . '/tests')
     );
+
+if (PHP_VERSION_ID >= 70400) {
+    $fixer->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+}
+
+return $fixer;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,11 @@ file that was distributed with this source code.
 EOS;
 
 $fixer = new PhpCsFixer\Config;
+
+$fixer->setParallelConfig(
+    \PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect()
+);
+
 $fixer->setRules([
     '@PHP71Migration' => true,
     'header_comment' => ['header' => $PREDIS_HEADER],
@@ -34,9 +39,5 @@ $fixer->setRules([
             ->in(__DIR__ . '/src')
             ->in(__DIR__ . '/tests')
     );
-
-if (PHP_VERSION_ID >= 70400) {
-    $fixer->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
-}
 
 return $fixer;


### PR DESCRIPTION
Without parallel:
```bash
$ composer style
> php-cs-fixer fix --diff --dry-run
PHP CS Fixer 3.64.0 Space Sets by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.13
Running analysis on 1 core sequentially.
You can enable parallel runner and speed up the analysis! Please see usage docs for more information.
Loaded config default from "D:\Project\laragon\www\predis\.php-cs-fixer.dist.php".
 1071/1076 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░]  99%   1) src\Client.php
      ---------- begin diff ----------
--- D:\Project\laragon\www\predis\src\Client.php
+++ D:\Project\laragon\www\predis\src\Client.php
@@ -472,7 +472,7 @@
      *
      * @return Pipeline|array
      */
-    protected function createPipeline(array $options = null, $callable = null)
+    protected function createPipeline(?array $options = null, $callable = null)
     {
         if (isset($options['atomic']) && $options['atomic']) {
             $class = Atomic::class;

      ----------- end diff -----------


Found 1 of 1076 files that can be fixed in 52.695 seconds, 26.00 MB memory used
 1076/1076 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Script php-cs-fixer fix --diff --dry-run handling the style event returned with error code 8
```

With parallel:
```bash
$ composer style
> php-cs-fixer fix --diff --dry-run
PHP CS Fixer 3.64.0 Space Sets by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.13
Running analysis on 4 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config default from "D:\Project\laragon\www\predis\.php-cs-fixer.dist.php".
 1076/1076 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

   1) src\Client.php
      ---------- begin diff ----------
--- D:\Project\laragon\www\predis\src\Client.php
+++ D:\Project\laragon\www\predis\src\Client.php
@@ -472,7 +472,7 @@
      *
      * @return Pipeline|array
      */
-    protected function createPipeline(array $options = null, $callable = null)
+    protected function createPipeline(?array $options = null, $callable = null)
     {
         if (isset($options['atomic']) && $options['atomic']) {
             $class = Atomic::class;

      ----------- end diff -----------


Found 1 of 1076 files that can be fixed in 17.150 seconds, 20.00 MB memory used
Script php-cs-fixer fix --diff --dry-run handling the style event returned with error code 8
```