### PR TITLE
fix(stream): Fixed return type to match function signature

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -145,7 +145,7 @@ class StreamConnection extends AbstractConnection
         $stream = $this->getResource();
 
         if ($stream->eof()) {
-            $this->onStreamError(new RuntimeException('Stream is already at the end'), '');
+            $this->onStreamError(new RuntimeException('', 1), 'Stream is already at the end');
         }
 
         try {

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -15,6 +15,7 @@ namespace Predis\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use Predis\Client;
 use Predis\Command\RawCommand;
+use Predis\CommunicationException;
 use Predis\Connection\Resource\Exception\StreamInitException;
 use Predis\Connection\Resource\StreamFactoryInterface;
 use Predis\Consumer\Push\PushResponse;
@@ -463,7 +464,7 @@ class StreamConnectionTest extends PredisConnectionTestCase
 
         $connection = new StreamConnection($parameters, $this->mockStreamFactory);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CommunicationException::class);
         $this->expectExceptionMessage('Stream is already at the end');
 
         $connection->read();


### PR DESCRIPTION
Fixing thrown exception when stream is EOF, as specified in a signature CommunicationException should be thrown