### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "composer"
+    directory: /
+    schedule:
+      interval: "monthly"
+    groups:
+      composer-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration for automated dependency updates
- Configures `github-actions` and `composer` package ecosystems
- Updates are checked monthly with minor/patch updates grouped together

## Details
- **GitHub Actions**: All action updates grouped into a single PR
- **Composer**: Minor and patch updates grouped; major updates get separate PRs for review