### PR TITLE
BITOP added operation validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for `XCLAIM` command (#1557)
 - Added support for `XPENDING` command (#1558)
 - Added support for `XSETID` command (#1559)
+- Added validation and support for the new `BITOP` command operations (#1566)
 
 ### Changed
 - Handle and retry `LOADING` errors from Sentinel replicas (#1536)

--- a/src/Command/Redis/BITOP.php
+++ b/src/Command/Redis/BITOP.php
@@ -41,9 +41,11 @@ class BITOP extends RedisCommand
             array_unshift($arguments, $operation, $destination);
         }
 
-        $operation = strtoupper($arguments[0]);
-        if (!in_array($operation, self::VALID_OPERATIONS, true)) {
-            throw new InvalidArgumentException('BITOP operation must be one of: AND, OR, XOR, NOT, DIFF, DIFF1, ANDOR, ONE');
+        if (!empty($arguments)) {
+            $operation = strtoupper($arguments[0]);
+            if (!in_array($operation, self::VALID_OPERATIONS, false)) {
+                throw new InvalidArgumentException('BITOP operation must be one of: AND, OR, XOR, NOT, DIFF, DIFF1, ANDOR, ONE');
+            }
         }
 
         parent::setArguments($arguments);

--- a/src/Command/Redis/BITOP.php
+++ b/src/Command/Redis/BITOP.php
@@ -12,8 +12,8 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\PrefixableCommand as RedisCommand;
 use InvalidArgumentException;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see http://redis.io/commands/bitop

--- a/src/Command/Redis/BITOP.php
+++ b/src/Command/Redis/BITOP.php
@@ -13,12 +13,15 @@
 namespace Predis\Command\Redis;
 
 use Predis\Command\PrefixableCommand as RedisCommand;
+use InvalidArgumentException;
 
 /**
  * @see http://redis.io/commands/bitop
  */
 class BITOP extends RedisCommand
 {
+    private const VALID_OPERATIONS = ['AND', 'OR', 'XOR', 'NOT', 'DIFF', 'DIFF1', 'ANDOR', 'ONE'];
+
     /**
      * {@inheritdoc}
      */
@@ -36,6 +39,11 @@ class BITOP extends RedisCommand
             [$operation, $destination] = $arguments;
             $arguments = $arguments[2];
             array_unshift($arguments, $operation, $destination);
+        }
+
+        $operation = strtoupper($arguments[0]);
+        if (!in_array($operation, self::VALID_OPERATIONS, true)) {
+            throw new InvalidArgumentException('BITOP operation must be one of: AND, OR, XOR, NOT, DIFF, DIFF1, ANDOR, ONE');
         }
 
         parent::setArguments($arguments);

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -170,7 +170,7 @@ class BITOP_Test extends PredisCommandTestCase
         $this->assertSame("\x03", $redis->get('key:dst'));
     }
 
-        /**
+    /**
      * @group connected
      * @requiresRedisVersion >= 8.0.2
      */
@@ -186,7 +186,7 @@ class BITOP_Test extends PredisCommandTestCase
         $this->assertSame("\x01", $redis->get('key:dst'));
     }
 
-        /**
+    /**
      * @group connected
      * @requiresRedisVersion >= 8.0.2
      */
@@ -201,7 +201,6 @@ class BITOP_Test extends PredisCommandTestCase
         $this->assertSame(1, $redis->bitop('DIFF1', 'key:dst', 'key:src:1', 'key:src:2', 'key:src:3'));
         $this->assertSame("\x04", $redis->get('key:dst'));
     }
-
 
     /**
      * @group connected

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -12,8 +12,8 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\PrefixableCommand;
 use InvalidArgumentException;
+use Predis\Command\PrefixableCommand;
 
 /**
  * @group commands

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -157,7 +157,7 @@ class BITOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisVersion >= 8.0.2
+     * @requiresRedisVersion >= 8.2.0
      */
     public function testCanPerformBitwiseONE(): void
     {
@@ -172,7 +172,7 @@ class BITOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisVersion >= 8.0.2
+     * @requiresRedisVersion >= 8.2.0
      */
     public function testCanPerformBitwiseDIFF(): void
     {
@@ -188,7 +188,7 @@ class BITOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisVersion >= 8.0.2
+     * @requiresRedisVersion >= 8.2.0
      */
     public function testCanPerformBitwiseDIFF1(): void
     {
@@ -204,7 +204,7 @@ class BITOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @requiresRedisVersion >= 8.0.2
+     * @requiresRedisVersion >= 8.2.0
      */
     public function testCanPerformBitwiseANDOR(): void
     {

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis;
 
 use Predis\Command\PrefixableCommand;
+use InvalidArgumentException;
 
 /**
  * @group commands
@@ -84,9 +85,9 @@ class BITOP_Test extends PredisCommandTestCase
     {
         /** @var PrefixableCommand $command */
         $command = $this->getCommand();
-        $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
+        $actualArguments = ['AND', 'arg1', 'arg2', 'arg3', 'arg4'];
         $prefix = 'prefix:';
-        $expectedArguments = ['arg1', 'prefix:arg2', 'prefix:arg3', 'prefix:arg4'];
+        $expectedArguments = ['AND', 'prefix:arg1', 'prefix:arg2', 'prefix:arg3', 'prefix:arg4'];
 
         $command->setArguments($actualArguments);
         $command->prefixKeys($prefix);
@@ -181,15 +182,15 @@ class BITOP_Test extends PredisCommandTestCase
     }
 
     /**
-     * @group connected
-     * @requiresRedisVersion >= 2.6.0
+     * @group disconnected
      */
     public function testThrowsExceptionOnInvalidOperation(): void
     {
-        $this->expectException('Predis\Response\ServerException');
-        $this->expectExceptionMessage('ERR syntax error');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('BITOP operation must be one of: AND, OR, XOR, NOT, DIFF, DIFF1, ANDOR, ONE');
 
-        $this->getClient()->bitop('NOOP', 'key:dst', 'key:src:1', 'key:src:2');
+        $command = $this->getCommand();
+        $command->setArguments(['NOOP', 'key:dst', 'key:src:1', 'key:src:2']);
     }
 
     /**

--- a/tests/Predis/Command/Redis/BITOP_Test.php
+++ b/tests/Predis/Command/Redis/BITOP_Test.php
@@ -157,6 +157,70 @@ class BITOP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
+     * @requiresRedisVersion >= 8.0.2
+     */
+    public function testCanPerformBitwiseONE(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->set('key:src:1', "\x01");
+        $redis->set('key:src:2', "\x02");
+
+        $this->assertSame(1, $redis->bitop('ONE', 'key:dst', 'key:src:1', 'key:src:2'));
+        $this->assertSame("\x03", $redis->get('key:dst'));
+    }
+
+        /**
+     * @group connected
+     * @requiresRedisVersion >= 8.0.2
+     */
+    public function testCanPerformBitwiseDIFF(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->set('key:src:1', "\x01");
+        $redis->set('key:src:2', "\x00");
+        $redis->set('key:src:3', "\x04");
+
+        $this->assertSame(1, $redis->bitop('DIFF', 'key:dst', 'key:src:1', 'key:src:2', 'key:src:3'));
+        $this->assertSame("\x01", $redis->get('key:dst'));
+    }
+
+        /**
+     * @group connected
+     * @requiresRedisVersion >= 8.0.2
+     */
+    public function testCanPerformBitwiseDIFF1(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->set('key:src:1', "\x01");
+        $redis->set('key:src:2', "\x00");
+        $redis->set('key:src:3', "\x04");
+
+        $this->assertSame(1, $redis->bitop('DIFF1', 'key:dst', 'key:src:1', 'key:src:2', 'key:src:3'));
+        $this->assertSame("\x04", $redis->get('key:dst'));
+    }
+
+
+    /**
+     * @group connected
+     * @requiresRedisVersion >= 8.0.2
+     */
+    public function testCanPerformBitwiseANDOR(): void
+    {
+        $redis = $this->getClient();
+
+        $redis->set('key:src:1', "\x03");
+        $redis->set('key:src:2', "\x02");
+        $redis->set('key:src:3', "\x04");
+
+        $this->assertSame(1, $redis->bitop('ANDOR', 'key:dst', 'key:src:1', 'key:src:2', 'key:src:3'));
+        $this->assertSame("\x02", $redis->get('key:dst'));
+    }
+
+    /**
+     * @group connected
      * @requiresRedisVersion >= 2.6.0
      */
     public function testCanPerformBitwiseNOT(): void


### PR DESCRIPTION
Added a check that only valid operations can be sent to the server.
Modified the tests to accommodate the changes.
Included as valid operations the four new operations that are going to be introduced with Redis 8.2