### PR TITLE
Prevent named arguments runtime failure

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -375,6 +375,8 @@ use Predis\Response\Status;
  * @property FTCURSOR          $ftcursor
  * @property JSONDEBUG         $jsondebug
  * @property ACL               $acl
+ *
+ * @no-named-arguments
  */
 interface ClientInterface
 {


### PR DESCRIPTION
This is a followup of https://github.com/predis/predis/pull/1508. As we fail hard upon named argument usage during runtime, I think we should also fail within CI (PHPStan / Psalm analysis) to mitigate the risk of missing testcase and failing in production.

See playground: https://phpstan.org/r/f166adcf-c05c-47d5-ae9a-1e638043d186