### PR TITLE
Improve Relay compatibility

### DIFF
--- a/src/Command/Redis/VLINKS.php
+++ b/src/Command/Redis/VLINKS.php
@@ -57,9 +57,13 @@ class VLINKS extends RedisCommand
         if (!is_null($data)) {
             if ($this->withScores) {
                 foreach ($data as $key => $value) {
-                    $data[$key] = CommandUtility::arrayToDictionary($value, function ($key, $value) {
-                        return [$key, (float) $value];
-                    });
+                    if ($value === array_values($value)) {
+                        $data[$key] = CommandUtility::arrayToDictionary($value, function ($key, $value) {
+                            return [$key, (float) $value];
+                        });
+                    } else {
+                        $data[$key] = $value;
+                    }
                 }
             }
         }

--- a/tests/Predis/Command/Redis/VEMB_Test.php
+++ b/tests/Predis/Command/Redis/VEMB_Test.php
@@ -66,8 +66,6 @@ class VEMB_Test extends PredisCommandTestCase
     /**
      * @dataProvider quantisationProvider
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */
@@ -100,8 +98,6 @@ class VEMB_Test extends PredisCommandTestCase
     /**
      * @dataProvider quantisationProvider
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/VGETATTR_Test.php
+++ b/tests/Predis/Command/Redis/VGETATTR_Test.php
@@ -62,8 +62,6 @@ class VGETATTR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */
@@ -88,8 +86,6 @@ class VGETATTR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/VLINKS_Test.php
+++ b/tests/Predis/Command/Redis/VLINKS_Test.php
@@ -62,8 +62,6 @@ class VLINKS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */
@@ -96,8 +94,6 @@ class VLINKS_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/VREM_Test.php
+++ b/tests/Predis/Command/Redis/VREM_Test.php
@@ -54,8 +54,6 @@ class VREM_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */
@@ -80,8 +78,6 @@ class VREM_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/VSETATTR_Test.php
+++ b/tests/Predis/Command/Redis/VSETATTR_Test.php
@@ -59,8 +59,6 @@ class VSETATTR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */
@@ -80,8 +78,6 @@ class VSETATTR_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/VSIM_Test.php
+++ b/tests/Predis/Command/Redis/VSIM_Test.php
@@ -134,8 +134,6 @@ class VSIM_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 8.0.0
      */

--- a/tests/Predis/Command/Redis/XREADGROUP_Test.php
+++ b/tests/Predis/Command/Redis/XREADGROUP_Test.php
@@ -54,8 +54,6 @@ class XREADGROUP_Test extends PredisCommandTestCase
 
     /**
      * @group connected
-     * @group relay-incompatible
-     * @group relay-fixme
      * @return void
      * @requiresRedisVersion >= 5.0.0
      */


### PR DESCRIPTION
There are 2 tests with `relay-fixme` group remaining:
- `VINFO_Test` requires new version of Relay
- `MULTI_Test` is really incompatible