### PR TITLE
fix(conn): Removed automatic conn_uid assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 ### Fixed
 - Fixed return type for `ZCOUNT` to be `int` (#1546)
-- fix(conn): Removed automatic conn_uid assignment (#1551)
+- Removed automatic `conn_uid` parameter assignment (#1551)
 
 ## v2.4.0 (2025-04-30)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Fixed
 - Fixed return type for `ZCOUNT` to be `int` (#1546)
+- fix(conn): Removed automatic conn_uid assignment (#1551)
 
 ## v2.4.0 (2025-04-30)
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,6 +138,50 @@ it is still desired to have control of when the connection is opened or closed: 
 achieved by invoking `$client->connect()` and `$client->disconnect()`. Please note that the effect
 of these methods on aggregate connections may differ depending on each specific implementation.
 
+#### Persistent connections ####
+
+To increase a performance of your application you may set up a client to use persistent TCP connection, this way
+client saves a time on socket creation and connection handshake. By default, connection is created on first-command
+execution and will be automatically closed by GC before the process is being killed.
+However, if your application is backed by PHP-FPM the processes are idle, and you may set up it to be persistent and
+re-usable across multiple script execution within the same process.
+
+To enable the persistent connection mode you should provide following configuration:
+
+```php
+// Standalone
+$client = new Predis\Client(['persistent' => true]);
+
+// Cluster
+$client = new Predis\Client(
+    ['tcp://host:port', 'tcp://host:port', 'tcp://host:port'],
+    ['cluster' => 'redis', 'parameters' => ['persistent' => true]]
+);
+```
+
+**Important**
+
+If you operate on multiple clients within the same application, and they communicate with the same resource, by default
+they will share the same socket (that's the default behaviour of persistent sockets). So in this case you would need
+to additionally provide a `conn_uid` identifier for each client, this way each client will create its own socket so
+the connection context won't be shared across clients. This socket behaviour explained
+[here](https://www.php.net/manual/en/function.stream-socket-client.php#105393)
+
+```php
+// Standalone
+$client1 = new Predis\Client(['persistent' => true, 'conn_uid' => 'id_1']);
+$client2 = new Predis\Client(['persistent' => true, 'conn_uid' => 'id_2']);
+
+// Cluster
+$client1 = new Predis\Client(
+    ['tcp://host:port', 'tcp://host:port', 'tcp://host:port'],
+    ['cluster' => 'redis', 'parameters' => ['persistent' => true, 'conn_uid' => 'id_1']]
+);
+$client2 = new Predis\Client(
+    ['tcp://host:port', 'tcp://host:port', 'tcp://host:port'],
+    ['cluster' => 'redis', 'parameters' => ['persistent' => true, 'conn_uid' => 'id_2']]
+);
+```
 
 ### Client configuration ###
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To increase a performance of your application you may set up a client to use per
 client saves a time on socket creation and connection handshake. By default, connection is created on first-command
 execution and will be automatically closed by GC before the process is being killed.
 However, if your application is backed by PHP-FPM the processes are idle, and you may set up it to be persistent and
-re-usable across multiple script execution within the same process.
+reusable across multiple script execution within the same process.
 
 To enable the persistent connection mode you should provide following configuration:
 

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -41,7 +41,6 @@ class StreamConnection extends AbstractConnection
     public function __construct(ParametersInterface $parameters)
     {
         parent::__construct($parameters);
-        $this->parameters->conn_uid = spl_object_hash($this);
     }
 
     /**

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1288,14 +1288,30 @@ class ClientTest extends PredisTestCase
      */
     public function testClientsCreateDifferentPersistentConnections(): void
     {
-        $client1 = new Client($this->getParameters(['database' => 14, 'persistent' => true]));
-        $client2 = new Client($this->getParameters(['database' => 15, 'persistent' => true]));
+        $client1 = new Client($this->getParameters(['database' => 14, 'persistent' => true, 'conn_uid' => 1]));
+        $client2 = new Client($this->getParameters(['database' => 15, 'persistent' => true, 'conn_uid' => 2]));
 
         $client1->set('foo', 'bar');
         $client2->set('foo', 'baz');
 
         $this->assertSame('bar', $client1->get('foo'));
         $this->assertSame('baz', $client2->get('foo'));
+        $this->assertNotSame($client1->client('ID'), $client2->client('ID'));
+    }
+
+    /**
+     * @group connected
+     */
+    public function testClientsCreateSamePersistentConnections(): void
+    {
+        $client1 = new Client($this->getParameters(['persistent' => true]));
+        $client2 = new Client($this->getParameters(['persistent' => true]));
+
+        $client1->set('foo', 'bar');
+        $client2->set('foo', 'baz');
+
+        $this->assertSame('baz', $client2->get('foo'));
+        $this->assertSame($client1->client('ID'), $client2->client('ID'));
     }
 
     /**
@@ -1307,11 +1323,11 @@ class ClientTest extends PredisTestCase
     {
         $client1 = new Client(
             $this->getDefaultParametersArray(),
-            ['cluster' => 'redis', 'parameters' => ['persistent' => true]]
+            ['cluster' => 'redis', 'parameters' => ['persistent' => true, 'conn_uid' => 1]]
         );
         $client2 = new Client(
             $this->getDefaultParametersArray(),
-            ['cluster' => 'redis', 'parameters' => ['persistent' => true]]
+            ['cluster' => 'redis', 'parameters' => ['persistent' => true, 'conn_uid' => 2]]
         );
 
         $client1->set('{shard1}foo', 'bar');

--- a/tests/Predis/ClientTest.php
+++ b/tests/Predis/ClientTest.php
@@ -1285,6 +1285,7 @@ class ClientTest extends PredisTestCase
 
     /**
      * @group connected
+     * @requiresRedisVersion >= 5.0.0
      */
     public function testClientsCreateDifferentPersistentConnections(): void
     {
@@ -1301,6 +1302,7 @@ class ClientTest extends PredisTestCase
 
     /**
      * @group connected
+     * @requiresRedisVersion >= 5.0.0
      */
     public function testClientsCreateSamePersistentConnections(): void
     {

--- a/tests/Predis/Connection/ParametersTest.php
+++ b/tests/Predis/Connection/ParametersTest.php
@@ -403,6 +403,17 @@ class ParametersTest extends PredisTestCase
         $this->assertSame($expected, Parameters::parse($uri));
     }
 
+    /**
+     * @group disconnected
+     */
+    public function testSetParameters(): void
+    {
+        $parameters = new Parameters();
+        $parameters->property = 'value';
+
+        $this->assertEquals('value', $parameters->property);
+    }
+
     // ******************************************************************** //
     // ---- HELPER METHODS ------------------------------------------------ //
     // ******************************************************************** //


### PR DESCRIPTION
Closes #1539 

Automatic `conn_uid` assignment was added as a part of #1512, but it leads to a connection spikes in case if failover happens and connections is recreated by client. Since, `conn_uid` is a parameter option it must be assigned by user instead to avoid sharing of the socket between different clients within a single process.