### PR TITLE
PHP 8.4.0 compatibility with call to stream_context_set_option

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -211,10 +211,18 @@ class StreamConnection extends AbstractConnection
             $options['crypto_type'] = STREAM_CRYPTO_METHOD_TLS_CLIENT;
         }
 
-        if (!stream_context_set_option($resource, ['ssl' => $options])) {
+        $rtn_context_option = false;
+
+        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
+            $rtn_context_option = stream_context_set_options($resource, ['ssl' => $options]);
+        } else {
+            $rtn_context_option = stream_context_set_option($resource, ['ssl' => $options]);
+        }
+        
+        if (!$rtn_context_option) {
             $this->onConnectionError('Error while setting SSL context options');
         }
-
+        
         if (!stream_socket_enable_crypto($resource, true, $options['crypto_type'])) {
             $this->onConnectionError('Error while switching to encrypted communication');
         }

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -211,15 +211,11 @@ class StreamConnection extends AbstractConnection
             $options['crypto_type'] = STREAM_CRYPTO_METHOD_TLS_CLIENT;
         }
 
-        $rtn_context_option = false;
+        $context_options = function_exists('stream_context_set_options')
+            ? stream_context_set_options($resource, ['ssl' => $options])
+            : stream_context_set_option($resource, ['ssl' => $options]);
 
-        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
-            $rtn_context_option = stream_context_set_options($resource, ['ssl' => $options]);
-        } else {
-            $rtn_context_option = stream_context_set_option($resource, ['ssl' => $options]);
-        }
-
-        if (!$rtn_context_option) {
+        if (!$context_options) {
             $this->onConnectionError('Error while setting SSL context options');
         }
 

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -218,11 +218,11 @@ class StreamConnection extends AbstractConnection
         } else {
             $rtn_context_option = stream_context_set_option($resource, ['ssl' => $options]);
         }
-        
+
         if (!$rtn_context_option) {
             $this->onConnectionError('Error while setting SSL context options');
         }
-        
+
         if (!stream_socket_enable_crypto($resource, true, $options['crypto_type'])) {
             $this->onConnectionError('Error while switching to encrypted communication');
         }


### PR DESCRIPTION
PHP 8.4.0 deprecated calls to stream_context_set_option with 2 arguments. Use stream_context_set_options function instead. Although the function is only deprecated, this will remove the deprecation message.