### PR TITLE
fail on broken TLS connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Refactor pipeline data writing depends on connection type (#1586)
 - Improved compatiblity with Relay (#1597)
+- Fail on broken TLS connection (#1595)
 
 ### Maintenance
 - Added testing with 8.4-M01 (#1593)

--- a/src/Connection/Resource/Stream.php
+++ b/src/Connection/Resource/Stream.php
@@ -211,6 +211,16 @@ class Stream implements StreamInterface
             throw new RuntimeException('Unable to write to stream', 1);
         }
 
+        if ($result === 0) {
+            if ($this->eof()) {
+                throw new RuntimeException('Stream closed', 1);
+            }
+
+            if (stream_get_meta_data($this->stream)['timed_out']) {
+                throw new RuntimeException('Stream timed out', 1);
+            }
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
Fix for #1595

There's a draft of the test, it requires a server simulating the issue. It can be omitted or I can add the server to the test suite as well. 