### PR TITLE
Add DriverInfo API for CLIENT SETINFO support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Unreleased
+- Added DriverInfo API for CLIENT SETINFO support
 - Fixed getParameter() call on array + added integration testing with Sentinel (#2423)
 
 ## v3.4.0 (2026-02-11)

--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -15,6 +15,7 @@ namespace Predis\Connection;
 use InvalidArgumentException;
 use Predis\Client;
 use Predis\Command\RawCommand;
+use Predis\DriverInfo;
 use ReflectionClass;
 use UnexpectedValueException;
 
@@ -164,6 +165,9 @@ class Factory implements FactoryInterface
     {
         $parameters = $connection->getParameters();
 
+        // Get driver info from parameters or use default
+        $driverInfo = $parameters->driver_info ?? DriverInfo::createDefault();
+
         if (!empty($parameters->password)) {
             $cmdAuthArgs = [$parameters->protocol, 'AUTH'];
 
@@ -183,10 +187,12 @@ class Factory implements FactoryInterface
             );
         }
 
+        // Set library name via CLIENT SETINFO
         $connection->addConnectCommand(
-            new RawCommand('CLIENT', ['SETINFO', 'LIB-NAME', 'predis'])
+            new RawCommand('CLIENT', ['SETINFO', 'LIB-NAME', $driverInfo->getFormattedName()])
         );
 
+        // Set library version via CLIENT SETINFO (always Predis version)
         $connection->addConnectCommand(
             new RawCommand('CLIENT', ['SETINFO', 'LIB-VER', Client::VERSION])
         );

--- a/src/Connection/ParametersInterface.php
+++ b/src/Connection/ParametersInterface.php
@@ -12,6 +12,7 @@
 
 namespace Predis\Connection;
 
+use Predis\DriverInfo;
 use Predis\Retry\Retry;
 
 /**
@@ -21,27 +22,28 @@ use Predis\Retry\Retry;
  * each connection backend class (please refer to their specific documentation),
  * but the most common parameters used through the library are:
  *
- * @property string $scheme             Connection scheme, such as 'tcp' or 'unix'.
- * @property string $host               IP address or hostname of Redis.
- * @property int    $port               TCP port on which Redis is listening to.
- * @property int    $protocol           Version of RESP protocol.
- * @property string $path               Path of a UNIX domain socket file.
- * @property string $alias              Alias for the connection.
- * @property float  $timeout            Timeout for the connect() operation.
- * @property float  $read_write_timeout Timeout for read() and write() operations.
- * @property bool   $persistent         Leaves the connection open after a GC collection.
- * @property string $conn_uid           Unique identifier of connection, needs to create a multiple persistent connections to the same resource.
- * @property string $username           Username to access Redis (see the AUTH command).
- * @property string $password           Password to access Redis (see the AUTH command).
- * @property string $database           Database index (see the SELECT command).
- * @property bool   $async_connect      Performs the connect() operation asynchronously.
- * @property bool   $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
- * @property bool   $client_info        Whether to set LIB-NAME and LIB-VER when connecting.
- * @property Retry  $retry              Retry configuration
- * @property bool   $cache              (Relay only) Whether to use in-memory caching.
- * @property string $serializer         (Relay only) Serializer used for data serialization.
- * @property string $compression        (Relay only) Algorithm used for data compression.
- * @method   bool   isDisabledRetry()   Specify if custom retry configuration was provided.
+ * @property string     $scheme             Connection scheme, such as 'tcp' or 'unix'.
+ * @property string     $host               IP address or hostname of Redis.
+ * @property int        $port               TCP port on which Redis is listening to.
+ * @property int        $protocol           Version of RESP protocol.
+ * @property string     $path               Path of a UNIX domain socket file.
+ * @property string     $alias              Alias for the connection.
+ * @property float      $timeout            Timeout for the connect() operation.
+ * @property float      $read_write_timeout Timeout for read() and write() operations.
+ * @property bool       $persistent         Leaves the connection open after a GC collection.
+ * @property string     $conn_uid           Unique identifier of connection, needs to create a multiple persistent connections to the same resource.
+ * @property string     $username           Username to access Redis (see the AUTH command).
+ * @property string     $password           Password to access Redis (see the AUTH command).
+ * @property string     $database           Database index (see the SELECT command).
+ * @property bool       $async_connect      Performs the connect() operation asynchronously.
+ * @property bool       $tcp_nodelay        Toggles the Nagle's algorithm for coalescing.
+ * @property bool       $client_info        Whether to set LIB-NAME and LIB-VER when connecting.
+ * @property DriverInfo $driver_info        Driver metadata for CLIENT SETINFO (lib name and version).
+ * @property Retry      $retry              Retry configuration
+ * @property bool       $cache              (Relay only) Whether to use in-memory caching.
+ * @property string     $serializer         (Relay only) Serializer used for data serialization.
+ * @property string     $compression        (Relay only) Algorithm used for data compression.
+ * @method   bool       isDisabledRetry()   Specify if custom retry configuration was provided.
  */
 interface ParametersInterface
 {

--- a/src/DriverInfo.php
+++ b/src/DriverInfo.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2025 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis;
+
+/**
+ * Driver information for CLIENT SETINFO.
+ *
+ * This class holds metadata about upstream libraries using Predis,
+ * allowing them to identify themselves to Redis via CLIENT SETINFO commands.
+ *
+ * The formatted name follows the pattern: "predis(upstream_vVersion)" when an upstream
+ * library is specified, or just "predis" when used standalone.
+ *
+ * LIB-NAME will contain the formatted name (e.g., "predis(laravel_v11.0.0)").
+ * LIB-VER will always contain the Predis version (Client::VERSION).
+ *
+ * Example:
+ *   $driverInfo = new DriverInfo();
+ *   $driverInfo->addUpstreamDriver('laravel', '11.0.0');
+ *   $driverInfo->getFormattedName(); // Returns: "predis(laravel_v11.0.0)"
+ *   // LIB-NAME = "predis(laravel_v11.0.0)"
+ *   // LIB-VER = Client::VERSION (e.g., "3.4.0")
+ *
+ * @see https://redis.io/commands/client-setinfo/
+ */
+class DriverInfo
+{
+    /** @var string */
+    private $name;
+
+    /** @var array<string> */
+    private $upstreamDrivers = [];
+
+    /**
+     * Create a new DriverInfo instance.
+     *
+     * @param string $name Base library name (default: 'predis')
+     */
+    public function __construct(string $name = 'predis')
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Add an upstream driver to this instance.
+     *
+     * @param  string      $driverName    Upstream library name (e.g., 'laravel', 'symfony')
+     * @param  string|null $driverVersion Upstream library version (e.g., '11.0.0', '7.0.0'), optional
+     * @return self
+     */
+    public function addUpstreamDriver(string $driverName, ?string $driverVersion = null): self
+    {
+        if ($driverVersion !== null) {
+            $entry = "{$driverName}_v{$driverVersion}";
+        } else {
+            $entry = $driverName;
+        }
+        // Insert at the beginning so latest is first
+        array_unshift($this->upstreamDrivers, $entry);
+
+        return $this;
+    }
+
+    /**
+     * Get the formatted name for CLIENT SETINFO LIB-NAME.
+     *
+     * Returns the base library name with upstream drivers encoded in the format:
+     * - "predis(upstream1_vVersion1;upstream2_vVersion2)" if upstream drivers are set
+     * - "predis" if no upstream drivers are set
+     *
+     * @return string
+     */
+    public function getFormattedName(): string
+    {
+        if (empty($this->upstreamDrivers)) {
+            return $this->name;
+        }
+
+        $upstreamStr = implode(';', $this->upstreamDrivers);
+
+        return "{$this->name}({$upstreamStr})";
+    }
+
+    /**
+     * Create a default DriverInfo instance for Predis.
+     *
+     * @return self
+     */
+    public static function createDefault(): self
+    {
+        return new self();
+    }
+}

--- a/tests/Predis/ClientDriverInfoIntegrationTest.php
+++ b/tests/Predis/ClientDriverInfoIntegrationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2025 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis;
+
+use PredisTestCase;
+
+/**
+ * @group connected
+ * @group relay-incompatible
+ * @requiresRedisVersion >= 7.2.0
+ */
+class ClientDriverInfoIntegrationTest extends PredisTestCase
+{
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisVersion >= 7.2.0
+     */
+    public function testClientSetInfoWithDriverInfo(): void
+    {
+        $driverInfo = (new DriverInfo())->addUpstreamDriver('my-framework', '1.0.0');
+        $client = $this->createClient(['driver_info' => $driverInfo]);
+
+        $clientInfo = $this->parseClientInfo($client->client->info());
+        $this->assertArrayHasKey('lib-name', $clientInfo);
+        $this->assertArrayHasKey('lib-ver', $clientInfo);
+        $this->assertSame('predis(my-framework_v1.0.0)', $clientInfo['lib-name']);
+        $this->assertSame(Client::VERSION, $clientInfo['lib-ver']);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisVersion >= 7.2.0
+     */
+    public function testClientSetInfoWithDefaultDriverInfo(): void
+    {
+        $client = $this->createClient();
+
+        $clientInfo = $this->parseClientInfo($client->client->info());
+        $this->assertArrayHasKey('lib-name', $clientInfo);
+        $this->assertArrayHasKey('lib-ver', $clientInfo);
+        $this->assertSame('predis', $clientInfo['lib-name']);
+        $this->assertSame(Client::VERSION, $clientInfo['lib-ver']);
+    }
+
+    /**
+     * @group connected
+     * @group relay-incompatible
+     * @requiresRedisVersion >= 7.2.0
+     */
+    public function testClientSetInfoWithMultipleUpstreamDrivers(): void
+    {
+        $driverInfo = (new DriverInfo())
+            ->addUpstreamDriver('laravel', '11.0.0')
+            ->addUpstreamDriver('symfony', '7.0.0');
+        $client = $this->createClient(['driver_info' => $driverInfo]);
+
+        $clientInfo = $this->parseClientInfo($client->client->info());
+        $this->assertArrayHasKey('lib-name', $clientInfo);
+        $this->assertArrayHasKey('lib-ver', $clientInfo);
+        $this->assertSame('predis(symfony_v7.0.0;laravel_v11.0.0)', $clientInfo['lib-name']);
+        $this->assertSame(Client::VERSION, $clientInfo['lib-ver']);
+    }
+
+    /**
+     * Parse CLIENT INFO string response into an associative array.
+     *
+     * @param  string                $info
+     * @return array<string, string>
+     */
+    private function parseClientInfo(string $info): array
+    {
+        $result = [];
+        $pairs = explode(' ', trim($info));
+        foreach ($pairs as $pair) {
+            $parts = explode('=', $pair, 2);
+            if (count($parts) === 2) {
+                $result[$parts[0]] = $parts[1];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Predis/DriverInfoTest.php
+++ b/tests/Predis/DriverInfoTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) 2009-2020 Daniele Alessandri
+ * (c) 2021-2025 Till Krüss
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis;
+
+use PHPUnit\Framework\TestCase;
+
+class DriverInfoTest extends TestCase
+{
+    public function testConstructorWithDefaultName(): void
+    {
+        $driverInfo = new DriverInfo();
+
+        $this->assertSame('predis', $driverInfo->getFormattedName());
+    }
+
+    public function testConstructorWithCustomName(): void
+    {
+        $driverInfo = new DriverInfo('custom-lib');
+
+        $this->assertSame('custom-lib', $driverInfo->getFormattedName());
+    }
+
+    public function testAddUpstreamDriverSingle(): void
+    {
+        $driverInfo = new DriverInfo();
+        $driverInfo->addUpstreamDriver('laravel', '11.0.0');
+
+        $this->assertSame('predis(laravel_v11.0.0)', $driverInfo->getFormattedName());
+    }
+
+    public function testAddUpstreamDriverWithoutVersion(): void
+    {
+        $driverInfo = new DriverInfo();
+        $driverInfo->addUpstreamDriver('laravel');
+
+        $this->assertSame('predis(laravel)', $driverInfo->getFormattedName());
+    }
+
+    public function testAddUpstreamDriverMixedWithAndWithoutVersion(): void
+    {
+        $driverInfo = new DriverInfo();
+        $driverInfo->addUpstreamDriver('laravel', '11.0.0');
+        $driverInfo->addUpstreamDriver('my-custom-lib');
+
+        // Latest added appears first
+        $this->assertSame('predis(my-custom-lib;laravel_v11.0.0)', $driverInfo->getFormattedName());
+    }
+
+    public function testAddUpstreamDriverMultiple(): void
+    {
+        $driverInfo = new DriverInfo();
+        $driverInfo->addUpstreamDriver('laravel', '11.0.0');
+        $driverInfo->addUpstreamDriver('symfony', '7.0.0');
+
+        // Latest added appears first
+        $this->assertSame('predis(symfony_v7.0.0;laravel_v11.0.0)', $driverInfo->getFormattedName());
+    }
+
+    public function testAddUpstreamDriverReturnsThis(): void
+    {
+        $driverInfo = new DriverInfo();
+        $result = $driverInfo->addUpstreamDriver('celery', '5.4.1');
+
+        $this->assertSame($driverInfo, $result);
+    }
+
+    public function testAddUpstreamDriverChaining(): void
+    {
+        $driverInfo = (new DriverInfo())
+            ->addUpstreamDriver('laravel', '11.0.0')
+            ->addUpstreamDriver('symfony', '7.0.0');
+
+        $this->assertSame('predis(symfony_v7.0.0;laravel_v11.0.0)', $driverInfo->getFormattedName());
+    }
+
+    public function testCreateDefault(): void
+    {
+        $driverInfo = DriverInfo::createDefault();
+
+        $this->assertSame('predis', $driverInfo->getFormattedName());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a DriverInfo API that allows upstream libraries (e.g., Laravel, Symfony) to identify themselves when connecting to Redis via CLIENT SETINFO.

## Usage

```php
use Predis\Client;
use Predis\DriverInfo;

// Upstream library (e.g., Laravel) creates DriverInfo
$driverInfo = (new DriverInfo())
    ->addUpstreamDriver('laravel', '11.0.0');

$client = new Client(['driver_info' => $driverInfo]);
```

Result in Redis:

`LIB-NAME: predis(laravel_v11.0.0)`
`LIB-VER: 3.0.0` (Predis version)

## Features

- Multiple upstream drivers supported (semicolon-separated)
- Version parameter is optional: `addUpstreamDriver('laravel') → predis(laravel)`
- Latest added driver appears first in the formatted name

## Changes

- **Added**: `src/DriverInfo.php` - New class for driver metadata
- **Modified**: `src/Connection/Factory.php` - Sends `CLIENT SETINFO` on connection
- **Added**: Unit and integration tests

## Notes

- Requires Redis >= 7.2.0 (when `CLIENT SETINFO` was introduced)
- `HELLO SETNAME` remains unchanged ('predis')