### PR TITLE
Avoid busy loop on full stream buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Refactor pipeline data writing depends on connection type (#1586)
 - Improved compatiblity with Relay (#1597)
+- Avoid busy loop on full stream buffer (#1595)
 
 ### Maintenance
 - Added testing with 8.4-M01 (#1593)

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -129,6 +129,10 @@ class StreamConnection extends AbstractConnection
                 return;
             }
 
+            if (0 === $written) { // full stream buffer, wait to avoid "busy loop"
+                usleep(10000);
+            }
+
             $buffer = substr($buffer, $written); // @phpstan-ignore-line
         }
     }


### PR DESCRIPTION
Introduce small wait when stream buffer is full to avoid busy loop. Split from #1596