### PR TITLE
Treat LOADING Errors as Connection Failures to Retry with Next Replica

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -715,6 +715,9 @@ class SentinelReplication extends AbstractAggregateConnection implements Replica
         while ($retries <= $this->retryLimit) {
             try {
                 $response = $this->getConnectionByCommand($command)->$method($command);
+                if ($response instanceof Error && $response->getErrorType() === 'LOADING') {
+                    throw new ConnectionException($this->current, $response->getMessage());
+                }
                 break;
             } catch (CommunicationException $exception) {
                 $this->wipeServerList();


### PR DESCRIPTION
https://github.com/predis/predis/issues/1144

Treat LOADING error responses as ConnectionException to allow retry mechanism to discard the current replica and switch to the next available one.
