### PR TITLE
Marked missing commands as Prefixable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - fix(commands): Fixed wrong command API call on prefix processing (#1554)
 - fix `XREAD` response parsing while read null (#1563)
 - fix `XINFO` command responses parsing (#1560)
+- Marked missing commands as Prefixable (#1576)
 
 ### Maintenance
 - Updated Redis 8.0 test image (#1562)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
     stopOnFailure="false"
     beStrictAboutTestsThatDoNotTestAnything="true"
 >
+    <php>
+        <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
+    </php>
 
     <testsuites>
         <testsuite name="Predis Test Suite">

--- a/src/Command/Redis/BloomFilter/BFADD.php
+++ b/src/Command/Redis/BloomFilter/BFADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.add/
@@ -25,5 +25,11 @@ class BFADD extends RedisCommand
     public function getId()
     {
         return 'BF.ADD';
+    }
+
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFADD.php
+++ b/src/Command/Redis/BloomFilter/BFADD.php
@@ -27,7 +27,6 @@ class BFADD extends RedisCommand
         return 'BF.ADD';
     }
 
-
     public function prefixKeys($prefix)
     {
         $this->applyPrefixForFirstArgument($prefix);

--- a/src/Command/Redis/BloomFilter/BFEXISTS.php
+++ b/src/Command/Redis/BloomFilter/BFEXISTS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.exists/
@@ -24,5 +24,10 @@ class BFEXISTS extends RedisCommand
     public function getId()
     {
         return 'BF.EXISTS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFINFO.php
+++ b/src/Command/Redis/BloomFilter/BFINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use UnexpectedValueException;
 
 /**
@@ -75,5 +75,10 @@ class BFINFO extends RedisCommand
         }
 
         return $data;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFINSERT.php
+++ b/src/Command/Redis/BloomFilter/BFINSERT.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\BloomFilters\Capacity;
 use Predis\Command\Traits\BloomFilters\Error;
 use Predis\Command\Traits\BloomFilters\Expansion;
@@ -46,6 +46,11 @@ class BFINSERT extends RedisCommand
     public function getId()
     {
         return 'BF.INSERT';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 
     public function setArguments(array $arguments)

--- a/src/Command/Redis/BloomFilter/BFLOADCHUNK.php
+++ b/src/Command/Redis/BloomFilter/BFLOADCHUNK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.loadchunk/
@@ -24,5 +24,10 @@ class BFLOADCHUNK extends RedisCommand
     public function getId()
     {
         return 'BF.LOADCHUNK';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFMADD.php
+++ b/src/Command/Redis/BloomFilter/BFMADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.madd/
@@ -25,5 +25,10 @@ class BFMADD extends RedisCommand
     public function getId()
     {
         return 'BF.MADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFMEXISTS.php
+++ b/src/Command/Redis/BloomFilter/BFMEXISTS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.mexists/
@@ -24,5 +24,10 @@ class BFMEXISTS extends RedisCommand
     public function getId()
     {
         return 'BF.MEXISTS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFRESERVE.php
+++ b/src/Command/Redis/BloomFilter/BFRESERVE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\BloomFilters\Expansion;
 
 /**
@@ -45,5 +45,10 @@ class BFRESERVE extends RedisCommand
 
         $this->setExpansion($arguments);
         $this->filterArguments();
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/BloomFilter/BFSCANDUMP.php
+++ b/src/Command/Redis/BloomFilter/BFSCANDUMP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/bf.scandump/
@@ -25,5 +25,10 @@ class BFSCANDUMP extends RedisCommand
     public function getId()
     {
         return 'BF.SCANDUMP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSINCRBY.php
+++ b/src/Command/Redis/CountMinSketch/CMSINCRBY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.incrby/
@@ -25,5 +25,10 @@ class CMSINCRBY extends RedisCommand
     public function getId()
     {
         return 'CMS.INCRBY';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSINFO.php
+++ b/src/Command/Redis/CountMinSketch/CMSINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.info/
@@ -41,5 +41,10 @@ class CMSINFO extends RedisCommand
         }
 
         return $data;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSINITBYDIM.php
+++ b/src/Command/Redis/CountMinSketch/CMSINITBYDIM.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.initbydim/
@@ -24,5 +24,10 @@ class CMSINITBYDIM extends RedisCommand
     public function getId()
     {
         return 'CMS.INITBYDIM';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSINITBYPROB.php
+++ b/src/Command/Redis/CountMinSketch/CMSINITBYPROB.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.initbyprob/
@@ -24,5 +24,10 @@ class CMSINITBYPROB extends RedisCommand
     public function getId()
     {
         return 'CMS.INITBYPROB';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSMERGE.php
+++ b/src/Command/Redis/CountMinSketch/CMSMERGE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.merge/
@@ -38,5 +38,18 @@ class CMSMERGE extends RedisCommand
         }
 
         parent::setArguments($processedArguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            $arguments[0] = $prefix . $arguments[0];
+
+            for ($i = 2, $iMax = (int) $arguments[1] + 2; $i < $iMax; $i++) {
+                $arguments[$i] = $prefix . $arguments[$i];
+            }
+
+            $this->setRawArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/CountMinSketch/CMSQUERY.php
+++ b/src/Command/Redis/CountMinSketch/CMSQUERY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cms.query/
@@ -24,5 +24,10 @@ class CMSQUERY extends RedisCommand
     public function getId()
     {
         return 'CMS.QUERY';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFADD.php
+++ b/src/Command/Redis/CuckooFilter/CFADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.add/
@@ -24,5 +24,10 @@ class CFADD extends RedisCommand
     public function getId()
     {
         return 'CF.ADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFADDNX.php
+++ b/src/Command/Redis/CuckooFilter/CFADDNX.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.addnx/
@@ -24,5 +24,10 @@ class CFADDNX extends RedisCommand
     public function getId()
     {
         return 'CF.ADDNX';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFCOUNT.php
+++ b/src/Command/Redis/CuckooFilter/CFCOUNT.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.count/
@@ -25,5 +25,10 @@ class CFCOUNT extends RedisCommand
     public function getId()
     {
         return 'CF.COUNT';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFDEL.php
+++ b/src/Command/Redis/CuckooFilter/CFDEL.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.del/
@@ -26,5 +26,10 @@ class CFDEL extends RedisCommand
     public function getId()
     {
         return 'CF.DEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFEXISTS.php
+++ b/src/Command/Redis/CuckooFilter/CFEXISTS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.exists/
@@ -24,5 +24,10 @@ class CFEXISTS extends RedisCommand
     public function getId()
     {
         return 'CF.EXISTS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFINFO.php
+++ b/src/Command/Redis/CuckooFilter/CFINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.info/
@@ -41,5 +41,10 @@ class CFINFO extends RedisCommand
         }
 
         return $data;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFINSERT.php
+++ b/src/Command/Redis/CuckooFilter/CFINSERT.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\BloomFilters\Capacity;
 use Predis\Command\Traits\BloomFilters\Items;
 use Predis\Command\Traits\BloomFilters\NoCreate;
@@ -48,5 +48,10 @@ class CFINSERT extends RedisCommand
 
         $this->setCapacity($arguments);
         $this->filterArguments();
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFLOADCHUNK.php
+++ b/src/Command/Redis/CuckooFilter/CFLOADCHUNK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.loadchunk/
@@ -25,5 +25,10 @@ class CFLOADCHUNK extends RedisCommand
     public function getId()
     {
         return 'CF.LOADCHUNK';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFMEXISTS.php
+++ b/src/Command/Redis/CuckooFilter/CFMEXISTS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.mexists/
@@ -24,5 +24,10 @@ class CFMEXISTS extends RedisCommand
     public function getId()
     {
         return 'CF.MEXISTS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFRESERVE.php
+++ b/src/Command/Redis/CuckooFilter/CFRESERVE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\BloomFilters\BucketSize;
 use Predis\Command\Traits\BloomFilters\Expansion;
 use Predis\Command\Traits\BloomFilters\MaxIterations;
@@ -48,5 +48,10 @@ class CFRESERVE extends RedisCommand
 
         $this->setBucketSize($arguments);
         $this->filterArguments();
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/CuckooFilter/CFSCANDUMP.php
+++ b/src/Command/Redis/CuckooFilter/CFSCANDUMP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/cf.scandump/
@@ -25,5 +25,10 @@ class CFSCANDUMP extends RedisCommand
     public function getId()
     {
         return 'CF.SCANDUMP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/EXPIRETIME.php
+++ b/src/Command/Redis/EXPIRETIME.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/expiretime/
@@ -25,5 +25,10 @@ class EXPIRETIME extends RedisCommand
     public function getId()
     {
         return 'EXPIRETIME';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/GEOSEARCH.php
+++ b/src/Command/Redis/GEOSEARCH.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\By\GeoBy;
 use Predis\Command\Traits\Count;
 use Predis\Command\Traits\From\GeoFrom;
@@ -118,5 +118,10 @@ class GEOSEARCH extends RedisCommand
         }
 
         return $parsedData;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/GETDEL.php
+++ b/src/Command/Redis/GETDEL.php
@@ -12,12 +12,17 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class GETDEL extends RedisCommand
 {
     public function getId()
     {
         return 'GETDEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRAPPEND.php
+++ b/src/Command/Redis/Json/JSONARRAPPEND.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrappend/
@@ -24,5 +24,10 @@ class JSONARRAPPEND extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRAPPEND';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRINDEX.php
+++ b/src/Command/Redis/Json/JSONARRINDEX.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrindex/
@@ -24,5 +24,10 @@ class JSONARRINDEX extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRINDEX';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRINSERT.php
+++ b/src/Command/Redis/Json/JSONARRINSERT.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrinsert/
@@ -24,5 +24,10 @@ class JSONARRINSERT extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRINSERT';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRLEN.php
+++ b/src/Command/Redis/Json/JSONARRLEN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrlen/
@@ -24,5 +24,10 @@ class JSONARRLEN extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRLEN';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRPOP.php
+++ b/src/Command/Redis/Json/JSONARRPOP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrpop/
@@ -24,5 +24,10 @@ class JSONARRPOP extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRPOP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONARRTRIM.php
+++ b/src/Command/Redis/Json/JSONARRTRIM.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.arrtrim/
@@ -24,5 +24,10 @@ class JSONARRTRIM extends RedisCommand
     public function getId()
     {
         return 'JSON.ARRTRIM';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONCLEAR.php
+++ b/src/Command/Redis/Json/JSONCLEAR.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.clear/
@@ -24,5 +24,10 @@ class JSONCLEAR extends RedisCommand
     public function getId()
     {
         return 'JSON.CLEAR';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONDEL.php
+++ b/src/Command/Redis/Json/JSONDEL.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.del/
@@ -24,5 +24,10 @@ class JSONDEL extends RedisCommand
     public function getId()
     {
         return 'JSON.DEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONFORGET.php
+++ b/src/Command/Redis/Json/JSONFORGET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.forget/
@@ -24,5 +24,10 @@ class JSONFORGET extends RedisCommand
     public function getId()
     {
         return 'JSON.FORGET';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONGET.php
+++ b/src/Command/Redis/Json/JSONGET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\Json\Indent;
 use Predis\Command\Traits\Json\Newline;
 use Predis\Command\Traits\Json\Space;
@@ -53,5 +53,10 @@ class JSONGET extends RedisCommand
 
         $this->setIndent($arguments);
         $this->filterArguments();
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONMERGE.php
+++ b/src/Command/Redis/Json/JSONMERGE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.merge/
@@ -25,5 +25,10 @@ class JSONMERGE extends RedisCommand
     public function getId()
     {
         return 'JSON.MERGE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONMGET.php
+++ b/src/Command/Redis/Json/JSONMGET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class JSONMGET extends RedisCommand
 {
@@ -32,5 +32,10 @@ class JSONMGET extends RedisCommand
         $unpackedArguments[] = $arguments[1];
 
         parent::setArguments($unpackedArguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixSkippingLastArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONMSET.php
+++ b/src/Command/Redis/Json/JSONMSET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.mset/
@@ -24,5 +24,16 @@ class JSONMSET extends RedisCommand
     public function getId()
     {
         return 'JSON.MSET';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            for ($i = 0, $l = count($arguments); $i < $l; $i += 3) {
+                $arguments[$i] = $prefix . $arguments[$i];
+            }
+
+            $this->setArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/Json/JSONNUMINCRBY.php
+++ b/src/Command/Redis/Json/JSONNUMINCRBY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.numincrby/
@@ -24,5 +24,10 @@ class JSONNUMINCRBY extends RedisCommand
     public function getId()
     {
         return 'JSON.NUMINCRBY';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONOBJKEYS.php
+++ b/src/Command/Redis/Json/JSONOBJKEYS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.objkeys/
@@ -24,5 +24,10 @@ class JSONOBJKEYS extends RedisCommand
     public function getId()
     {
         return 'JSON.OBJKEYS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONOBJLEN.php
+++ b/src/Command/Redis/Json/JSONOBJLEN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.objlen/
@@ -24,5 +24,10 @@ class JSONOBJLEN extends RedisCommand
     public function getId()
     {
         return 'JSON.OBJLEN';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONRESP.php
+++ b/src/Command/Redis/Json/JSONRESP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.resp/
@@ -24,5 +24,10 @@ class JSONRESP extends RedisCommand
     public function getId()
     {
         return 'JSON.RESP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONSET.php
+++ b/src/Command/Redis/Json/JSONSET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 use Predis\Command\Traits\Json\NxXxArgument;
 
 /**
@@ -37,5 +37,10 @@ class JSONSET extends RedisCommand
     {
         $this->setSubcommand($arguments);
         $this->filterArguments();
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONSTRAPPEND.php
+++ b/src/Command/Redis/Json/JSONSTRAPPEND.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.strappend/
@@ -24,5 +24,10 @@ class JSONSTRAPPEND extends RedisCommand
     public function getId()
     {
         return 'JSON.STRAPPEND';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONSTRLEN.php
+++ b/src/Command/Redis/Json/JSONSTRLEN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.strlen/
@@ -24,5 +24,10 @@ class JSONSTRLEN extends RedisCommand
     public function getId()
     {
         return 'JSON.STRLEN';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONTOGGLE.php
+++ b/src/Command/Redis/Json/JSONTOGGLE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.toggle/
@@ -24,5 +24,10 @@ class JSONTOGGLE extends RedisCommand
     public function getId()
     {
         return 'JSON.TOGGLE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Json/JSONTYPE.php
+++ b/src/Command/Redis/Json/JSONTYPE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/json.type/
@@ -24,5 +24,10 @@ class JSONTYPE extends RedisCommand
     public function getId()
     {
         return 'JSON.TYPE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/LMOVE.php
+++ b/src/Command/Redis/LMOVE.php
@@ -12,12 +12,22 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class LMOVE extends RedisCommand
 {
     public function getId()
     {
         return 'LMOVE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            $arguments[0] = $prefix . $arguments[0];
+            $arguments[1] = $prefix . $arguments[1];
+
+            $this->setRawArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/SMISMEMBER.php
+++ b/src/Command/Redis/SMISMEMBER.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/smismember/
@@ -24,5 +24,10 @@ class SMISMEMBER extends RedisCommand
     public function getId()
     {
         return 'SMISMEMBER';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTAGGREGATE.php
+++ b/src/Command/Redis/Search/FTAGGREGATE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.aggregate/
@@ -49,5 +49,10 @@ class FTAGGREGATE extends RedisCommand
             [$index, $query],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTALIASADD.php
+++ b/src/Command/Redis/Search/FTALIASADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.aliasadd/
@@ -24,5 +24,10 @@ class FTALIASADD extends RedisCommand
     public function getId()
     {
         return 'FT.ALIASADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForAllArguments($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTALIASDEL.php
+++ b/src/Command/Redis/Search/FTALIASDEL.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.aliasdel/
@@ -24,5 +24,10 @@ class FTALIASDEL extends RedisCommand
     public function getId()
     {
         return 'FT.ALIASDEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTALIASUPDATE.php
+++ b/src/Command/Redis/Search/FTALIASUPDATE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.aliasupdate/
@@ -25,5 +25,10 @@ class FTALIASUPDATE extends RedisCommand
     public function getId()
     {
         return 'FT.ALIASUPDATE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForAllArguments($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTALTER.php
+++ b/src/Command/Redis/Search/FTALTER.php
@@ -13,7 +13,7 @@
 namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\FieldInterface;
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class FTALTER extends RedisCommand
 {
@@ -38,5 +38,10 @@ class FTALTER extends RedisCommand
             $commandArguments,
             $schema
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTCREATE.php
+++ b/src/Command/Redis/Search/FTCREATE.php
@@ -13,7 +13,7 @@
 namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\FieldInterface;
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.create/
@@ -43,5 +43,10 @@ class FTCREATE extends RedisCommand
             $commandArguments,
             $schema
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTCURSOR.php
+++ b/src/Command/Redis/Search/FTCURSOR.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class FTCURSOR extends RedisCommand
 {
@@ -30,5 +30,10 @@ class FTCURSOR extends RedisCommand
             [$subcommand, $index, $cursorId],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTDICTADD.php
+++ b/src/Command/Redis/Search/FTDICTADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.dictadd/
@@ -24,5 +24,10 @@ class FTDICTADD extends RedisCommand
     public function getId()
     {
         return 'FT.DICTADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTDICTDEL.php
+++ b/src/Command/Redis/Search/FTDICTDEL.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.dictdel/
@@ -24,5 +24,10 @@ class FTDICTDEL extends RedisCommand
     public function getId()
     {
         return 'FT.DICTDEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTDICTDUMP.php
+++ b/src/Command/Redis/Search/FTDICTDUMP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.dictdump/
@@ -24,5 +24,10 @@ class FTDICTDUMP extends RedisCommand
     public function getId()
     {
         return 'FT.DICTDUMP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTDROPINDEX.php
+++ b/src/Command/Redis/Search/FTDROPINDEX.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class FTDROPINDEX extends RedisCommand
 {
@@ -34,5 +34,10 @@ class FTDROPINDEX extends RedisCommand
             [$index],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTEXPLAIN.php
+++ b/src/Command/Redis/Search/FTEXPLAIN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.explain/
@@ -48,5 +48,10 @@ class FTEXPLAIN extends RedisCommand
             [$index, $query],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTINFO.php
+++ b/src/Command/Redis/Search/FTINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.info/
@@ -24,5 +24,10 @@ class FTINFO extends RedisCommand
     public function getId()
     {
         return 'FT.INFO';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTPROFILE.php
+++ b/src/Command/Redis/Search/FTPROFILE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.profile/
@@ -34,5 +34,10 @@ class FTPROFILE extends RedisCommand
             [$index],
             $arguments->toArray()
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTSEARCH.php
+++ b/src/Command/Redis/Search/FTSEARCH.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see  https://redis.io/commands/ft.search/
@@ -48,5 +48,10 @@ class FTSEARCH extends RedisCommand
             [$index, $query],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTSPELLCHECK.php
+++ b/src/Command/Redis/Search/FTSPELLCHECK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 class FTSPELLCHECK extends RedisCommand
 {
@@ -47,5 +47,10 @@ class FTSPELLCHECK extends RedisCommand
             [$index, $query],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTSYNDUMP.php
+++ b/src/Command/Redis/Search/FTSYNDUMP.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.syndump/
@@ -24,5 +24,10 @@ class FTSYNDUMP extends RedisCommand
     public function getId()
     {
         return 'FT.SYNDUMP';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTSYNUPDATE.php
+++ b/src/Command/Redis/Search/FTSYNUPDATE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.synupdate/
@@ -42,5 +42,10 @@ class FTSYNUPDATE extends RedisCommand
             $commandArguments,
             $terms
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/Search/FTTAGVALS.php
+++ b/src/Command/Redis/Search/FTTAGVALS.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ft.tagvals/
@@ -24,5 +24,10 @@ class FTTAGVALS extends RedisCommand
     public function getId()
     {
         return 'FT.TAGVALS';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTADD.php
+++ b/src/Command/Redis/TDigest/TDIGESTADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.add/
@@ -24,5 +24,10 @@ class TDIGESTADD extends RedisCommand
     public function getId()
     {
         return 'TDIGEST.ADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYRANK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.byrank/
@@ -51,5 +51,10 @@ class TDIGESTBYRANK extends RedisCommand
                 default: return $value;
             }
         }, $data);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTBYREVRANK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.byrevrank/
@@ -51,5 +51,10 @@ class TDIGESTBYREVRANK extends RedisCommand
                 default: return $value;
             }
         }, $data);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTCDF.php
+++ b/src/Command/Redis/TDigest/TDIGESTCDF.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.cdf/
@@ -53,5 +53,10 @@ class TDIGESTCDF extends RedisCommand
                 default: return $value;
             }
         }, $data);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTCREATE.php
+++ b/src/Command/Redis/TDigest/TDIGESTCREATE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.create/
@@ -36,5 +36,10 @@ class TDIGESTCREATE extends RedisCommand
         }
 
         parent::setArguments($arguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTINFO.php
+++ b/src/Command/Redis/TDigest/TDIGESTINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.info/
@@ -37,5 +37,10 @@ class TDIGESTINFO extends RedisCommand
         }
 
         return $result;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMAX.php
+++ b/src/Command/Redis/TDigest/TDIGESTMAX.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.max/
@@ -45,5 +45,10 @@ class TDIGESTMAX extends RedisCommand
             case -INF: return '-inf';
             default: return $data;
         }
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMERGE.php
+++ b/src/Command/Redis/TDigest/TDIGESTMERGE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.merge/
@@ -39,5 +39,18 @@ class TDIGESTMERGE extends RedisCommand
         }
 
         parent::setArguments($processedArguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            $arguments[0] = $prefix . $arguments[0];
+
+            for ($i = 2, $iMax = (int) $arguments[1] + 2; $i < $iMax; $i++) {
+                $arguments[$i] = $prefix . $arguments[$i];
+            }
+
+            $this->setRawArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTMIN.php
+++ b/src/Command/Redis/TDigest/TDIGESTMIN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.min/
@@ -45,5 +45,10 @@ class TDIGESTMIN extends RedisCommand
             case -INF: return '-inf';
             default: return $data;
         }
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
+++ b/src/Command/Redis/TDigest/TDIGESTQUANTILE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.quantile/
@@ -51,5 +51,10 @@ class TDIGESTQUANTILE extends RedisCommand
                 default: return $value;
             }
         }, $data);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTRANK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.rank/
@@ -26,5 +26,10 @@ class TDIGESTRANK extends RedisCommand
     public function getId()
     {
         return 'TDIGEST.RANK';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTRESET.php
+++ b/src/Command/Redis/TDigest/TDIGESTRESET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.reset/
@@ -24,5 +24,10 @@ class TDIGESTRESET extends RedisCommand
     public function getId()
     {
         return 'TDIGEST.RESET';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTREVRANK.php
+++ b/src/Command/Redis/TDigest/TDIGESTREVRANK.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.revrank/
@@ -26,5 +26,10 @@ class TDIGESTREVRANK extends RedisCommand
     public function getId()
     {
         return 'TDIGEST.REVRANK';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
+++ b/src/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/tdigest.trimmed_mean/
@@ -46,5 +46,10 @@ class TDIGESTTRIMMED_MEAN extends RedisCommand
             case -INF: return '-inf';
             default: return $data;
         }
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSADD.php
+++ b/src/Command/Redis/TimeSeries/TSADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.add/
@@ -35,5 +35,10 @@ class TSADD extends RedisCommand
             [$key, $timestamp, $value],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSALTER.php
+++ b/src/Command/Redis/TimeSeries/TSALTER.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.alter/
@@ -35,5 +35,10 @@ class TSALTER extends RedisCommand
             [$key],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSCREATE.php
+++ b/src/Command/Redis/TimeSeries/TSCREATE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.create/
@@ -35,5 +35,10 @@ class TSCREATE extends RedisCommand
             [$key],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSCREATERULE.php
+++ b/src/Command/Redis/TimeSeries/TSCREATERULE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.createrule/
@@ -36,5 +36,15 @@ class TSCREATERULE extends RedisCommand
         }
 
         parent::setArguments($processedArguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            $arguments[0] = $prefix . $arguments[0];
+            $arguments[1] = $prefix . $arguments[1];
+
+            $this->setRawArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/TimeSeries/TSDECRBY.php
+++ b/src/Command/Redis/TimeSeries/TSDECRBY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.decrby/
@@ -37,5 +37,10 @@ class TSDECRBY extends RedisCommand
             [$key, $value],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSDEL.php
+++ b/src/Command/Redis/TimeSeries/TSDEL.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.del/
@@ -24,5 +24,10 @@ class TSDEL extends RedisCommand
     public function getId()
     {
         return 'TS.DEL';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSDELETERULE.php
+++ b/src/Command/Redis/TimeSeries/TSDELETERULE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.deleterule/
@@ -24,5 +24,10 @@ class TSDELETERULE extends RedisCommand
     public function getId()
     {
         return 'TS.DELETERULE';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSGET.php
+++ b/src/Command/Redis/TimeSeries/TSGET.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.get/
@@ -35,5 +35,10 @@ class TSGET extends RedisCommand
             [$key],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSINCRBY.php
+++ b/src/Command/Redis/TimeSeries/TSINCRBY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.incrby/
@@ -37,5 +37,10 @@ class TSINCRBY extends RedisCommand
             [$key, $value],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSINFO.php
+++ b/src/Command/Redis/TimeSeries/TSINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.info/
@@ -35,5 +35,10 @@ class TSINFO extends RedisCommand
             [$key],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TimeSeries/TSMADD.php
+++ b/src/Command/Redis/TimeSeries/TSMADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.madd/
@@ -24,5 +24,16 @@ class TSMADD extends RedisCommand
     public function getId()
     {
         return 'TS.MADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        if ($arguments = $this->getArguments()) {
+            for ($i = 0, $l = count($arguments); $i < $l; $i += 3) {
+                $arguments[$i] = $prefix . $arguments[$i];
+            }
+
+            $this->setArguments($arguments);
+        }
     }
 }

--- a/src/Command/Redis/TimeSeries/TSRANGE.php
+++ b/src/Command/Redis/TimeSeries/TSRANGE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TimeSeries;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/ts.range/
@@ -35,5 +35,10 @@ class TSRANGE extends RedisCommand
             [$key, $fromTimestamp, $toTimestamp],
             $commandArguments
         ));
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKADD.php
+++ b/src/Command/Redis/TopK/TOPKADD.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.add/
@@ -27,5 +27,10 @@ class TOPKADD extends RedisCommand
     public function getId()
     {
         return 'TOPK.ADD';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKINCRBY.php
+++ b/src/Command/Redis/TopK/TOPKINCRBY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.incrby/
@@ -26,5 +26,10 @@ class TOPKINCRBY extends RedisCommand
     public function getId()
     {
         return 'TOPK.INCRBY';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKINFO.php
+++ b/src/Command/Redis/TopK/TOPKINFO.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.info/
@@ -37,5 +37,10 @@ class TOPKINFO extends RedisCommand
         }
 
         return $result;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKLIST.php
+++ b/src/Command/Redis/TopK/TOPKLIST.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.list/
@@ -73,5 +73,10 @@ class TOPKLIST extends RedisCommand
         $lastArgument = (!empty($arguments)) ? $arguments[count($arguments) - 1] : null;
 
         return is_string($lastArgument) && strtoupper($lastArgument) === 'WITHCOUNT';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKQUERY.php
+++ b/src/Command/Redis/TopK/TOPKQUERY.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.query/
@@ -25,5 +25,10 @@ class TOPKQUERY extends RedisCommand
     public function getId()
     {
         return 'TOPK.QUERY';
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/TopK/TOPKRESERVE.php
+++ b/src/Command/Redis/TopK/TOPKRESERVE.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see https://redis.io/commands/topk.reserve/
@@ -43,5 +43,10 @@ class TOPKRESERVE extends RedisCommand
         }
 
         parent::setArguments($arguments);
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/ZPOPMAX.php
+++ b/src/Command/Redis/ZPOPMAX.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see http://redis.io/commands/zpopmax
@@ -62,5 +62,10 @@ class ZPOPMAX extends RedisCommand
         }
 
         return $parsedData;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/src/Command/Redis/ZPOPMIN.php
+++ b/src/Command/Redis/ZPOPMIN.php
@@ -12,7 +12,7 @@
 
 namespace Predis\Command\Redis;
 
-use Predis\Command\Command as RedisCommand;
+use Predis\Command\PrefixableCommand as RedisCommand;
 
 /**
  * @see http://redis.io/commands/zpopmin
@@ -62,5 +62,10 @@ class ZPOPMIN extends RedisCommand
         }
 
         return $parsedData;
+    }
+
+    public function prefixKeys($prefix)
+    {
+        $this->applyPrefixForFirstArgument($prefix);
     }
 }

--- a/tests/Predis/Command/Redis/BLMOVE_Test.php
+++ b/tests/Predis/Command/Redis/BLMOVE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Response\ServerException;
 
 class BLMOVE_Test extends PredisCommandTestCase
@@ -52,6 +53,23 @@ class BLMOVE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];;
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BLMOVE_Test.php
+++ b/tests/Predis/Command/Redis/BLMOVE_Test.php
@@ -64,7 +64,7 @@ class BLMOVE_Test extends PredisCommandTestCase
         $command = $this->getCommand();
         $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
         $prefix = 'prefix:';
-        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];;
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];
 
         $command->setArguments($actualArguments);
         $command->prefixKeys($prefix);

--- a/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class BFADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFEXISTS_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class BFEXISTS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFINFO_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFINFO_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -57,6 +58,23 @@ class BFINFO_Test extends PredisCommandTestCase
     public function testParseResponse(array $actualResponse, array $expectedResponse): void
     {
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFINSERT_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFINSERT_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -56,6 +57,23 @@ class BFINSERT_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFLOADCHUNK_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFLOADCHUNK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class BFLOADCHUNK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFMADD_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFMADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class BFMADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFMEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFMEXISTS_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class BFMEXISTS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFRESERVE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -56,6 +57,23 @@ class BFRESERVE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/BloomFilter/BFSCANDUMP_Test.php
+++ b/tests/Predis/Command/Redis/BloomFilter/BFSCANDUMP_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\BloomFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class BFSCANDUMP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINCRBY_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CMSINCRBY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINFO_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINFO_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -60,6 +61,23 @@ class CMSINFO_Test extends PredisCommandTestCase
         $expectedResponse = ['width' => 2000, 'depth' => 10, 'count' => 0];
 
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYDIM_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYDIM_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CMSINITBYDIM_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYPROB_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSINITBYPROB_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CMSINITBYPROB_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSMERGE_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSMERGE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -55,6 +56,23 @@ class CMSMERGE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['dest', ['key1', 'key2', 'key3'], [10]];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:dest', 3, 'prefix:key1', 'prefix:key2', 'prefix:key3', 'WEIGHTS', 10];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CountMinSketch/CMSQUERY_Test.php
+++ b/tests/Predis/Command/Redis/CountMinSketch/CMSQUERY_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CountMinSketch;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CMSQUERY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFADDNX_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFADDNX_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CFADDNX_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFADD_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CFADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFCOUNT_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFCOUNT_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class CFCOUNT_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFDEL_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFDEL_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CFDEL_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFEXISTS_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class CFEXISTS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINFO_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINFO_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class CFINFO_Test extends PredisCommandTestCase
     public function testParseResponse(array $actualResponse, array $expectedResponse): void
     {
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINSERTNX_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINSERTNX_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -47,6 +48,23 @@ class CFINSERTNX_Test extends PredisCommandTestCase
         $command->setArguments($actualArguments);
 
         $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFINSERT_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFINSERT_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -48,6 +49,23 @@ class CFINSERT_Test extends PredisCommandTestCase
         $command->setArguments($actualArguments);
 
         $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFLOADCHUNK_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFLOADCHUNK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CFLOADCHUNK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFMEXISTS_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFMEXISTS_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class CFMEXISTS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFRESERVE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -47,6 +48,23 @@ class CFRESERVE_Test extends PredisCommandTestCase
         $command->setArguments($actualArguments);
 
         $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/CuckooFilter/CFSCANDUMP_Test.php
+++ b/tests/Predis/Command/Redis/CuckooFilter/CFSCANDUMP_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\CuckooFilter;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class CFSCANDUMP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/EXPIRETIME_Test.php
+++ b/tests/Predis/Command/Redis/EXPIRETIME_Test.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
+
 /**
  * @group commands
  * @group realm-keys
@@ -54,6 +56,23 @@ class EXPIRETIME_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/GEOSEARCH_Test.php
+++ b/tests/Predis/Command/Redis/GEOSEARCH_Test.php
@@ -19,6 +19,7 @@ use Predis\Command\Argument\Geospatial\ByRadius;
 use Predis\Command\Argument\Geospatial\FromInterface;
 use Predis\Command\Argument\Geospatial\FromLonLat;
 use Predis\Command\Argument\Geospatial\FromMember;
+use Predis\Command\PrefixableCommand;
 use UnexpectedValueException;
 
 class GEOSEARCH_Test extends PredisCommandTestCase
@@ -58,6 +59,23 @@ class GEOSEARCH_Test extends PredisCommandTestCase
     public function testParseResponse(array $actualResponse, array $expectedResponse): void
     {
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/GETDEL_Test.php
+++ b/tests/Predis/Command/Redis/GETDEL_Test.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
+
 class GETDEL_Test extends PredisCommandTestCase
 {
     /**
@@ -42,6 +44,23 @@ class GETDEL_Test extends PredisCommandTestCase
         $command->setArguments($arguments);
 
         $this->assertSame($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRAPPEND_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRAPPEND_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRAPPEND_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRINDEX_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRINDEX_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRINDEX_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRINSERT_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRINSERT_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRINSERT_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRLEN_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRLEN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRPOP_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRPOP_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRPOP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONARRTRIM_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONARRTRIM_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONARRTRIM_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONCLEAR_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONCLEAR_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONCLEAR_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONDEL_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONDEL_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONDEL_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONFORGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONFORGET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONFORGET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONGET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use UnexpectedValueException;
 
@@ -47,6 +48,23 @@ class JSONGET_Test extends PredisCommandTestCase
         $command->setArguments($actualArguments);
 
         $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONMERGE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMERGE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 class JSONMERGE_Test extends PredisCommandTestCase
@@ -52,6 +53,23 @@ class JSONMERGE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONMGET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMGET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONMGET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = [['arg1', 'arg2'], 'arg3'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONMSET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONMSET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -53,6 +54,23 @@ class JSONMSET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['key', '$..', 'value', 'key1', '$', 'value1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:key', '$..', 'value', 'prefix:key1', '$', 'value1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONNUMINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONNUMINCRBY_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONNUMINCRBY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONOBJKEYS_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONOBJKEYS_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONOBJKEYS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONOBJLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONOBJLEN_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONOBJLEN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONRESP_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONRESP_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\Status;
 
@@ -57,6 +58,23 @@ class JSONRESP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONSET_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use UnexpectedValueException;
 
@@ -55,6 +56,23 @@ class JSONSET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONSTRAPPEND_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSTRAPPEND_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONSTRAPPEND_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONSTRLEN_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONSTRLEN_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONSTRLEN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONTOGGLE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONTOGGLE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONTOGGLE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Json/JSONTYPE_Test.php
+++ b/tests/Predis/Command/Redis/Json/JSONTYPE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Json;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class JSONTYPE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/LMOVE_Test.php
+++ b/tests/Predis/Command/Redis/LMOVE_Test.php
@@ -68,7 +68,7 @@ class LMOVE_Test extends PredisCommandTestCase
         $command = $this->getCommand();
         $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
         $prefix = 'prefix:';
-        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];;
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];
 
         $command->setArguments($actualArguments);
         $command->prefixKeys($prefix);

--- a/tests/Predis/Command/Redis/LMOVE_Test.php
+++ b/tests/Predis/Command/Redis/LMOVE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Response\ServerException;
 
 /**
@@ -56,6 +57,23 @@ class LMOVE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];;
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/SMISMEMBER_Test.php
+++ b/tests/Predis/Command/Redis/SMISMEMBER_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Response\ServerException;
 
 /**
@@ -58,6 +59,23 @@ class SMISMEMBER_Test extends PredisCommandTestCase
         $command = $this->getCommand();
 
         $this->assertSame(1, $command->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTAGGREGATE_Test.php
@@ -17,6 +17,7 @@ use Predis\Command\Argument\Search\CreateArguments;
 use Predis\Command\Argument\Search\SchemaFields\AbstractField;
 use Predis\Command\Argument\Search\SchemaFields\NumericField;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -61,6 +62,23 @@ class FTAGGREGATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\CreateArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class FTALIASADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2'];;
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASADD_Test.php
@@ -71,7 +71,7 @@ class FTALIASADD_Test extends PredisCommandTestCase
         $command = $this->getCommand();
         $actualArguments = ['arg1', 'arg2'];
         $prefix = 'prefix:';
-        $expectedArguments = ['prefix:arg1', 'prefix:arg2'];;
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2'];
 
         $command->setArguments($actualArguments);
         $command->prefixKeys($prefix);

--- a/tests/Predis/Command/Redis/Search/FTALIASDEL_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASDEL_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class FTALIASDEL_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTALIASUPDATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALIASUPDATE_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class FTALIASUPDATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTALTER_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTALTER_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\AlterArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTALTER_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTCREATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCREATE_Test.php
@@ -18,6 +18,7 @@ use Predis\Command\Argument\Search\SchemaFields\NumericField;
 use Predis\Command\Argument\Search\SchemaFields\TagField;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Argument\Search\SchemaFields\VectorField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -60,6 +61,23 @@ class FTCREATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTCURSOR_Test.php
@@ -18,6 +18,7 @@ use Predis\Command\Argument\Search\CursorArguments;
 use Predis\Command\Argument\Search\SchemaFields\AbstractField;
 use Predis\Command\Argument\Search\SchemaFields\NumericField;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -75,6 +76,23 @@ class FTCURSOR_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTDICTADD_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class FTDICTADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTDICTDEL_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTDEL_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -56,6 +57,23 @@ class FTDICTDEL_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTDICTDUMP_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDICTDUMP_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\Search;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTDICTDUMP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTDROPINDEX_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTDROPINDEX_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\DropArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTDROPINDEX_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTEXPLAIN_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\ExplainArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTEXPLAIN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTINFO_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTINFO_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\CreateArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class FTINFO_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTPROFILE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTPROFILE_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\ProfileArguments;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTPROFILE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSEARCH_Test.php
@@ -20,6 +20,7 @@ use Predis\Command\Argument\Search\SchemaFields\TagField;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Argument\Search\SchemaFields\VectorField;
 use Predis\Command\Argument\Search\SearchArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -55,6 +56,23 @@ class FTSEARCH_Test extends PredisCommandTestCase
         $command->setArguments($actualArguments);
 
         $this->assertSameValues($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSPELLCHECK_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis\Search;
 use InvalidArgumentException;
 use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Argument\Search\SpellcheckArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class FTSPELLCHECK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSYNDUMP_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSYNDUMP_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\TextField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class FTSYNDUMP_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTSYNUPDATE_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTSYNUPDATE_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\SchemaFields\TextField;
 use Predis\Command\Argument\Search\SynUpdateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class FTSYNUPDATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/Search/FTTAGVALS_Test.php
+++ b/tests/Predis/Command/Redis/Search/FTTAGVALS_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\Search;
 
 use Predis\Command\Argument\Search\CreateArguments;
 use Predis\Command\Argument\Search\SchemaFields\TagField;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class FTTAGVALS_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTADD_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTBYRANK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTBYREVRANK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTCDF_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCREATE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCREATE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -55,6 +56,23 @@ class TDIGESTCREATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTINFO_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTINFO_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -73,6 +74,23 @@ class TDIGESTINFO_Test extends PredisCommandTestCase
         ];
 
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTMAX_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMERGE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -45,6 +46,23 @@ class TDIGESTMERGE_Test extends PredisCommandTestCase
     {
         $command = $this->getCommand();
         $command->setArguments($actualArguments);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['dest', ['key1', 'key2', 'key3'], 10];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:dest', 3, 'prefix:key1', 'prefix:key2', 'prefix:key3', 'COMPRESSION', 10];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
 
         $this->assertSame($expectedArguments, $command->getArguments());
     }

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTMIN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTQUANTILE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRANK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTRANK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTRESET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTREVRANK_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTREVRANK_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTTRIMMED_MEAN_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TDigest;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TDIGESTTRIMMED_MEAN_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSADD_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis\TimeSeries;
 use Predis\Command\Argument\TimeSeries\AddArguments;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use UnexpectedValueException;
 
@@ -72,6 +73,23 @@ class TSADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSALTER_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis\TimeSeries;
 use Predis\Command\Argument\TimeSeries\AlterArguments;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -73,6 +74,23 @@ class TSALTER_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATERULE_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -56,6 +57,23 @@ class TSCREATERULE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1', 'arg2', 'arg3', 'arg4'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1', 'prefix:arg2', 'arg3', 'arg4'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSCREATE_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 use UnexpectedValueException;
@@ -72,6 +73,23 @@ class TSCREATE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDECRBY_Test.php
@@ -16,6 +16,7 @@ use Predis\Command\Argument\TimeSeries\AddArguments;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\DecrByArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class TSDECRBY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDELETERULE_Test.php
@@ -13,6 +13,7 @@
 namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class TSDELETERULE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSDEL_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class TSDEL_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSGET_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis\TimeSeries;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\GetArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -58,6 +59,23 @@ class TSGET_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINCRBY_Test.php
@@ -16,6 +16,7 @@ use Predis\Command\Argument\TimeSeries\AddArguments;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\IncrByArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class TSINCRBY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSINFO_Test.php
@@ -15,6 +15,7 @@ namespace Predis\Command\Redis\TimeSeries;
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\InfoArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 
 /**
@@ -57,6 +58,23 @@ class TSINFO_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSMADD_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CommonArguments;
 use Predis\Command\Argument\TimeSeries\CreateArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class TSMADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['key', 1000, 'value', 'key1', 1001, 'value1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:key', 1000, 'value', 'prefix:key1', 1001, 'value1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSRANGE_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\RangeArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TSRANGE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
+++ b/tests/Predis/Command/Redis/TimeSeries/TSREVRANGE_Test.php
@@ -14,6 +14,7 @@ namespace Predis\Command\Redis\TimeSeries;
 
 use Predis\Command\Argument\TimeSeries\CreateArguments;
 use Predis\Command\Argument\TimeSeries\RangeArguments;
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TSREVRANGE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setRawArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKADD_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKADD_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TOPKADD_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKINCRBY_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINCRBY_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TOPKINCRBY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKINFO_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -60,6 +61,23 @@ class TOPKINFO_Test extends PredisCommandTestCase
         $expectedResponse = ['k' => 50, 'width' => 8, 'depth' => 7, 'decay' => '0.90000000000000002'];
 
         $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKLIST_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKLIST_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -59,6 +60,23 @@ class TOPKLIST_Test extends PredisCommandTestCase
         $command->setArguments($arguments);
 
         $this->assertSame($expectedResponse, $command->parseResponse($actualResponse));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKQUERY_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKQUERY_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -57,6 +58,23 @@ class TOPKQUERY_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
+++ b/tests/Predis/Command/Redis/TopK/TOPKRESERVE_Test.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Command\Redis\TopK;
 
+use Predis\Command\PrefixableCommand;
 use Predis\Command\Redis\PredisCommandTestCase;
 use Predis\Response\ServerException;
 
@@ -55,6 +56,23 @@ class TOPKRESERVE_Test extends PredisCommandTestCase
     public function testParseResponse(): void
     {
         $this->assertSame(1, $this->getCommand()->parseResponse(1));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZPOPMAX_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMAX_Test.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
+
 /**
  * @group commands
  * @group realm-zset
@@ -48,6 +50,23 @@ class ZPOPMAX_Test extends PredisCommandTestCase
         $command->setArguments($arguments);
 
         $this->assertSame($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**

--- a/tests/Predis/Command/Redis/ZPOPMIN_Test.php
+++ b/tests/Predis/Command/Redis/ZPOPMIN_Test.php
@@ -12,6 +12,8 @@
 
 namespace Predis\Command\Redis;
 
+use Predis\Command\PrefixableCommand;
+
 /**
  * @group commands
  * @group realm-zset
@@ -63,6 +65,23 @@ class ZPOPMIN_Test extends PredisCommandTestCase
         $command = $this->getCommand();
 
         $this->assertSame($expected, $command->parseResponse($raw));
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testPrefixKeys(): void
+    {
+        /** @var PrefixableCommand $command */
+        $command = $this->getCommand();
+        $actualArguments = ['arg1'];
+        $prefix = 'prefix:';
+        $expectedArguments = ['prefix:arg1'];
+
+        $command->setArguments($actualArguments);
+        $command->prefixKeys($prefix);
+
+        $this->assertSame($expectedArguments, $command->getArguments());
     }
 
     /**


### PR DESCRIPTION
This PR makes more commands Prefixable, so they could be used by `KeyPrefixProcessor`

Close #1575 