### PR TITLE
fix XREAD read null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix(stream): Fixed throwing `CommunicationException` when stream is EOF (#1548)
 - Removed automatic `conn_uid` parameter assignment (#1552)
 - fix(commands): Fixed wrong command API call on prefix processing (#1554)
+- fix `XREAD` response parsing while read null (#1563)
 
 ### Maintenance
 - Updated Redis 8.0 test image (#1562)

--- a/src/Command/Redis/XREAD.php
+++ b/src/Command/Redis/XREAD.php
@@ -46,6 +46,10 @@ class XREAD extends RedisCommand
 
     public function parseResponse($data)
     {
+        if (!$data) {
+            return [];
+        }
+
         $processedData = [];
 
         foreach ($data as $stream) {

--- a/tests/Predis/Command/Redis/XREAD_Test.php
+++ b/tests/Predis/Command/Redis/XREAD_Test.php
@@ -165,6 +165,23 @@ class XREAD_Test extends PredisCommandTestCase
         $this->assertSame($expectedResponse, $response);
     }
 
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisVersion >= 5.0.0
+     * @return void
+     */
+    public function testReadNull(): void
+    {
+        $redis = $this->getClient();
+
+        $stream1Id1 = $redis->xadd('stream1', ['field1' => 'value1']);
+        $redis->xdel('stream1', $stream1Id1);
+        $response = $redis->xread(1, null, ['stream1'], '0-0');
+
+        $this->assertSame([], $response);
+    }
+
     public function argumentsProvider(): array
     {
         return [


### PR DESCRIPTION
I discovered the following bug in parsing the XREAD response when null is returned. It can be easily reproduced with the following code:

```php
$stream1Id1 = $redis->xadd('stream1', ['field1' => 'value1']);
$redis->xdel('stream1', $stream1Id1);
$redis->xread(1, null, ['stream1'], '0-0');

foreach() argument must be of type array|object, null given
 /predis/src/Command/Redis/XREAD.php:51
 /predis/src/Client.php:394
 /predis/src/Client.php:336
 /predis/tests/Predis/Command/Redis/XREAD_Test.php:180
```

To avoid changing the XREAD interface, I suggest returning an empty array.