### PR TITLE
Unable to authenticate to Redis-Sentinel in v2.x

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -264,14 +264,10 @@ class SentinelReplication implements ReplicationInterface
         }
 
         if (is_array($parameters)) {
-            // NOTE: sentinels do not accept AUTH and SELECT commands so we must
-            // explicitly set them to NULL to avoid problems when using default
-            // parameters set via client options. Actually AUTH is supported for
-            // sentinels starting with Redis 5 but we have to differentiate from
-            // sentinels passwords and nodes passwords, this will be implemented
-            // in a later release.
+            // NOTE: sentinels do not accept SELECT command so we must
+            // explicitly set it to NULL to avoid problems when using default
+            // parameters set via client options.
             $parameters['database'] = null;
-            $parameters['username'] = null;
 
             // don't leak password from between configurations
             // https://github.com/predis/predis/pull/807/#discussion_r985764770


### PR DESCRIPTION
**Describe the bug**

I can't use predis 2.x to authenticate to Redis-Sentinel.

This only affects users defined via ACL's. The default (admin) user is not affected.

#1429 resolved this in 3.x.

**How to reproduce**

Spin up a Redis-Sentinel service hosted at `redis-sentinel` and create an ACL for user `myusername` and password `mypassword`.

Then execute this test script:

```php
<?php

use Predis\Client;

$client = new Client(
  [
    'redis://myusername:mypassword@redis-sentinel:26379',
  ],
  [
    'replication' => 'sentinel',
    'service' => 'redis',
    'prefix' => 'myprefix',
    'parameters' => [
      'scheme' => 'tcp',
      'database' => 0,
      'username' => 'myusername',
      'password' => 'mypassword',
    ],
  ]
);

print_r($client->set('foo', 'bar'));
```

Running the above leads to this error:

```
In SentinelReplication.php line 302:
                                                   
  No sentinel server available for autodiscovery.  
```

**Expected behaviour**

The above script would be expected to show:

```
Predis\Response\Status Object
(
    [payload:Predis\Response\Status:private] => OK
)
```

**Versions**

- predis 2.4.1
- PHP 8.3
- Redis 6.2