### PR TITLE
Check if data is countable

### DIFF
--- a/src/Command/Redis/ZRANGE.php
+++ b/src/Command/Redis/ZRANGE.php
@@ -92,12 +92,13 @@ class ZRANGE extends RedisCommand
     {
         if ($this->withScores()) {
             $result = [];
-
-            for ($i = 0; $i < count($data); ++$i) {
-                if (is_array($data[$i])) {
-                    $result[$data[$i][0]] = $data[$i][1]; // Relay
-                } else {
-                    $result[$data[$i]] = $data[++$i];
+            if (is_countable($data)) {
+                for ($i = 0; $i < count($data); ++$i) {
+                    if (is_array($data[$i])) {
+                        $result[$data[$i][0]] = $data[$i][1]; // Relay
+                    } else {
+                        $result[$data[$i]] = $data[++$i];
+                    }
                 }
             }
 


### PR DESCRIPTION
Hi,

Every once in a while we see this in our logs where Redis seems to be returning data that is not countable. 

If I check if the data is_countable prior prior to the loop it fixes it. 


[2024-12-05 15:23:03] worker.ERROR: count(): Argument #1 ($value) must be of type Countable|array, int given {"exception":"[object] (TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, int given at /home/ss/application/vendor/predis/predis/src/Command/Redis/ZRANGE.php:96)
[stacktrace]
#0 /home/ss/application/vendor/predis/predis/src/Command/Redis/ZRANGE.php(96): count(0)
#1 /home/ss/application/vendor/predis/predis/src/Client.php(391): Predis\\Command\\Redis\\ZRANGE->parseResponse(0)