### PR TITLE
Return NAN for RESP3 NaN double payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unlreleads
 ### Added
 ### Changed
+- Changed RESP3 double parsing to return `NAN` for NaN payloads instead of `0.0`
 ### Fixed
 
 ## v3.6.0 (2026-08-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## Changelog
 
-## Unlreleads
-### Added
+## Unreleased
 ### Changed
 - Changed RESP3 double parsing to return `NAN` for NaN payloads instead of `0.0`
-### Fixed
-- Fixed RESP3 double parsing returning positive `INF` for `-inf` payloads (#1716)
-- Fixed `client_info` connection parameter being ignored (#1722)
 
 ## v3.6.0 (2026-08-14)
 ### Added

--- a/src/Protocol/Parser/Strategy/Resp3Strategy.php
+++ b/src/Protocol/Parser/Strategy/Resp3Strategy.php
@@ -66,7 +66,7 @@ class Resp3Strategy extends Resp2Strategy
         if ($string === 'inf') {
             return INF;
         }
-      
+
         if ($string === '-inf') {
             return -INF;
         }

--- a/src/Protocol/Parser/Strategy/Resp3Strategy.php
+++ b/src/Protocol/Parser/Strategy/Resp3Strategy.php
@@ -67,6 +67,12 @@ class Resp3Strategy extends Resp2Strategy
             return INF;
         }
 
+        // Redis < 7.2 may emit any libc representation of NaN,
+        // such as "-nan", "NAN" or "nan(char-sequence)".
+        if (preg_match('/^-?nan(\(.*\))?$/i', $string) === 1) {
+            return NAN;
+        }
+
         return (float) $string;
     }
 

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYRANK_Test.php
@@ -118,7 +118,11 @@ class TDIGESTBYRANK_Test extends PredisCommandTestCase
         $actualResponse = $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5, 6);
 
         $this->assertEquals($expectedResponse, $actualResponse);
-        $this->assertEquals([null, null], $redis->tdigestbyrank('empty_key', 0, 1));
+        $emptyResponse = $redis->tdigestbyrank('empty_key', 0, 1);
+        $this->assertCount(2, $emptyResponse);
+        foreach ($emptyResponse as $value) {
+            $this->assertNan($value);
+        }
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTBYREVRANK_Test.php
@@ -118,7 +118,11 @@ class TDIGESTBYREVRANK_Test extends PredisCommandTestCase
         $actualResponse = $redis->tdigestbyrevrank('key', 0, 1, 2, 3, 4, 5, 6);
 
         $this->assertEquals($expectedResponse, $actualResponse);
-        $this->assertEquals([null, null], $redis->tdigestbyrevrank('empty_key', 0, 1));
+        $emptyResponse = $redis->tdigestbyrevrank('empty_key', 0, 1);
+        $this->assertCount(2, $emptyResponse);
+        foreach ($emptyResponse as $value) {
+            $this->assertNan($value);
+        }
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTCDF_Test.php
@@ -118,7 +118,11 @@ class TDIGESTCDF_Test extends PredisCommandTestCase
         $actualResponse = $redis->tdigestcdf('key', 0, 1, 2, 3, 4);
 
         $this->assertSameWithPrecision($expectedResponse, $actualResponse, 5);
-        $this->assertSame([0.0, 0.0], $redis->tdigestcdf('empty_key', 0, 1));
+        $emptyResponse = $redis->tdigestcdf('empty_key', 0, 1);
+        $this->assertCount(2, $emptyResponse);
+        foreach ($emptyResponse as $value) {
+            $this->assertNan($value);
+        }
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMAX_Test.php
@@ -116,7 +116,7 @@ class TDIGESTMAX_Test extends PredisCommandTestCase
         $actualResponse = $redis->tdigestmax('key');
 
         $this->assertEquals('5', $actualResponse);
