### PR TITLE
Fix typing in ClientContextInterface.php

### DIFF
--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -128,7 +128,7 @@ use Predis\Command\Redis\VADD;
  * @method $this cfinsertnx(string $key, int $capacity = -1, bool $noCreate = false, string ...$item)
  * @method $this cfreserve(string $key, int $capacity, int $bucketSize = -1, int $maxIterations = -1, int $expansion = -1)
  * @method $this cfscandump(string $key, int $iterator)
- * @method $this cmsincrby(string $key, string|int...$itemIncrementDictionary)
+ * @method $this cmsincrby(string $key, string|int ...$itemIncrementDictionary)
  * @method $this cmsinfo(string $key)
  * @method $this cmsinitbydim(string $key, int $width, int $depth)
  * @method $this cmsinitbyprob(string $key, float $errorRate, float $probability)


### PR DESCRIPTION
Hi, 👋 

Related to https://github.com/vimeo/psalm/issues/10336#issuecomment-1790519219

Current version of predis:
```
ERROR: UndefinedMagicMethod
at foo.php:5
Magic method Predis\ClientContextInterface::zremrangebyscore does not exist (see https://psalm.dev/219)
            $pipe->zremrangebyscore($key, $min, $max);


ERROR: UndefinedMagicMethod
at foo.php:6
Magic method Predis\ClientContextInterface::zcard does not exist (see https://psalm.dev/219)
            $pipe->zcard($key);
```

After adding the space, those errors are gone.

Thanks 🙏 