### PR TITLE
Fix return type for ZCOUNT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## Unreleased
+### Fixed
+- Fixed return type for `ZCOUNT` to be `int`
+
 ## v2.4.0 (2025-04-30)
 ### Added
 - Added new hash-field expiration commands (#1520)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -300,7 +300,7 @@ use Predis\Response\Status;
  * @method array|null        xread(int $count = null, int $block = null, array $streams = null, string ...$id)
  * @method int               zadd(string $key, array $membersAndScoresDictionary)
  * @method int               zcard(string $key)
- * @method string            zcount(string $key, int|string $min, int|string $max)
+ * @method int               zcount(string $key, int|string $min, int|string $max)
  * @method array             zdiff(array $keys, bool $withScores = false)
  * @method int               zdiffstore(string $destination, array $keys)
  * @method string            zincrby(string $key, int $increment, string $member)


### PR DESCRIPTION
ZCOUNT returns an `int`:

> Integer reply: the number of members in the specified score range.