-        $this->assertEquals(0, $redis->tdigestmax('empty_key'));
+        $this->assertNan($redis->tdigestmax('empty_key'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTMIN_Test.php
@@ -116,7 +116,7 @@ class TDIGESTMIN_Test extends PredisCommandTestCase
         $actualResponse = $redis->tdigestmin('key');
 
         $this->assertEquals('1', $actualResponse);
-        $this->assertEquals(0, $redis->tdigestmin('empty_key'));
+        $this->assertNan($redis->tdigestmin('empty_key'));
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTQUANTILE_Test.php
@@ -118,7 +118,11 @@ class TDIGESTQUANTILE_Test extends PredisCommandTestCase
         $this->assertEquals([1.0, 2.0, 3.0, 3.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0], $quantileResponse);
 
         $redis->tdigestcreate('empty_key');
-        $this->assertEquals([null, null], $redis->tdigestquantile('empty_key', 0.0, 0.1));
+        $emptyResponse = $redis->tdigestquantile('empty_key', 0.0, 0.1);
+        $this->assertCount(2, $emptyResponse);
+        foreach ($emptyResponse as $value) {
+            $this->assertNan($value);
+        }
     }
 
     /**

--- a/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
+++ b/tests/Predis/Command/Redis/TDigest/TDIGESTRESET_Test.php
@@ -129,10 +129,11 @@ class TDIGESTRESET_Test extends PredisCommandTestCase
 
         $this->assertEquals('OK', $actualResponse);
         $this->assertSame(500, $info['Compression']);
-        $this->assertEquals(
-            [null, null, null, null, null, null],
-            $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5)
-        );
+        $resetResponse = $redis->tdigestbyrank('key', 0, 1, 2, 3, 4, 5);
+        $this->assertCount(6, $resetResponse);
+        foreach ($resetResponse as $value) {
+            $this->assertNan($value);
+        }
     }
 
     /**

--- a/tests/Predis/Protocol/Parser/Strategy/Resp3StrategyTest.php
+++ b/tests/Predis/Protocol/Parser/Strategy/Resp3StrategyTest.php
@@ -68,6 +68,19 @@ class Resp3StrategyTest extends PredisTestCase
     }
 
     /**
+     * @dataProvider nanProvider
+     * @group disconnected
+     * @param  string $data
+     * @return void
+     */
+    public function testParseDataReturnsFloatNanOnNanValue(string $data): void
+    {
+        $actualResponse = $this->strategy->parseData($data);
+
+        $this->assertNan($actualResponse);
+    }
+
+    /**
      * @dataProvider booleanProvider
      * @group disconnected
      * @param  string $data
@@ -168,6 +181,16 @@ class Resp3StrategyTest extends PredisTestCase
         return [
             'positive infinity' => [",inf\r\n"],
             'negative infinity' => [",-inf\r\n"],
+        ];
+    }
+
+    public function nanProvider(): array
+    {
+        return [
+            'canonical nan' => [",nan\r\n"],
+            'negative nan' => [",-nan\r\n"],
+            'uppercase nan' => [",NAN\r\n"],
+            'nan with payload' => [",nan(ind)\r\n"],
         ];
     }
 


### PR DESCRIPTION
Split out of #1716 as discussed there: this is the behavior-change half, while #1716 now carries only the -inf sign correction.

With protocol=3, ",nan" currently falls through to a float cast, and (float) "nan" is 0.0 in PHP, so a NaN score silently becomes a valid-looking zero. This PR returns NAN instead. Per the RESP3 specification, Redis before 7.2 may emit any libc representation of NaN ("-nan", "NAN", "nan(char-sequence)") and clients should handle them, so those spellings are accepted too.

The TDigest RESP3 tests asserted 0 or null for empty sketches, which only passed because of the collapsed 0.0 (null == 0.0 loosely); their RESP2 counterparts already assert the string "nan" for the same replies. They now assert NaN. Verified against a live redis-stack: the full realm-stack group passes (1356 tests).

On the json_encode() concern from the #1716 discussion: it indeed throws on NAN, so consumers serializing raw replies must handle it, whereas today NaN hides behind a plausible 0.0. Scheduling this for whichever release you consider appropriate is entirely your call.