### PR TITLE
Fix UNLINK missing single-array argument normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Expose pipeline API via ClientInterface (#1686)
 
+### Fixed
+- Allow `UNLINK` to accept an array of keys as a single argument
+
 ## v3.5.0 (2026-06-02)
 ### Added
 - Added support for `XNACK` command (#1666)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Expose pipeline API via ClientInterface (#1686)
 
 ### Fixed
-- Allow `UNLINK` to accept an array of keys as a single argument
+- Allow `UNLINK` to accept an array of keys as a single argument (#1687)
 
 ## v3.5.0 (2026-06-02)
 ### Added

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -77,7 +77,7 @@ use Predis\Command\Redis\VADD;
  * @method $this sort_ro(string $key, ?string $byPattern = null, ?LimitOffsetCount $limit = null, array $getPatterns = [], ?string $sorting = null, bool $alpha = false)
  * @method $this ttl($key)
  * @method $this type($key)
- * @method $this unlink(string ...$keys)
+ * @method $this unlink(array|string $keys)
  * @method $this append($key, $value)
  * @method $this arcount(string $key)
  * @method $this ardel(string $key, int ...$index)

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -77,7 +77,7 @@ use Predis\Command\Redis\VADD;
  * @method $this sort_ro(string $key, ?string $byPattern = null, ?LimitOffsetCount $limit = null, array $getPatterns = [], ?string $sorting = null, bool $alpha = false)
  * @method $this ttl($key)
  * @method $this type($key)
- * @method $this unlink(array|string $keys)
+ * @method $this unlink(string[]|string $keyOrKeys, string ...$keys = null)
  * @method $this append($key, $value)
  * @method $this arcount(string $key)
  * @method $this ardel(string $key, int ...$index)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -88,7 +88,7 @@ use Predis\Response\Status;
  * @method array             sort_ro(string $key, ?string $byPattern = null, ?LimitOffsetCount $limit = null, array $getPatterns = [], ?string $sorting = null, bool $alpha = false)
  * @method int               ttl(string $key)
  * @method mixed             type(string $key)
- * @method int               unlink(string ...$keys)
+ * @method int               unlink(string[]|string $keyOrKeys, string ...$keys = null)
  * @method int               append(string $key, $value)
  * @method int               arcount(string $key)
  * @method int               ardel(string $key, int ...$index)

--- a/src/Command/Redis/UNLINK.php
+++ b/src/Command/Redis/UNLINK.php
@@ -27,6 +27,16 @@ class UNLINK extends RedisCommand
         return 'UNLINK';
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function setArguments(array $arguments)
+    {
+        $arguments = self::normalizeArguments($arguments);
+
+        parent::setArguments($arguments);
+    }
+
     public function prefixKeys($prefix)
     {
         $this->applyPrefixForAllArguments($prefix);

--- a/tests/Predis/Command/Redis/UNLINK_Test.php
+++ b/tests/Predis/Command/Redis/UNLINK_Test.php
@@ -52,6 +52,20 @@ class UNLINK_Test extends PredisCommandTestCase
     /**
      * @group disconnected
      */
+    public function testFilterArgumentsAsSingleArray(): void
+    {
+        $arguments = [['key1', 'key2', 'key3']];
+        $expected = ['key1', 'key2', 'key3'];
+
+        $command = $this->getCommand();
+        $command->setArguments($arguments);
+
+        $this->assertSame($expected, $command->getArguments());
+    }
+
+    /**
+     * @group disconnected
+     */
     public function testParseResponse(): void
     {
         $command = $this->getCommand();


### PR DESCRIPTION
I noticed that with predis 3.5.0 i started getting some errors when using it with symfony/rate-limiter.
https://github.com/symfony/symfony/blob/e8d62b2f2d20ab87ce21fcf50584bfa65cad8777/src/Symfony/Component/Cache/Traits/RedisTrait.php#L683-L687

symfony cache component would try to call unlink with array argument, and if function does not exist it would fallback to `del`. That's why everything worked with older versions. Now with 3.5.0 unlink is available but does not support array arg.

Since UNLINK is very similar to DEL, i think the  signature should be the same.

UNLINK does not have the `setArguments()` override (like DEL), so `unlink(['key1', 'key2'])` keeps the keys nested instead of flattening them like del() does. On a client with a key prefix, `applyPrefixForAllArguments()` then concatenates the prefix with an array, silently sending UNLINK <prefix>Array — the real keys are never deleted.

This PR adds the `normalizeArguments` call to match `DEL`.
Test `testFilterArgumentsAsSingleArray` is copied from `DEL_Test`