### PR TITLE
fix command RPUSHX

### DIFF
--- a/src/Command/Redis/RPUSHX.php
+++ b/src/Command/Redis/RPUSHX.php
@@ -26,4 +26,14 @@ class RPUSHX extends RedisCommand
     {
         return 'RPUSHX';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setArguments(array $arguments)
+    {
+        $arguments = self::normalizeVariadic($arguments);
+
+        parent::setArguments($arguments);
+    }
 }


### PR DESCRIPTION
Closes #1504.

code from test:

```php
try {
    $this->client->rpushx($key, [$value]);
} catch (Throwable $throwable){
    echo sprintf("\n\n\ncode: %s, message: %s\n\n\n", $throwable->getCode(), $throwable->getMessage());
}
```

result: code: 0, message: call_user_func(): Argument https://github.com/predis/predis/issues/1 ($callback) must be a valid callback, class "PHPUnit\Util\ErrorHandler" not found