### PR TITLE
CommandFactory: reject named arguments as those are not supported

### DIFF
--- a/src/Command/Factory.php
+++ b/src/Command/Factory.php
@@ -67,6 +67,18 @@ abstract class Factory implements FactoryInterface
             throw new ClientException("Command `$commandID` is not a registered Redis command.");
         }
 
+        $containsNamedArgument = array_reduce(
+            array_keys($arguments),
+            static function (bool $carry, $key): bool {
+                return $carry || is_string($key);
+            },
+            false
+        );
+
+        if ($containsNamedArgument) {
+            throw new ClientException('Named arguments are not supported.');
+        }
+
         $command = new $commandClass();
         $command->setArguments($arguments);
 

--- a/tests/Predis/Command/Redis/SET_Test.php
+++ b/tests/Predis/Command/Redis/SET_Test.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\ClientException;
+
 /**
  * @group commands
  * @group realm-string
@@ -199,6 +201,23 @@ class SET_Test extends PredisCommandTestCase
         $this->assertEquals(
             'OK', $redis->set('foo', null)
         );
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 2.6.12
+     */
+    public function testNamedArguments(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Named arguments require PHP 8.0 or newer');
+        }
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Named arguments are not supported.');
+
+        $redis = $this->getClient();
+        $redis->set('foo', value: null); // would fail without named arguments validation
     }
 
     /**


### PR DESCRIPTION
Since predis [2.3.0](https://github.com/predis/predis/releases/tag/v2.3.0), named arguments are not supported (at least in `SET` command) due to [this change](https://github.com/predis/predis/pull/1471/files) as the `value` argument does not meet [the condition there](https://github.com/predis/predis/pull/1471/files#diff-786e3de4bbf9be306c2c5a6aba6933c6fc3fb7aa1de753be55f5b8a4cb519858R33).

At first, I was about to fix this by supporting it inside `SET::setArguments`, but as all the command calls are implemented via `__call`, I believe it is safer to rely on the fact that your users are not using named arguments at all.