### PR TITLE
Added support for UNLINK command

### DIFF
--- a/src/Command/Redis/UNLINK.php
+++ b/src/Command/Redis/UNLINK.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2025 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Command\PrefixableCommand as RedisCommand;
+
+/**
+ * @see http://redis.io/commands/unlink
+ */
+class UNLINK extends RedisCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return 'UNLINK';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
+    }
+}

--- a/tests/Predis/Command/Redis/UNLINK_Test.php
+++ b/tests/Predis/Command/Redis/UNLINK_Test.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2025 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command\Redis;
+
+use Predis\Command\PrefixableCommand;
+
+/**
+ * @group commands
+ * @group realm-key
+ */
+class UNLINK_Test extends PredisCommandTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommand(): string
+    {
+        return 'Predis\Command\Redis\UNLINK';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedId(): string
+    {
+        return 'UNLINK';
+    }
+
+    /**
+     * @group disconnected
+     * @requiresRedisVersion >= 4.0.0
+     */
+    public function testFilterArguments(): void
+    {
+        $arguments = ['key1', 'key2', 'key3'];
+        $expected = ['key1', 'key2', 'key3'];
+
+        $command = $this->getCommand();
+        $command->setArguments($arguments);
+        $this->assertSame($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     * @requiresRedisVersion >= 4.0.0
+     */
+    public function testFilterArgumentsAsSingleArray(): void
+    {
+        $arguments = [['key1', 'key2', 'key3']];
+        $expected = ['key1', 'key2', 'key3'];
+
+        $command = $this->getCommand();
+        $command->setArguments($arguments);
+
+        $this->assertSame($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     * @requiresRedisVersion >= 4.0.0
+     */
+    public function testParseResponse(): void
+    {
+        $command = $this->getCommand();
+
+        $this->assertSame(10, $command->parseResponse(10));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'prefix:arg3', 'prefix:arg4'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 4.0.0
+     */
+    public function testReturnsNumberOfDeletedKeys(): void
+    {
+        $redis = $this->getClient();
+
+        $this->assertSame(0, $redis->unlink('foo'));
+
+        $redis->set('foo', 'bar');
+        $this->assertSame(1, $redis->unlink('foo'));
+
+        $redis->set('foo', 'bar');
+        $this->assertSame(1, $redis->unlink('foo', 'hoge'));
+
+        $redis->set('foo', 'bar');
+        $redis->set('hoge', 'piyo');
+        $this->assertSame(2, $redis->unlink('foo', 'hoge'));
+    }
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 6.0.0
+     */
+    public function testReturnsNumberOfDeletedKeysResp3(): void
+    {
+        $redis = $this->getResp3Client();
+
+        $this->assertSame(0, $redis->unlink('foo'));
+
+        $redis->set('foo', 'bar');
+        $this->assertSame(1, $redis->unlink('foo'));
+
+        $redis->set('foo', 'bar');
+        $this->assertSame(1, $redis->unlink('foo', 'hoge'));
+
+        $redis->set('foo', 'bar');
+        $redis->set('hoge', 'piyo');
+        $this->assertSame(2, $redis->unlink('foo', 'hoge'));
+    }
+}


### PR DESCRIPTION
I initially implemented this against 2.4.0 at work, so this is from memory. I also guessed at the test implementation, basically just copying the DEL tests.

If not exactly this, something like this should be done to allow UNLINK to work. A similar change should likely be make against the 2.x branch.